### PR TITLE
fix(node/v2transport): handle unchecked errors from Send()

### DIFF
--- a/node/v2transport/transport.go
+++ b/node/v2transport/transport.go
@@ -337,7 +337,10 @@ func (p *Peer) InitiateV2Handshake(garbageLen int) error {
 	log.Debugf("Sending ellswift pubkey and garbage (total_len=%d)",
 		len(data))
 
-	p.Send(data)
+	if _, err = p.Send(data); err != nil {
+		log.Errorf("Failed to send ellswift pubkey and garbage: %v", err)
+		return err
+	}
 
 	return nil
 }
@@ -363,7 +366,11 @@ func (p *Peer) RespondV2Handshake(garbageLen int) error {
 
 	log.Debugf("Sending ellswift pubkey and garbage (total_len=%d)",
 		len(data))
-	p.Send(data)
+
+	if _, err = p.Send(data); err != nil {
+		log.Errorf("Failed to send ellswift pubkey and garbage: %v", err)
+		return err
+	}
 
 	return nil
 }
@@ -444,7 +451,10 @@ func (p *Peer) CompleteHandshake(initiating bool, decoyContentLens []int,
 
 	// Send garbage terminator.
 	log.Debugf("Sending garbage terminator: %x", p.sendGarbageTerm)
-	p.Send(p.sendGarbageTerm[:])
+	if _, err = p.Send(p.sendGarbageTerm[:]); err != nil {
+		log.Errorf("Failed to send garbage terminator: %v", err)
+		return err
+	}
 
 	// Optionally send decoy packets after garbage terminator.
 	aad := p.sentGarbage
@@ -461,7 +471,10 @@ func (p *Peer) CompleteHandshake(initiating bool, decoyContentLens []int,
 			return err
 		}
 
-		p.Send(encPacket)
+		if _, err = p.Send(encPacket); err != nil {
+			log.Errorf("Failed to send decoy packet %d: %v", i+1, err)
+			return err
+		}
 
 		// AAD is only used for the first packet after the handshake.
 		aad = nil

--- a/plonky2/projects/cache-friendly-fft/__init__.py
+++ b/plonky2/projects/cache-friendly-fft/__init__.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from transpose import transpose_square
 from util import lb_exact
 
@@ -13,7 +14,7 @@ def _interleave(x, scratch):
     `x` and whose length is at least half the length of `x`.
     """
     assert len(x.shape) == len(scratch.shape) == 1
-
+    
     n, = x.shape
     assert n % 2 == 0
 
@@ -22,7 +23,7 @@ def _interleave(x, scratch):
 
     assert x.dtype == scratch.dtype
     scratch = scratch[:half_n]
-
+    
     scratch[:] = x[:half_n]  # Save the first half of `x`.
     for i in range(half_n):
         x[2 * i] = scratch[i]
@@ -39,7 +40,7 @@ def _deinterleave(x, scratch):
     `x` and whose length is at least half the length of `x`.
     """
     assert len(x.shape) == len(scratch.shape) == 1
-
+    
     n, = x.shape
     assert n % 2 == 0
 
@@ -155,7 +156,7 @@ def _fft_inplace(x, scratch):
     # This does not copy the buffer.
     x = x.view()
     assert x.flags['C_CONTIGUOUS']
-
+    
     n, = x.shape
     if n == 1:
         return
@@ -165,7 +166,7 @@ def _fft_inplace(x, scratch):
         x[1] = x0 - x1
         return
 
-    lb_n = lb_exact(n)
+    lb_n = lb_exact(n)    
     is_odd = lb_n & 1 != 0
     if is_odd:
         _fft_inplace_oddpow(x, scratch)

--- a/plonky2/projects/cache-friendly-fft/__init__.py
+++ b/plonky2/projects/cache-friendly-fft/__init__.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from transpose import transpose_square
 from util import lb_exact
 
@@ -14,7 +13,7 @@ def _interleave(x, scratch):
     `x` and whose length is at least half the length of `x`.
     """
     assert len(x.shape) == len(scratch.shape) == 1
-    
+
     n, = x.shape
     assert n % 2 == 0
 
@@ -23,7 +22,7 @@ def _interleave(x, scratch):
 
     assert x.dtype == scratch.dtype
     scratch = scratch[:half_n]
-    
+
     scratch[:] = x[:half_n]  # Save the first half of `x`.
     for i in range(half_n):
         x[2 * i] = scratch[i]
@@ -40,7 +39,7 @@ def _deinterleave(x, scratch):
     `x` and whose length is at least half the length of `x`.
     """
     assert len(x.shape) == len(scratch.shape) == 1
-    
+
     n, = x.shape
     assert n % 2 == 0
 
@@ -156,7 +155,7 @@ def _fft_inplace(x, scratch):
     # This does not copy the buffer.
     x = x.view()
     assert x.flags['C_CONTIGUOUS']
-    
+
     n, = x.shape
     if n == 1:
         return
@@ -166,7 +165,7 @@ def _fft_inplace(x, scratch):
         x[1] = x0 - x1
         return
 
-    lb_n = lb_exact(n)    
+    lb_n = lb_exact(n)
     is_odd = lb_n & 1 != 0
     if is_odd:
         _fft_inplace_oddpow(x, scratch)


### PR DESCRIPTION
## Summary

Fixes errcheck lint violations found by `task lint:go`.

`Peer.Send()` returns `(int, error)` but the error was silently discarded in 4 call sites:

| Location | Function |
|---|---|
| Line 340 | `InitiateV2Handshake` |
| Line 366 | `RespondV2Handshake` |
| Line 447 | `CompleteHandshake` (garbage terminator) |
| Line 464 | `CompleteHandshake` (decoy packet loop) |

A send failure during the v2 handshake would previously go undetected, causing the connection to silently continue in a broken state.

## Testing
- `go build ./node/v2transport/...` ✅ passes