### PR TITLE
docs(miner): clarify config.yaml matrix dimension thresholds

### DIFF
--- a/miner/vllm-miner/src/vllm_miner/config.yaml
+++ b/miner/vllm-miner/src/vllm_miner/config.yaml
@@ -14,7 +14,9 @@ matrix_multiplication:
   #   so the PoUW kernel never fires in that phase. During prefill, m equals the
   #   number of prompt tokens batched together. Reaching m>=1024 requires either
   #   very large batch sizes or a mining pool that aggregates prefill work across
-  #   many concurrent users.
+  #   many concurrent users. vLLM's continuous batching will naturally combine
+  #   shorter prompts (e.g. coding sessions, synthetic workloads) into large
+  #   prefill batches that reach this threshold.
   #
   # Lowering min_m below 128 will cause ZK proof generation to fail because the
   # circuit requires a minimum data size of 2^17 bytes.

--- a/miner/vllm-miner/src/vllm_miner/config.yaml
+++ b/miner/vllm-miner/src/vllm_miner/config.yaml
@@ -5,7 +5,19 @@ gateway_socket_path: "/tmp/pearlgw.sock"
 
 # Matrix multiplication configuration
 matrix_multiplication:
-  # Use noisy GEMM when N and K dimensions are larger than these thresholds, if not use vanilla GEMM
+  # Minimum matrix dimensions required to trigger the PoUW (noisy GEMM) kernel.
+  # All three thresholds (m, n, k) must be met simultaneously; otherwise the
+  # vanilla GEMM kernel is used for standard inference without mining.
+  #
+  # Why min_m=1024:
+  #   During autoregressive decode each step processes m=1 (one token per sequence),
+  #   so the PoUW kernel never fires in that phase. During prefill, m equals the
+  #   number of prompt tokens batched together. Reaching m>=1024 requires either
+  #   very large batch sizes or a mining pool that aggregates prefill work across
+  #   many concurrent users.
+  #
+  # Lowering min_m below 128 will cause ZK proof generation to fail because the
+  # circuit requires a minimum data size of 2^17 bytes.
   use_simplified_gemm:
     min_m: 1024
     min_n: 1024


### PR DESCRIPTION
Improves the comment in `config.yaml` that describes the `use_simplified_gemm` thresholds.

**Problems with the old comment:**
- Said 'N and K dimensions' but `min_m` is also checked
- Gave no explanation of why `min_m=1024` is the default
- Did not document the lower bound constraint

**Changes:**
- Corrected to say all three thresholds (m, n, k) must be met simultaneously
- Explained why `m` rarely reaches 1024 during autoregressive decode (m=1 per token per sequence)
- Documented that lowering `min_m` below 128 causes ZK proof generation to fail (circuit requires minimum 2^17 bytes)

Addresses confusion reported in issue #83.