### PR TITLE
fix(node): handle unchecked errors in addrmanager and fullblocktests

### DIFF
--- a/node/addrmgr/addrmanager.go
+++ b/node/addrmgr/addrmanager.go
@@ -710,7 +710,9 @@ func (a *AddrManager) reset() {
 	a.addrIndex = make(map[string]*KnownAddress)
 
 	// fill key with bytes from a good random source.
-	io.ReadFull(crand.Reader, a.key[:])
+	if _, err := io.ReadFull(crand.Reader, a.key[:]); err != nil {
+		panic(fmt.Sprintf("failed to read random key: %v", err))
+	}
 	for i := range a.addrNew {
 		a.addrNew[i] = make(map[string]*KnownAddress)
 	}


### PR DESCRIPTION
## Summary

Fixes errcheck lint violations found by `task lint:go`.

### `node/addrmgr/addrmanager.go`
- `io.ReadFull(crand.Reader, a.key[:])` silently discarded error — if CSPRNG fails, address manager key remains zeroed which is a **security issue**. Now panics with descriptive message.

### `node/blockchain/fullblocktests/generate.go`
- `AddTransaction()` and `PrlEncode()` errors in test helper functions now panic with descriptive messages instead of being silently ignored.

## Testing
- `go build ./node/addrmgr/...` ✅ passes
- `go build ./node/blockchain/...` ✅ passes