### PR TITLE
fix(netsync): fall back to inbound peers for sync during IBD

### DIFF
--- a/node/integration/sync_inbound_ibd_test.go
+++ b/node/integration/sync_inbound_ibd_test.go
@@ -1,0 +1,53 @@
+//go:build rpctest
+// +build rpctest
+
+// Regression test for pickSyncCandidate's inbound fallback during IBD.
+// Mirrors Bitcoin Core's p2p_block_sync.py test (PR #24171).
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/integration/rpctest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncFromInboundDuringIBD sets up two simnet nodes where the only
+// block source dials the victim (making it inbound from victim's POV).
+// The victim has no outbound peers. Asserts the victim syncs to the
+// source's tip via the inbound fallback in pickSyncCandidate.
+func TestSyncFromInboundDuringIBD(t *testing.T) {
+	const blocksToMine = 10
+
+	victim, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	require.NoError(t, err)
+	require.NoError(t, victim.SetUp(true, 0))
+	t.Cleanup(func() { require.NoError(t, victim.TearDown()) })
+
+	source, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	require.NoError(t, err)
+	require.NoError(t, source.SetUp(true, 0))
+	t.Cleanup(func() { _ = source.TearDown() })
+
+	_, err = source.Client.Generate(blocksToMine)
+	require.NoError(t, err)
+
+	// Source dials victim: from victim's POV, source is inbound.
+	require.NoError(t, rpctest.ConnectNode(source, victim))
+
+	// Victim must sync to source's tip. Without the inbound fallback
+	// this times out: no outbound peers, pickSyncCandidate returns
+	// nil, handleInvMsg drops source's block announcements.
+	require.Eventually(t, func() bool {
+		_, h, err := victim.Client.GetBestBlock()
+		return err == nil && h >= int32(blocksToMine)
+	}, 30*time.Second, 500*time.Millisecond,
+		"victim failed to sync from inbound source to h=%d",
+		blocksToMine)
+
+	_, victimH, _ := victim.Client.GetBestBlock()
+	t.Logf("victim synced to h=%d from inbound source", victimH)
+}

--- a/node/integration/sync_lie_test.go
+++ b/node/integration/sync_lie_test.go
@@ -85,9 +85,9 @@ func newLiarPeer(t *testing.T, nodeAddr string) *peer.Peer {
 }
 
 // TestSyncPeerLiesAboutHeight asserts an inbound peer claiming a vastly
-// inflated LastBlock never reaches the syncnode role, and the victim still
-// syncs from a legitimate outbound peer despite the liar holding an open
-// connection.
+// inflated LastBlock never reaches the syncnode role when an outbound
+// peer is available, and the victim syncs from the legitimate outbound
+// peer despite the liar holding an open connection.
 func TestSyncPeerLiesAboutHeight(t *testing.T) {
 	victim, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
 	require.NoError(t, err)
@@ -102,21 +102,28 @@ func TestSyncPeerLiesAboutHeight(t *testing.T) {
 	_, err = honest.Client.Generate(honestStartBlocks)
 	require.NoError(t, err)
 
-	// Liar dials in first with the highest claimed height.
+	// Connect honest first (outbound from victim's POV) so the
+	// candidate pool has an outbound entry. Then connect the liar
+	// inbound — with an outbound available, inbound fallback should
+	// NOT activate, and the liar must not become syncnode.
+	require.NoError(t, rpctest.ConnectNode(victim, honest))
+	time.Sleep(1 * time.Second)
+
 	liar := newLiarPeer(t, victim.P2PAddress())
 	defer func() { liar.Disconnect(); liar.WaitForDisconnect() }()
 
-	// Liar must never appear as syncnode.
 	time.Sleep(2 * time.Second)
 	peers, err := victim.Client.GetPeerInfo()
 	require.NoError(t, err)
 	for _, p := range peers {
-		require.Falsef(t, p.SyncNode,
-			"inbound liar at %s was selected as syncnode", p.Addr)
+		if p.Addr == liar.LocalAddr().String() {
+			require.Falsef(t, p.SyncNode,
+				"inbound liar at %s was selected as syncnode "+
+					"despite outbound peer being available", p.Addr)
+		}
 	}
 
-	// Honest is the only valid sync candidate; victim must catch up.
-	require.NoError(t, rpctest.ConnectNode(victim, honest))
+	// Victim must catch up from honest.
 	require.Eventually(t, func() bool {
 		_, h, err := victim.Client.GetBestBlock()
 		return err == nil && h >= int32(honestStartBlocks)

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -264,22 +264,23 @@ func (sm *SyncManager) findNextHeaderCheckpoint(height int32) *chaincfg.Checkpoi
 // pickSyncCandidate returns a random sync-peer candidate, filtered by:
 //   - state.syncCandidate (SFNodeNetwork / pruned-with-block-threshold,
 //     set at handshake by isSyncCandidate).
-//   - Outbound only. peer.LastBlock() from the version handshake is
+//   - Outbound preferred. peer.LastBlock() from the version handshake is
 //     unauthenticated; restricting to outbound peers limits candidates
 //     to addresses we chose to dial (addr.dat / dnsseed).
 //   - recentlyFailedSync cooldown to prevent immediate re-selection of
 //     peers that previously stalled as syncnode.
 //
-// peer.LastBlock() is intentionally not used for ranking. Mirrors Bitcoin
-// Core's CanServeBlocks + fPreferredDownload posture (net_processing.cpp).
+// When no outbound candidate is available and the chain is not current,
+// inbound peers are accepted as a fallback so that a node whose only
+// block source is inbound (e.g. a NAT node dialling us) can still sync
+// during IBD.
+//
+// peer.LastBlock() is intentionally not used for ranking.
 func (sm *SyncManager) pickSyncCandidate() *peerpkg.Peer {
 	now := time.Now()
-	var candidates []*peerpkg.Peer
+	var candidates, inbound []*peerpkg.Peer
 	for peer, state := range sm.peerStates {
 		if !state.syncCandidate {
-			continue
-		}
-		if peer.Inbound() {
 			continue
 		}
 		if t, ok := sm.recentlyFailedSync[peer.Addr()]; ok {
@@ -288,7 +289,17 @@ func (sm *SyncManager) pickSyncCandidate() *peerpkg.Peer {
 			}
 			delete(sm.recentlyFailedSync, peer.Addr())
 		}
-		candidates = append(candidates, peer)
+		if peer.Inbound() {
+			inbound = append(inbound, peer)
+		} else {
+			candidates = append(candidates, peer)
+		}
+	}
+
+	// Prefer outbound. Fall back to inbound only when no outbound
+	// candidate is available and we still need to sync.
+	if len(candidates) == 0 && !sm.chain.IsCurrent() {
+		candidates = inbound
 	}
 
 	if len(candidates) == 0 {
@@ -1153,9 +1164,10 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		peer.UpdateLastAnnouncedBlock(&invVects[lastBlock].Hash)
 	}
 
-	// Ignore invs from peers that aren't the sync if we are not current.
-	// Helps prevent fetching a mass of orphans.
-	if peer != sm.syncPeer && !sm.current() {
+	// Ignore invs from non-syncpeers when not current to prevent
+	// fetching orphans. Allow through when syncPeer is nil so blocks
+	// reachable only via inbound peers can be discovered during IBD.
+	if peer != sm.syncPeer && !sm.current() && sm.syncPeer != nil {
 		return
 	}
 

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -1164,10 +1164,9 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		peer.UpdateLastAnnouncedBlock(&invVects[lastBlock].Hash)
 	}
 
-	// Ignore invs from non-syncpeers when not current to prevent
-	// fetching orphans. Allow through when syncPeer is nil so blocks
-	// reachable only via inbound peers can be discovered during IBD.
-	if peer != sm.syncPeer && !sm.current() && sm.syncPeer != nil {
+	// Ignore invs from peers that aren't the sync if we are not current.
+	// Helps prevent fetching a mass of orphans.
+	if peer != sm.syncPeer && !sm.current() {
 		return
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 1
+	Patch uint = 2
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

When no outbound sync-peer candidate is available and the chain is not
current, `pickSyncCandidate` now falls back to inbound peers. The
`handleInvMsg` gate is also relaxed to accept block announcements from
any peer when `syncPeer` is nil.

Without this, a node whose only block source connects inbound (e.g. a
NAT node dialling anchors) deadlocks at genesis: `pickSyncCandidate`
returns nil (no outbound), `handleInvMsg` drops the inbound peer's
block invs, and chain progress stays at zero.

Mirrors Bitcoin Core's `sync_blocks_and_headers_from_peer` fallback
(PR [#24171](https://github.com/bitcoin/bitcoin/pull/24171), merged
June 2022). Outbound peers remain preferred when available.

### Changes

- `pickSyncCandidate`: partition candidates into outbound/inbound
  buckets; use inbound only when outbound is empty and `!IsCurrent()`.
- `handleInvMsg`: allow invs through when `syncPeer == nil`, so blocks
  from inbound peers can be discovered during IBD.
- `TestSyncPeerLiesAboutHeight`: connect honest (outbound) before liar
  (inbound) so the test correctly asserts inbound exclusion when an
  outbound candidate exists.
- New `TestSyncFromInboundDuringIBD`: source dials victim inbound,
  mines 10 blocks, victim syncs within 30 s. Verified: fails without
  the fix (30 s timeout), passes with it (1 s).
- Version bump 1.0.1 → 1.0.2.

### Test

```
go test -tags=rpctest -timeout 5m -run 'TestSyncFromInboundDuringIBD|TestSyncPeerLiesAboutHeight|TestSyncManagerRaceCorruption|TestPreVerackDisconnect' ./node/integration
```