### PR TITLE
fix(node/peer): handle unchecked errors from AddInvVect and AddUserAgent

### DIFF
--- a/node/peer/peer.go
+++ b/node/peer/peer.go
@@ -1676,7 +1676,10 @@ out:
 					iv.Type == wire.InvTypeWitnessBlock {
 
 					invMsg := wire.NewMsgInvSizeHint(1)
-					invMsg.AddInvVect(iv)
+					if err := invMsg.AddInvVect(iv); err != nil {
+						log.Warnf("Failed to add inv vect: %v", err)
+						continue
+					}
 					waiting = queuePacket(outMsg{msg: invMsg},
 						pendingMsgs, waiting)
 				} else {
@@ -1705,7 +1708,10 @@ out:
 					continue
 				}
 
-				invMsg.AddInvVect(iv)
+				if err := invMsg.AddInvVect(iv); err != nil {
+					log.Warnf("Failed to add inv vect to trickle: %v", err)
+					continue
+				}
 				if len(invMsg.InvList) >= maxInvTrickleSize {
 					waiting = queuePacket(
 						outMsg{msg: invMsg},
@@ -2094,8 +2100,11 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 
 	// Version message.
 	msg := wire.NewMsgVersion(ourNA, theirNA, nonce, blockNum)
-	msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion,
-		p.cfg.UserAgentComments...)
+	if err := msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion,
+		p.cfg.UserAgentComments...); err != nil {
+		log.Errorf("Failed to add user agent: %v", err)
+		return nil, err
+	}
 
 	// Advertise local services.
 	msg.Services = p.cfg.Services


### PR DESCRIPTION
## Summary

Fixes errcheck lint violations found by `task lint:go`.

| Location | Function | Error Source |
|---|---|---|
| Line 1679 | `queueHandler` | `AddInvVect` — exceeds `MaxInvPerMsg` limit |
| Line 1711 | `queueHandler` (trickle loop) | `AddInvVect` — exceeds `MaxInvPerMsg` limit |
| Line 2097 | `writeLocalVersionMsg` | `AddUserAgent` — invalid user agent string |

Each call site now checks the error and handles it appropriately.

## Testing
- `go build ./node/peer/...` ✅ passes