### PR TITLE
fix(wallet/walletdb): assign error return from walletdb.View

### DIFF
--- a/wallet/walletdb/walletdbtest/interface.go
+++ b/wallet/walletdb/walletdbtest/interface.go
@@ -542,7 +542,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 
 	// Test that we can read the top level buckets.
 	var topLevelBuckets []string
-	walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 		return tx.ForEachBucket(func(key []byte) error {
 			topLevelBuckets = append(topLevelBuckets, string(key))
 			return nil


### PR DESCRIPTION
## Summary

Fixes errcheck lint violation found by `task lint:go`.

`walletdb.View()` return value was discarded in `testReadWriteInterface`. The `err` variable was declared earlier in the function but not assigned here, meaning any database error during top-level bucket enumeration would be silently ignored.

## Testing
- `go build ./wallet/...` ✅ passes