### PR TITLE
fix(lint): aggregate errcheck violations and style fixes

### DIFF
--- a/node/addrmgr/addrmanager.go
+++ b/node/addrmgr/addrmanager.go
@@ -710,7 +710,9 @@ func (a *AddrManager) reset() {
 	a.addrIndex = make(map[string]*KnownAddress)
 
 	// fill key with bytes from a good random source.
-	io.ReadFull(crand.Reader, a.key[:])
+	if _, err := io.ReadFull(crand.Reader, a.key[:]); err != nil {
+		panic(fmt.Sprintf("failed to read random key: %v", err))
+	}
 	for i := range a.addrNew {
 		a.addrNew[i] = make(map[string]*KnownAddress)
 	}

--- a/node/blockchain/fullblocktests/generate.go
+++ b/node/blockchain/fullblocktests/generate.go
@@ -375,7 +375,9 @@ func replaceCoinbaseSigScript(script []byte) func(*wire.MsgBlock) {
 // adding the provided transaction.
 func additionalTx(tx *wire.MsgTx) func(*wire.MsgBlock) {
 	return func(b *wire.MsgBlock) {
-		b.AddTransaction(tx)
+		if err := b.AddTransaction(tx); err != nil {
+			panic(fmt.Sprintf("AddTransaction: %v", err))
+		}
 	}
 }
 
@@ -657,12 +659,18 @@ func nonCanonicalVarInt(val uint32) []byte {
 func encodeNonCanonicalBlock(b *wire.MsgBlock) []byte {
 	var buf bytes.Buffer
 	// Encode certificate first (certificate-first architecture)
-	b.MsgHeader.MsgCertificate.PrlEncode(&buf, 0)
+	if err := b.MsgHeader.MsgCertificate.PrlEncode(&buf, 0); err != nil {
+		panic(fmt.Sprintf("MsgCertificate.PrlEncode: %v", err))
+	}
 	// Then encode header
-	b.BlockHeader().PrlEncode(&buf, 0, wire.BaseEncoding)
+	if err := b.BlockHeader().PrlEncode(&buf, 0, wire.BaseEncoding); err != nil {
+		panic(fmt.Sprintf("BlockHeader.PrlEncode: %v", err))
+	}
 	buf.Write(nonCanonicalVarInt(uint32(len(b.Transactions))))
 	for _, tx := range b.Transactions {
-		tx.PrlEncode(&buf, 0, wire.BaseEncoding)
+		if err := tx.PrlEncode(&buf, 0, wire.BaseEncoding); err != nil {
+			panic(fmt.Sprintf("tx.PrlEncode: %v", err))
+		}
 	}
 	return buf.Bytes()
 }
@@ -672,7 +680,9 @@ func cloneBlock(b *wire.MsgBlock) wire.MsgBlock {
 	var blockCopy wire.MsgBlock
 	blockCopy.MsgHeader = b.MsgHeader
 	for _, tx := range b.Transactions {
-		blockCopy.AddTransaction(tx.Copy())
+		if err := blockCopy.AddTransaction(tx.Copy()); err != nil {
+			panic(fmt.Sprintf("blockCopy.AddTransaction: %v", err))
+		}
 	}
 	return blockCopy
 }

--- a/node/mempool/estimatefee.go
+++ b/node/mempool/estimatefee.go
@@ -108,25 +108,39 @@ type observedTransaction struct {
 	mined int32
 }
 
-func (o *observedTransaction) Serialize(w io.Writer) {
-	binary.Write(w, binary.BigEndian, o.hash)
-	binary.Write(w, binary.BigEndian, o.feeRate)
-	binary.Write(w, binary.BigEndian, o.observed)
-	binary.Write(w, binary.BigEndian, o.mined)
+func (o *observedTransaction) Serialize(w io.Writer) error {
+	if err := binary.Write(w, binary.BigEndian, o.hash); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, o.feeRate); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.BigEndian, o.observed); err != nil {
+		return err
+	}
+	return binary.Write(w, binary.BigEndian, o.mined)
 }
 
 func deserializeObservedTransaction(r io.Reader) (*observedTransaction, error) {
 	ot := observedTransaction{}
 
 	// The first 32 bytes should be a hash.
-	binary.Read(r, binary.BigEndian, &ot.hash)
+	if err := binary.Read(r, binary.BigEndian, &ot.hash); err != nil {
+		return nil, err
+	}
 
 	// The next 8 are GrainPerByte
-	binary.Read(r, binary.BigEndian, &ot.feeRate)
+	if err := binary.Read(r, binary.BigEndian, &ot.feeRate); err != nil {
+		return nil, err
+	}
 
 	// And next there are two uint32's.
-	binary.Read(r, binary.BigEndian, &ot.observed)
-	binary.Read(r, binary.BigEndian, &ot.mined)
+	if err := binary.Read(r, binary.BigEndian, &ot.observed); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(r, binary.BigEndian, &ot.mined); err != nil {
+		return nil, err
+	}
 
 	return &ot, nil
 }
@@ -140,13 +154,19 @@ type registeredBlock struct {
 	transactions []*observedTransaction
 }
 
-func (rb *registeredBlock) serialize(w io.Writer, txs map[*observedTransaction]uint32) {
-	binary.Write(w, binary.BigEndian, rb.hash)
-
-	binary.Write(w, binary.BigEndian, uint32(len(rb.transactions)))
-	for _, o := range rb.transactions {
-		binary.Write(w, binary.BigEndian, txs[o])
+func (rb *registeredBlock) serialize(w io.Writer, txs map[*observedTransaction]uint32) error {
+	if err := binary.Write(w, binary.BigEndian, rb.hash); err != nil {
+		return err
 	}
+	if err := binary.Write(w, binary.BigEndian, uint32(len(rb.transactions))); err != nil {
+		return err
+	}
+	for _, o := range rb.transactions {
+		if err := binary.Write(w, binary.BigEndian, txs[o]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // FeeEstimator manages the data necessary to create
@@ -636,15 +656,15 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 	// TODO figure out what the capacity should be.
 	w := bytes.NewBuffer(make([]byte, 0))
 
-	binary.Write(w, binary.BigEndian, uint32(estimateFeeSaveVersion))
+	binary.Write(w, binary.BigEndian, uint32(estimateFeeSaveVersion)) //nolint:errcheck // bytes.Buffer.Write never returns an error
 
 	// Insert basic parameters.
-	binary.Write(w, binary.BigEndian, &ef.maxRollback)
-	binary.Write(w, binary.BigEndian, &ef.binSize)
-	binary.Write(w, binary.BigEndian, &ef.maxReplacements)
-	binary.Write(w, binary.BigEndian, &ef.minRegisteredBlocks)
-	binary.Write(w, binary.BigEndian, &ef.lastKnownHeight)
-	binary.Write(w, binary.BigEndian, &ef.numBlocksRegistered)
+	binary.Write(w, binary.BigEndian, &ef.maxRollback)         //nolint:errcheck // bytes.Buffer.Write never returns an error
+	binary.Write(w, binary.BigEndian, &ef.binSize)               //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.maxReplacements)       //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.minRegisteredBlocks)   //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.lastKnownHeight)       //nolint:errcheck
+	binary.Write(w, binary.BigEndian, &ef.numBlocksRegistered)   //nolint:errcheck
 
 	// Put all the observed transactions in a sorted list.
 	var txCount uint32
@@ -658,9 +678,11 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 
 	txCount = 0
 	observed := make(map[*observedTransaction]uint32)
-	binary.Write(w, binary.BigEndian, uint32(len(ef.observed)))
+	binary.Write(w, binary.BigEndian, uint32(len(ef.observed))) //nolint:errcheck // bytes.Buffer.Write never returns an error
 	for _, ot := range ots {
-		ot.Serialize(w)
+		if err := ot.Serialize(w); err != nil {
+			panic(fmt.Sprintf("unexpected error serializing observed tx: %v", err))
+		}
 		observed[ot] = txCount
 		txCount++
 	}
@@ -668,17 +690,19 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 	// Save all the right bins.
 	for _, list := range ef.bin {
 
-		binary.Write(w, binary.BigEndian, uint32(len(list)))
+		binary.Write(w, binary.BigEndian, uint32(len(list)))      //nolint:errcheck // bytes.Buffer.Write never returns an error
 
 		for _, o := range list {
-			binary.Write(w, binary.BigEndian, observed[o])
+			binary.Write(w, binary.BigEndian, observed[o]) //nolint:errcheck
 		}
 	}
 
 	// Dropped transactions.
-	binary.Write(w, binary.BigEndian, uint32(len(ef.dropped)))
+	binary.Write(w, binary.BigEndian, uint32(len(ef.dropped))) //nolint:errcheck // bytes.Buffer.Write never returns an error
 	for _, registered := range ef.dropped {
-		registered.serialize(w, observed)
+		if err := registered.serialize(w, observed); err != nil {
+			panic(fmt.Sprintf("unexpected error serializing registered block: %v", err))
+		}
 	}
 
 	// Commit the tx and return.

--- a/node/peer/peer.go
+++ b/node/peer/peer.go
@@ -1679,7 +1679,10 @@ out:
 					iv.Type == wire.InvTypeWitnessBlock {
 
 					invMsg := wire.NewMsgInvSizeHint(1)
-					invMsg.AddInvVect(iv)
+					if err := invMsg.AddInvVect(iv); err != nil {
+						log.Warnf("Failed to add inv vect: %v", err)
+						continue
+					}
 					waiting = queuePacket(outMsg{msg: invMsg},
 						pendingMsgs, waiting)
 				} else {
@@ -1708,7 +1711,10 @@ out:
 					continue
 				}
 
-				invMsg.AddInvVect(iv)
+				if err := invMsg.AddInvVect(iv); err != nil {
+					log.Warnf("Failed to add inv vect to trickle: %v", err)
+					continue
+				}
 				if len(invMsg.InvList) >= maxInvTrickleSize {
 					waiting = queuePacket(
 						outMsg{msg: invMsg},
@@ -2097,8 +2103,11 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 
 	// Version message.
 	msg := wire.NewMsgVersion(ourNA, theirNA, nonce, blockNum)
-	msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion,
-		p.cfg.UserAgentComments...)
+	if err := msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion,
+		p.cfg.UserAgentComments...); err != nil {
+		log.Errorf("Failed to add user agent: %v", err)
+		return nil, err
+	}
 
 	// Advertise local services.
 	msg.Services = p.cfg.Services

--- a/node/txscript/sighash.go
+++ b/node/txscript/sighash.go
@@ -68,7 +68,7 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 		// First write out, then encode the transaction's version
 		// number.
 		binary.LittleEndian.PutUint32(scratch[:], uint32(tx.Version))
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 
 		// Next write out the possibly pre-calculated hashes for the
 		// sequence numbers of all inputs, and the hashes of the
@@ -79,9 +79,9 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 		// hashPrevOuts, otherwise we just write zeroes for the prev
 		// outs.
 		if hashType&SigHashAnyOneCanPay == 0 {
-			w.Write(sigHashes.HashPrevOutsV0[:])
+			w.Write(sigHashes.HashPrevOutsV0[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else {
-			w.Write(zeroHash[:])
+			w.Write(zeroHash[:]) //nolint:errcheck // sha256 writer never returns an error
 		}
 
 		// If the sighash isn't anyone can pay, single, or none, the
@@ -91,31 +91,31 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 			hashType&sigHashMask != SigHashSingle &&
 			hashType&sigHashMask != SigHashNone {
 
-			w.Write(sigHashes.HashSequenceV0[:])
+			w.Write(sigHashes.HashSequenceV0[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else {
-			w.Write(zeroHash[:])
+			w.Write(zeroHash[:]) //nolint:errcheck // sha256 writer never returns an error
 		}
 
 		txIn := tx.TxIn[idx]
 
 		// Next, write the outpoint being spent.
-		w.Write(txIn.PreviousOutPoint.Hash[:])
+		w.Write(txIn.PreviousOutPoint.Hash[:]) //nolint:errcheck // sha256 writer never returns an error
 		var bIndex [4]byte
 		binary.LittleEndian.PutUint32(
 			bIndex[:], txIn.PreviousOutPoint.Index,
 		)
-		w.Write(bIndex[:])
+		w.Write(bIndex[:]) //nolint:errcheck // sha256 writer never returns an error
 
 		// The script code is the original script, with all code
 		// separators removed, serialized with a var int length prefix.
-		wire.WriteVarBytes(w, 0, subScript)
+		wire.WriteVarBytes(w, 0, subScript) //nolint:errcheck // sha256 writer never returns an error
 
 		// Next, add the input amount, and sequence number of the input
 		// being signed.
 		binary.LittleEndian.PutUint64(scratch[:], uint64(amt))
-		w.Write(scratch[:])
+		w.Write(scratch[:]) //nolint:errcheck // sha256 writer never returns an error
 		binary.LittleEndian.PutUint32(scratch[:], txIn.Sequence)
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 
 		// If the current signature mode isn't single, or none, then we
 		// can re-use the pre-generated hashoutputs sighash fragment.
@@ -124,25 +124,25 @@ func calcWitnessSignatureHashRaw(subScript []byte, sigHashes *TxSigHashes,
 		if hashType&sigHashMask != SigHashSingle &&
 			hashType&sigHashMask != SigHashNone {
 
-			w.Write(sigHashes.HashOutputsV0[:])
+			w.Write(sigHashes.HashOutputsV0[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else if hashType&sigHashMask == SigHashSingle &&
 			idx < len(tx.TxOut) {
 
 			h := chainhash.DoubleHashRaw(func(tw io.Writer) error {
-				wire.WriteTxOut(tw, 0, 0, tx.TxOut[idx])
+				wire.WriteTxOut(tw, 0, 0, tx.TxOut[idx]) //nolint:errcheck // sha256 writer never returns an error
 				return nil
 			})
-			w.Write(h[:])
+			w.Write(h[:]) //nolint:errcheck // sha256 writer never returns an error
 		} else {
-			w.Write(zeroHash[:])
+			w.Write(zeroHash[:]) //nolint:errcheck // sha256 writer never returns an error
 		}
 
 		// Finally, write out the transaction's locktime, and the sig
 		// hash type.
 		binary.LittleEndian.PutUint32(scratch[:], tx.LockTime)
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 		binary.LittleEndian.PutUint32(scratch[:], uint32(hashType))
-		w.Write(scratch[:4])
+		w.Write(scratch[:4]) //nolint:errcheck // sha256 writer never returns an error
 
 		return nil
 	})

--- a/node/v2transport/transport.go
+++ b/node/v2transport/transport.go
@@ -337,7 +337,10 @@ func (p *Peer) InitiateV2Handshake(garbageLen int) error {
 	log.Debugf("Sending ellswift pubkey and garbage (total_len=%d)",
 		len(data))
 
-	p.Send(data)
+	if _, err = p.Send(data); err != nil {
+		log.Errorf("Failed to send ellswift pubkey and garbage: %v", err)
+		return err
+	}
 
 	return nil
 }
@@ -363,7 +366,11 @@ func (p *Peer) RespondV2Handshake(garbageLen int) error {
 
 	log.Debugf("Sending ellswift pubkey and garbage (total_len=%d)",
 		len(data))
-	p.Send(data)
+
+	if _, err = p.Send(data); err != nil {
+		log.Errorf("Failed to send ellswift pubkey and garbage: %v", err)
+		return err
+	}
 
 	return nil
 }
@@ -444,7 +451,10 @@ func (p *Peer) CompleteHandshake(initiating bool, decoyContentLens []int,
 
 	// Send garbage terminator.
 	log.Debugf("Sending garbage terminator: %x", p.sendGarbageTerm)
-	p.Send(p.sendGarbageTerm[:])
+	if _, err = p.Send(p.sendGarbageTerm[:]); err != nil {
+		log.Errorf("Failed to send garbage terminator: %v", err)
+		return err
+	}
 
 	// Optionally send decoy packets after garbage terminator.
 	aad := p.sentGarbage
@@ -461,7 +471,10 @@ func (p *Peer) CompleteHandshake(initiating bool, decoyContentLens []int,
 			return err
 		}
 
-		p.Send(encPacket)
+		if _, err = p.Send(encPacket); err != nil {
+			log.Errorf("Failed to send decoy packet %d: %v", i+1, err)
+			return err
+		}
 
 		// AAD is only used for the first packet after the handshake.
 		aad = nil

--- a/plonky2/projects/cache-friendly-fft/__init__.py
+++ b/plonky2/projects/cache-friendly-fft/__init__.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from transpose import transpose_square
 from util import lb_exact
 
@@ -14,7 +13,7 @@ def _interleave(x, scratch):
     `x` and whose length is at least half the length of `x`.
     """
     assert len(x.shape) == len(scratch.shape) == 1
-    
+
     n, = x.shape
     assert n % 2 == 0
 
@@ -23,7 +22,7 @@ def _interleave(x, scratch):
 
     assert x.dtype == scratch.dtype
     scratch = scratch[:half_n]
-    
+
     scratch[:] = x[:half_n]  # Save the first half of `x`.
     for i in range(half_n):
         x[2 * i] = scratch[i]
@@ -40,7 +39,7 @@ def _deinterleave(x, scratch):
     `x` and whose length is at least half the length of `x`.
     """
     assert len(x.shape) == len(scratch.shape) == 1
-    
+
     n, = x.shape
     assert n % 2 == 0
 
@@ -156,7 +155,7 @@ def _fft_inplace(x, scratch):
     # This does not copy the buffer.
     x = x.view()
     assert x.flags['C_CONTIGUOUS']
-    
+
     n, = x.shape
     if n == 1:
         return
@@ -166,7 +165,7 @@ def _fft_inplace(x, scratch):
         x[1] = x0 - x1
         return
 
-    lb_n = lb_exact(n)    
+    lb_n = lb_exact(n)
     is_odd = lb_n & 1 != 0
     if is_odd:
         _fft_inplace_oddpow(x, scratch)

--- a/wallet/walletdb/walletdbtest/interface.go
+++ b/wallet/walletdb/walletdbtest/interface.go
@@ -542,7 +542,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 
 	// Test that we can read the top level buckets.
 	var topLevelBuckets []string
-	walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
 		return tx.ForEachBucket(func(key []byte) error {
 			topLevelBuckets = append(topLevelBuckets, string(key))
 			return nil


### PR DESCRIPTION
## Summary

Aggregates all lint and style fixes into a single PR as requested.

Fixes `errcheck` violations found by `task lint:go` and style issues from `uvx ruff check`:

| File | Fix |
|---|---|
| `node/v2transport/transport.go` | `Peer.Send()` return values were silently discarded in 4 call sites during v2 handshake |
| `node/peer/peer.go` | `AddInvVect()` and `AddUserAgent()` errors unchecked |
| `node/mempool/estimatefee.go` | `binary.Read/Write` errors unchecked in serialization |
| `node/txscript/sighash.go` | Annotated intentional `w.Write()` ignores inside `DoubleHashRaw` callback with `//nolint:errcheck` |
| `node/addrmgr/addrmanager.go` | `io.ReadFull` on CSPRNG key silently discarded — security issue |
| `node/blockchain/fullblocktests/generate.go` | `AddTransaction()` and `PrlEncode()` errors unchecked in test helpers |
| `wallet/walletdb/walletdbtest/interface.go` | `walletdb.View()` return value unassigned |
| `plonky2/projects/cache-friendly-fft/__init__.py` | Trailing whitespace (W291/W293) fixed by `uvx ruff check` |

## Testing
- `go build ./node/...` ✅ passes
- `go build ./wallet/...` ✅ passes
- `uvx ruff check plonky2/projects/cache-friendly-fft/__init__.py` ✅ All checks passed

Closes #62, #63, #64, #65, #66, #67