### PR TITLE
fix(node): handle unchecked errors in mempool estimatefee and txscript sighash

### DIFF
--- a/node/mempool/estimatefee.go
+++ b/node/mempool/estimatefee.go
@@ -108,25 +108,39 @@ type observedTransaction struct {
 	mined int32
 }
 
-func (o *observedTransaction) Serialize(w io.Writer) {
-	binary.Write(w, binary.BigEndian, o.hash)
-	binary.Write(w, binary.BigEndian, o.feeRate)
-	binary.Write(w, binary.BigEndian, o.observed)
-	binary.Write(w, binary.BigEndian, o.mined)
+func (o *observedTransaction) Serialize(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, o.hash); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, o.feeRate); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, o.observed); err != nil {
+		return err
+	}
+	return binary.Write(w, binary.BigEndian, o.mined)
 }
 
 func deserializeObservedTransaction(r io.Reader) (*observedTransaction, error) {
 	ot := observedTransaction{}
 
 	// The first 32 bytes should be a hash.
-	binary.Read(r, binary.BigEndian, &ot.hash)
+	if err := binary.Read(r, binary.BigEndian, &ot.hash); err != nil {
+		return nil, err
+	}
 
 	// The next 8 are GrainPerByte
-	binary.Read(r, binary.BigEndian, &ot.feeRate)
+	if err := binary.Read(r, binary.BigEndian, &ot.feeRate); err != nil {
+		return nil, err
+	}
 
 	// And next there are two uint32's.
-	binary.Read(r, binary.BigEndian, &ot.observed)
-	binary.Read(r, binary.BigEndian, &ot.mined)
+	if err := binary.Read(r, binary.BigEndian, &ot.observed); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r, binary.BigEndian, &ot.mined); err != nil {
+		return nil, err
+	}
 
 	return &ot, nil
 }
@@ -140,13 +154,19 @@ type registeredBlock struct {
 	transactions []*observedTransaction
 }
 
-func (rb *registeredBlock) serialize(w io.Writer, txs map[*observedTransaction]uint32) {
-	binary.Write(w, binary.BigEndian, rb.hash)
-
-	binary.Write(w, binary.BigEndian, uint32(len(rb.transactions)))
-	for _, o := range rb.transactions {
-		binary.Write(w, binary.BigEndian, txs[o])
+func (rb *registeredBlock) serialize(w io.Writer, txs map[*observedTransaction]uint32) error {
+	if err := binary.Write(w, binary.BigEndian, rb.hash); err != nil {
+		return err
 	}
+	if err := binary.Write(w, binary.BigEndian, uint32(len(rb.transactions))); err != nil {
+		return err
+	}
+	for _, o := range rb.transactions {
+		if err := binary.Write(w, binary.BigEndian, txs[o]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // FeeEstimator manages the data necessary to create
@@ -636,15 +656,15 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 	// TODO figure out what the capacity should be.
 	w := bytes.NewBuffer(make([]byte, 0))
 
-	binary.Write(w, binary.BigEndian, uint32(estimateFeeSaveVersion))
+	binary.Write(w, binary.BigEndian, uint32(estimateFeeSaveVersion)) //nolint:errcheck // bytes.Buffer.Write never returns an error
 
 	// Insert basic parameters.
-	binary.Write(w, binary.BigEndian, &ef.maxRollback)
-	binary.Write(w, binary.BigEndian, &ef.binSize)
-	binary.Write(w, binary.BigEndian, &ef.maxReplacements)
-	binary.Write(w, binary.BigEndian, &ef.minRegisteredBlocks)
-	binary.Write(w, binary.BigEndian, &ef.lastKnownHeight)
-	binary.Write(w, binary.BigEndian, &ef.numBlocksRegistered)
+	binary.Write(w, binary.BigEndian, &ef.maxRollback)         //nolint:errcheck // bytes.Buffer.Write never returns an error
+	binary.Write(w, binary.BigEndian, &ef.binSize)               //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.maxReplacements)       //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.minRegisteredBlocks)   //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.lastKnownHeight)       //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.numBlocksRegistered)   //nolint:errcheck
 
 	// Put all the observed transactions in a sorted list.
 	var txCount uint32
@@ -658,9 +678,11 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 
 	txCount = 0
 	observed := make(map[*observedTransaction]uint32)
-	binary.Write(w, binary.BigEndian, uint32(len(ef.observed)))
+	binary.Write(w, binary.BigEndian, uint32(len(ef.observed))) //nolint:errcheck // bytes.Buffer.Write never returns an error
 	for _, ot := range ots {
-		ot.Serialize(w)
+		if err := ot.Serialize(w); err != nil {
+			panic(fmt.Sprintf("unexpected error serializing observed tx: %v", err))
+		}
 		observed[ot] = txCount
 		txCount++
 	}
@@ -668,17 +690,19 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 	// Save all the right bins.
 	for _, list := range ef.bin {
 
-		binary.Write(w, binary.BigEndian, uint32(len(list)))
+		binary.Write(w, binary.BigEndian, uint32(len(list)))      //nolint:errcheck // bytes.Buffer.Write never returns an error
 
 		for _, o := range list {
-			binary.Write(w, binary.BigEndian, observed[o])
+			binary.Write(w, binary.BigEndian, observed[o]) //nolint:errcheck
 		}
 	}
 
 	// Dropped transactions.
-	binary.Write(w, binary.BigEndian, uint32(len(ef.dropped)))
+	binary.Write(w, binary.BigEndian, uint32(len(ef.dropped))) //nolint:errcheck // bytes.Buffer.Write never returns an error
 	for _, registered := range ef.dropped {
-		registered.serialize(w, observed)
+		if err := registered.serialize(w, observed); err != nil {
+			panic(fmt.Sprintf("unexpected error serializing registered block: %v", err))
+		}
 	}
 
 	// Commit the tx and return.

--- a/node/txscript/sighash.go
+++ b/node/txscript/sighash.go
@@ -68,7 +68,7 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 		// First write out, then encode the transaction's version
 		// number.
 		binary.LittleEndian.PutUint32(scratch[:], uint32(tx.Version))
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 
 		// Next write out the possibly pre-calculated hashes for the
 		// sequence numbers of all inputs, and the hashes of the
@@ -79,9 +79,9 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 		// hashPrevOuts, otherwise we just write zeroes for the prev
 		// outs.
 		if hashType&SigHashAnyOneCanPay == 0 {
-			w.Write(sigHashes.HashPrevOutsV0[:])
+			w.Write(sigHashes.HashPrevOutsV0[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else {
-			w.Write(zeroHash[:])
+			w.Write(zeroHash[:]) //nolint:errcheck // sha256 writer never returns an error
 		}
 
 		// If the sighash isn't anyone can pay, single, or none, the
@@ -91,31 +91,31 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 			hashType&sigHashMask != SigHashSingle &&
 			hashType&sigHashMask != SigHashNone {
 
-			w.Write(sigHashes.HashSequenceV0[:])
+			w.Write(sigHashes.HashSequenceV0[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else {
-			w.Write(zeroHash[:])
+			w.Write(zeroHash[:]) //nolint:errcheck // sha256 writer never returns an error
 		}
 
 		txIn := tx.TxIn[idx]
 
 		// Next, write the outpoint being spent.
-		w.Write(txIn.PreviousOutPoint.Hash[:])
+		w.Write(txIn.PreviousOutPoint.Hash[:]) //nolint:errcheck // sha256 writer never returns an error
 		var bIndex [4]byte
 		binary.LittleEndian.PutUint32(
 			bIndex[:], txIn.PreviousOutPoint.Index,
 		)
-		w.Write(bIndex[:])
+		w.Write(bIndex[:]) //nolint:errcheck // sha256 writer never returns an error
 
 		// The script code is the original script, with all code
 		// separators removed, serialized with a var int length prefix.
-		wire.WriteVarBytes(w, 0, subScript)
+		wire.WriteVarBytes(w, 0, subScript) //nolint:errcheck // sha256 writer never returns an error
 
 		// Next, add the input amount, and sequence number of the input
 		// being signed.
 		binary.LittleEndian.PutUint64(scratch[:], uint64(amt))
-		w.Write(scratch[:])
+		w.Write(scratch[:]) //nolint:errcheck // sha256 writer never returns an error
 		binary.LittleEndian.PutUint32(scratch[:], txIn.Sequence)
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 
 		// If the current signature mode isn't single, or none, then we
 		// can re-use the pre-generated hashoutputs sighash fragment.
@@ -124,25 +124,25 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 		if hashType&sigHashMask != SigHashSingle &&
 			hashType&sigHashMask != SigHashNone {
 
-			w.Write(sigHashes.HashOutputsV0[:])
+			w.Write(sigHashes.HashOutputsV0[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else if hashType&sigHashMask == SigHashSingle &&
 			idx < len(tx.TxOut) {
 
 			h := chainhash.DoubleHashRaw(func(tw io.Writer) error {
-				wire.WriteTxOut(tw, 0, 0, tx.TxOut[idx])
+				wire.WriteTxOut(tw, 0, 0, tx.TxOut[idx]) //nolint:errcheck // sha256 writer never returns an error
 				return nil
 			})
-			w.Write(h[:])
+			w.Write(h[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else {
-			w.Write(zeroHash[:])
+			w.Write(zeroHash[:]) //nolint:errcheck // sha256 writer never returns an error
 		}
 
 		// Finally, write out the transaction's locktime, and the sig
 		// hash type.
 		binary.LittleEndian.PutUint32(scratch[:], tx.LockTime)
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 		binary.LittleEndian.PutUint32(scratch[:], uint32(hashType))
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 
 		return nil
 	})


### PR DESCRIPTION
## Summary

Fixes errcheck lint violations found by `task lint:go`.

### `node/mempool/estimatefee.go`
- `binary.Read` in `deserializeObservedTransaction` silently discarded errors indicating corrupt/truncated data — now returns error to caller
- `binary.Write` in `Serialize`/`serialize` methods now return errors
- `binary.Write` in `Save()` operates on `bytes.Buffer` (never errors) — annotated with `//nolint:errcheck`

### `node/txscript/sighash.go`
- `w.Write()` inside `DoubleHashRaw` callback operates on `sha256.Hash` writer which never errors, as documented in `DoubleHashRaw` itself — annotated with `//nolint:errcheck`

## Testing
- `go build ./node/mempool/...` ✅ passes
- `go build ./node/txscript/...` ✅ passes