### PR TITLE
fix(netsync): harden sync-peer selection against forged version height

### DIFF
--- a/node/database/example_test.go
+++ b/node/database/example_test.go
@@ -129,7 +129,6 @@ func Example_blockStorageAndRetrieval() {
 	}
 	db, err := database.Create("ffldb", dbPath, wire.MainNet)
 	if err != nil {
-		fmt.Println("fail here")
 		fmt.Println(err)
 		return
 	}
@@ -151,7 +150,7 @@ func Example_blockStorageAndRetrieval() {
 	// Use the View function of the database to perform a managed read-only
 	// transaction and fetch the block stored above.
 	var loadedBlockBytes []byte
-	err = db.Update(func(tx database.Tx) error {
+	err = db.View(func(tx database.Tx) error {
 		genesisHash := chaincfg.MainNetParams.GenesisBlock.BlockHash()
 		blockBytes, err := tx.FetchBlock(&genesisHash)
 		if err != nil {
@@ -178,5 +177,5 @@ func Example_blockStorageAndRetrieval() {
 	fmt.Printf("Serialized block size: %d bytes\n", len(loadedBlockBytes))
 
 	// Output:
-	// Serialized block size: 533 bytes
+	// Serialized block size: 612 bytes
 }

--- a/node/integration/sync_lie_test.go
+++ b/node/integration/sync_lie_test.go
@@ -1,0 +1,141 @@
+//go:build rpctest
+// +build rpctest
+
+// Regression test for pickSyncCandidate's inbound-exclusion + cooldown
+// hardening (node/netsync/manager.go).
+
+package integration
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+	"github.com/pearl-research-labs/pearl/node/integration/rpctest"
+	"github.com/pearl-research-labs/pearl/node/peer"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// Forged tip height advertised by the liar in its version handshake.
+	liarClaimedHeight int32 = 999_999
+
+	// Time the victim has to catch up to honest's tip after honest connects.
+	catchupWindow = 30 * time.Second
+
+	// Blocks honest pre-mines before connecting; large enough to make the
+	// catch-up assertion unambiguous.
+	honestStartBlocks uint32 = 10
+)
+
+// newLiarPeer dials nodeAddr, completes the v2 handshake claiming
+// LastBlock=liarClaimedHeight, and answers getheaders/getblocks with empty
+// messages. Empty replies (vs silence) clear the wire-level stall deadline
+// so pearld won't disconnect us at the wire layer. The returned peer must
+// be Disconnect()'d by the caller.
+func newLiarPeer(t *testing.T, nodeAddr string) *peer.Peer {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", nodeAddr, 5*time.Second)
+	require.NoError(t, err, "liar: dial victim")
+
+	verackCh := make(chan struct{})
+	cfg := &peer.Config{
+		Listeners: peer.MessageListeners{
+			OnVerAck: func(_ *peer.Peer, _ *wire.MsgVerAck) {
+				close(verackCh)
+			},
+			OnGetHeaders: func(p *peer.Peer, _ *wire.MsgGetHeaders) {
+				p.QueueMessage(wire.NewMsgHeaders(), nil)
+			},
+			OnGetBlocks: func(p *peer.Peer, _ *wire.MsgGetBlocks) {
+				p.QueueMessage(wire.NewMsgInv(), nil)
+			},
+		},
+		// NewestBlock backs our outgoing version's LastBlock; forge it.
+		NewestBlock: func() (*chainhash.Hash, int32, error) {
+			return &chainhash.Hash{}, liarClaimedHeight, nil
+		},
+		UserAgentName:       "liar-peer",
+		UserAgentVersion:    "1.0.0",
+		Services:            wire.SFNodeNetwork | wire.SFNodeWitness | wire.SFNodeP2PV2,
+		ChainParams:         &chaincfg.SimNetParams,
+		DisableStallHandler: true, // test drives lifetime via Disconnect()
+	}
+
+	p, err := peer.NewOutboundPeer(cfg, nodeAddr)
+	if err != nil {
+		conn.Close()
+		t.Fatalf("liar: NewOutboundPeer: %v", err)
+	}
+	p.AssociateConnection(conn)
+
+	select {
+	case <-verackCh:
+		return p
+	case <-time.After(15 * time.Second):
+		p.Disconnect()
+		p.WaitForDisconnect()
+		t.Fatal("liar: timed out waiting for verack")
+		return nil
+	}
+}
+
+// TestSyncPeerLiesAboutHeight asserts an inbound peer claiming a vastly
+// inflated LastBlock never reaches the syncnode role, and the victim still
+// syncs from a legitimate outbound peer despite the liar holding an open
+// connection.
+func TestSyncPeerLiesAboutHeight(t *testing.T) {
+	victim, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	require.NoError(t, err)
+	require.NoError(t, victim.SetUp(true, 0))
+	t.Cleanup(func() { require.NoError(t, victim.TearDown()) })
+
+	honest, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	require.NoError(t, err)
+	require.NoError(t, honest.SetUp(true, 0))
+	t.Cleanup(func() { _ = honest.TearDown() })
+
+	_, err = honest.Client.Generate(honestStartBlocks)
+	require.NoError(t, err)
+
+	// Liar dials in first with the highest claimed height.
+	liar := newLiarPeer(t, victim.P2PAddress())
+	defer func() { liar.Disconnect(); liar.WaitForDisconnect() }()
+
+	// Liar must never appear as syncnode.
+	time.Sleep(2 * time.Second)
+	peers, err := victim.Client.GetPeerInfo()
+	require.NoError(t, err)
+	for _, p := range peers {
+		require.Falsef(t, p.SyncNode,
+			"inbound liar at %s was selected as syncnode", p.Addr)
+	}
+
+	// Honest is the only valid sync candidate; victim must catch up.
+	require.NoError(t, rpctest.ConnectNode(victim, honest))
+	require.Eventually(t, func() bool {
+		_, h, err := victim.Client.GetBestBlock()
+		return err == nil && h >= int32(honestStartBlocks)
+	}, catchupWindow, 500*time.Millisecond,
+		"victim failed to catch up to honest tip h=%d",
+		honestStartBlocks)
+
+	_, hFinal, _ := victim.Client.GetBestBlock()
+	t.Logf("victim caught up to h=%d with liar still connected", hFinal)
+
+	// Liar's inbound connection is still present and still not syncnode.
+	peers, err = victim.Client.GetPeerInfo()
+	require.NoError(t, err)
+	var liarFound bool
+	for _, p := range peers {
+		if p.Addr == liar.LocalAddr().String() {
+			liarFound = true
+			require.False(t, p.SyncNode, "liar must not be syncnode")
+		}
+	}
+	require.True(t, liarFound, "liar's inbound connection should still be present")
+}

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -47,6 +47,10 @@ const (
 	// stallSampleInterval the interval at which we will check to see if our
 	// sync has stalled.
 	stallSampleInterval = 30 * time.Second
+
+	// syncPeerCooldown is how long an address that stalled as syncnode
+	// is excluded from re-selection.
+	syncPeerCooldown = 10 * time.Minute
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
@@ -206,6 +210,11 @@ type SyncManager struct {
 
 	// An optional fee estimator.
 	feeEstimator *mempool.FeeEstimator
+
+	// recentlyFailedSync tracks outbound peer addresses that stalled
+	// while serving as syncnode. pickSyncCandidate skips entries
+	// within syncPeerCooldown and lazy-evicts expired ones.
+	recentlyFailedSync map[string]time.Time
 }
 
 // resetHeaderState sets the headers-first mode state to values appropriate for
@@ -252,10 +261,50 @@ func (sm *SyncManager) findNextHeaderCheckpoint(height int32) *chaincfg.Checkpoi
 	return nextCheckpoint
 }
 
+// pickSyncCandidate returns a random sync-peer candidate, filtered by:
+//   - state.syncCandidate (SFNodeNetwork / pruned-with-block-threshold,
+//     set at handshake by isSyncCandidate).
+//   - Outbound only. peer.LastBlock() from the version handshake is
+//     unauthenticated; restricting to outbound peers limits candidates
+//     to addresses we chose to dial (addr.dat / dnsseed).
+//   - recentlyFailedSync cooldown to prevent immediate re-selection of
+//     peers that previously stalled as syncnode.
+//
+// peer.LastBlock() is intentionally not used for ranking. Mirrors Bitcoin
+// Core's CanServeBlocks + fPreferredDownload posture (net_processing.cpp).
+func (sm *SyncManager) pickSyncCandidate() *peerpkg.Peer {
+	now := time.Now()
+	var candidates []*peerpkg.Peer
+	for peer, state := range sm.peerStates {
+		if !state.syncCandidate {
+			continue
+		}
+		if peer.Inbound() {
+			continue
+		}
+		if t, ok := sm.recentlyFailedSync[peer.Addr()]; ok {
+			if now.Sub(t) < syncPeerCooldown {
+				continue
+			}
+			delete(sm.recentlyFailedSync, peer.Addr())
+		}
+		candidates = append(candidates, peer)
+	}
+
+	if len(candidates) == 0 {
+		if sm.chain.IsCurrent() {
+			best := sm.chain.BestSnapshot()
+			log.Infof("Caught up to block %s(%d)",
+				best.Hash.String(), best.Height)
+		}
+		return nil
+	}
+	return candidates[rand.Intn(len(candidates))]
+}
+
 // startSync will choose the best peer among the available candidate peers to
 // download/sync the blockchain from.  When syncing is already running, it
-// simply returns.  It also examines the candidates for any which are no longer
-// candidates and removes them as needed.
+// simply returns.
 func (sm *SyncManager) startSync() {
 	// Return now if we're already syncing.
 	if sm.syncPeer != nil {
@@ -263,56 +312,7 @@ func (sm *SyncManager) startSync() {
 	}
 
 	best := sm.chain.BestSnapshot()
-	var higherPeers, equalPeers []*peerpkg.Peer
-	for peer, state := range sm.peerStates {
-		if !state.syncCandidate {
-			continue
-		}
-
-		// Remove sync candidate peers that are no longer candidates due
-		// to passing their latest known block.  NOTE: The < is
-		// intentional as opposed to <=.  While technically the peer
-		// doesn't have a later block when it's equal, it will likely
-		// have one soon so it is a reasonable choice.  It also allows
-		// the case where both are at 0 such as during regression test.
-		if peer.LastBlock() < best.Height {
-			state.syncCandidate = false
-			continue
-		}
-
-		// If the peer is at the same height as us, we'll add it a set
-		// of backup peers in case we do not find one with a higher
-		// height. If we are synced up with all of our peers, all of
-		// them will be in this set.
-		if peer.LastBlock() == best.Height {
-			equalPeers = append(equalPeers, peer)
-			continue
-		}
-
-		// This peer has a height greater than our own, we'll consider
-		// it in the set of better peers from which we'll randomly
-		// select.
-		higherPeers = append(higherPeers, peer)
-	}
-
-	if sm.chain.IsCurrent() && len(higherPeers) == 0 {
-		log.Infof("Caught up to block %s(%d)", best.Hash.String(), best.Height)
-		return
-	}
-
-	// Pick randomly from the set of peers greater than our block height,
-	// falling back to a random peer of the same height if none are greater.
-	//
-	// TODO(conner): Use a better algorithm to ranking peers based on
-	// observed metrics and/or sync in parallel.
-	var bestPeer *peerpkg.Peer
-	switch {
-	case len(higherPeers) > 0:
-		bestPeer = higherPeers[rand.Intn(len(higherPeers))]
-
-	case len(equalPeers) > 0:
-		bestPeer = equalPeers[rand.Intn(len(equalPeers))]
-	}
+	bestPeer := sm.pickSyncCandidate()
 
 	// Start syncing from the best peer if one was selected.
 	if bestPeer != nil {
@@ -463,8 +463,12 @@ func (sm *SyncManager) handleStallSample() {
 		return
 	}
 
-	// If we don't have an active sync peer, exit early.
+	// No syncpeer — retry selection periodically so cooled-down
+	// candidates get re-evaluated as their entries expire.
 	if sm.syncPeer == nil {
+		if !sm.chain.IsCurrent() {
+			sm.startSync()
+		}
 		return
 	}
 
@@ -480,6 +484,13 @@ func (sm *SyncManager) handleStallSample() {
 	}
 
 	sm.clearRequestedState(state)
+
+	// Temporarily exclude the stalled peer from sync-peer selection.
+	// Inbound peers are skipped (ephemeral source port, already
+	// excluded from candidates).
+	if !sm.syncPeer.Inbound() {
+		sm.recentlyFailedSync[sm.syncPeer.Addr()] = time.Now()
+	}
 
 	disconnectSyncPeer := sm.shouldDCStalledSyncPeer()
 	sm.updateSyncPeer(disconnectSyncPeer)
@@ -1679,19 +1690,20 @@ func (sm *SyncManager) Pause() chan<- struct{} {
 // block, tx, and inv updates.
 func New(config *Config) (*SyncManager, error) {
 	sm := SyncManager{
-		peerNotifier:    config.PeerNotifier,
-		chain:           config.Chain,
-		txMemPool:       config.TxMemPool,
-		chainParams:     config.ChainParams,
-		rejectedTxns:    make(map[chainhash.Hash]struct{}),
-		requestedTxns:   make(map[chainhash.Hash]struct{}),
-		requestedBlocks: make(map[chainhash.Hash]struct{}),
-		peerStates:      make(map[*peerpkg.Peer]*peerSyncState),
-		progressLogger:  newBlockProgressLogger("Processed", log),
-		msgChan:         make(chan interface{}, config.MaxPeers*3),
-		headerList:      list.New(),
-		quit:            make(chan struct{}),
-		feeEstimator:    config.FeeEstimator,
+		peerNotifier:       config.PeerNotifier,
+		chain:              config.Chain,
+		txMemPool:          config.TxMemPool,
+		chainParams:        config.ChainParams,
+		rejectedTxns:       make(map[chainhash.Hash]struct{}),
+		requestedTxns:      make(map[chainhash.Hash]struct{}),
+		requestedBlocks:    make(map[chainhash.Hash]struct{}),
+		peerStates:         make(map[*peerpkg.Peer]*peerSyncState),
+		progressLogger:     newBlockProgressLogger("Processed", log),
+		msgChan:            make(chan interface{}, config.MaxPeers*3),
+		headerList:         list.New(),
+		quit:               make(chan struct{}),
+		feeEstimator:       config.FeeEstimator,
+		recentlyFailedSync: make(map[string]time.Time),
 	}
 
 	best := sm.chain.BestSnapshot()

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 0
+	Patch uint = 1
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

Sync-peer candidates are now restricted to outbound peers with `SFNodeNetwork`,
picked uniformly at random. The unauthenticated `peer.LastBlock()` from the
version handshake is no longer used for ranking — it's a forgeable 32-bit
integer that any connecting peer can set to an arbitrary value.

This mirrors Bitcoin Core's `CanServeBlocks` + `fPreferredDownload` posture
in `net_processing.cpp`'s `SendMessages`.

### Changes

- **`pickSyncCandidate`** replaces the height-ranked `higherPeers`/`equalPeers`
  partitioning in `startSync`. Filter: `syncCandidate` (services) + outbound +
  cooldown check. Uniform random pick from remaining pool.
- **Stall cooldown**: when `handleStallSample` rotates away from a stalled
  syncnode, the peer's address is excluded from re-selection for 10 minutes.
  Inbound peers are skipped (ephemeral source port).
- **Periodic retry**: `handleStallSample` retries `startSync` when no syncpeer
  exists and the chain is not current, so expired cooldown entries get
  re-evaluated without waiting for peer churn.
- Drive-by: fix failing `Example_blockStorageAndRetrieval` test (`db.Update` →
  `db.View` for read path, expected block size 533 → 612).
- Version bump 1.0.0 → 1.0.1.

### Test

`TestSyncPeerLiesAboutHeight` (`node/integration/sync_lie_test.go`, build tag
`rpctest`): inbound peer claims `LastBlock=999_999` with empty getblocks/getheaders
replies. Asserts it never appears as syncnode and the victim syncs from a
legitimate outbound peer within 30 s. Runtime ~3 s.

### Not in scope

- Headers-presync (post-selection PoW enforcement) — separate in-progress PR.
- Inv-triggered parallel `getheaders` (Bitcoin Core PR #25720) — belongs to
  the headers-presync PR.
- `addrmgr` flap-penalty for outbound-slot churn — separate workstream.
- Banscore for header-misbehavior disconnect paths — separate concern.