### PR TITLE
fix(test): replace t.Fatalf with t.Errorf in goroutines

### DIFF
--- a/node/btcec/schnorr/musig2/musig2_test.go
+++ b/node/btcec/schnorr/musig2/musig2_test.go
@@ -151,11 +151,13 @@ func testMultiPartySign(t *testing.T, taprootTweak []byte,
 				nonce := otherCtx.PublicNonce()
 				haveAll, err := signer.RegisterPubNonce(nonce)
 				if err != nil {
-					t.Fatalf("unable to add public nonce")
+					t.Errorf("unable to add public nonce")
+					return
 				}
 
 				if j == len(signers)-1 && !haveAll {
-					t.Fatalf("all public nonces should have been detected")
+					t.Errorf("all public nonces should have been detected")
+					return
 				}
 			}
 		}(i, signCtx)

--- a/node/integration/rpctest/rpc_harness_test.go
+++ b/node/integration/rpctest/rpc_harness_test.go
@@ -296,7 +296,8 @@ func testJoinBlocks(r *Harness, t *testing.T) {
 	blocksSynced := make(chan struct{})
 	go func() {
 		if err := JoinNodes(nodeSlice, Blocks); err != nil {
-			t.Fatalf("unable to join node on blocks: %v", err)
+			t.Errorf("unable to join node on blocks: %v", err)
+			return
 		}
 		blocksSynced <- struct{}{}
 	}()

--- a/node/integration/rpctest/rpc_harness_test.go
+++ b/node/integration/rpctest/rpc_harness_test.go
@@ -221,7 +221,8 @@ func testJoinMempools(r *Harness, t *testing.T) {
 		for {
 			poolHashes, err := r.Client.GetRawMempool()
 			if err != nil {
-				t.Fatalf("failed to retrieve harness mempool: %v", err)
+				t.Errorf("failed to retrieve harness mempool: %v", err)
+				return
 			}
 			if len(poolHashes) > 0 {
 				break
@@ -241,7 +242,8 @@ func testJoinMempools(r *Harness, t *testing.T) {
 	poolsSynced := make(chan struct{})
 	go func() {
 		if err := JoinNodes(nodeSlice, Mempools); err != nil {
-			t.Fatalf("unable to join node on mempools: %v", err)
+			t.Errorf("unable to join node on mempools: %v", err)
+			return
 		}
 		poolsSynced <- struct{}{}
 	}()


### PR DESCRIPTION
## Summary

Calling `t.Fatalf` (or `t.Fatal`) from a non-test goroutine is incorrect. It calls `runtime.Goexit()` on the wrong goroutine, which can cause unexpected behavior or deadlocks instead of properly failing the test.

Detected by `staticcheck` (`SA2002: call to (*testing.T).Fatalf from a non-test goroutine`).

### Files fixed

**`node/btcec/schnorr/musig2/musig2_test.go`**
- `RegisterPubNonce` error in goroutine → `t.Errorf` + `return`
- Missing nonces check in goroutine → `t.Errorf` + `return`

**`node/integration/rpctest/rpc_harness_test.go`**
- `GetRawMempool` error in goroutine → `t.Errorf` + `return`
- `JoinNodes` error in goroutine → `t.Errorf` + `return`

## Testing
- `go vet ./node/btcec/schnorr/musig2/...` ✅ passes
- `go vet ./node/integration/rpctest/...` ✅ passes