### PR TITLE
fix(miner/pearl-gateway): fix type annotation errors

### DIFF
--- a/miner/pearl-gateway/src/pearl_gateway/pearl_client.py
+++ b/miner/pearl-gateway/src/pearl_gateway/pearl_client.py
@@ -20,7 +20,7 @@ class PearlNodeClient:
         self.rpc_url = url
         self.auth = aiohttp.BasicAuth(config.rpc_user, config.rpc_password)
         self.mining_address = config.mining_address
-        self.session = None
+        self.session: aiohttp.ClientSession | None = None
         self.request_id = 0
         self.backoff_time = 1  # Initial backoff time in seconds
         self.max_backoff = 60  # Maximum backoff time in seconds
@@ -44,7 +44,7 @@ class PearlNodeClient:
             await self.session.close()
             self.session = None
 
-    async def _make_rpc_call(self, method: str, params: list = None) -> dict[str, Any]:
+    async def _make_rpc_call(self, method: str, params: list[Any] | None = None) -> dict[str, Any]:
         """Make a JSON-RPC call to the Pearl node."""
         if not self.session:
             self.session = self._create_session()

--- a/miner/pearl-gateway/src/pearl_gateway/scheduler.py
+++ b/miner/pearl-gateway/src/pearl_gateway/scheduler.py
@@ -27,7 +27,7 @@ class TemplateScheduler:
         self.work_cache = work_cache
         self.refresh_interval = config.refresh_interval_seconds
         self.running = False
-        self.last_refresh_time = 0
+        self.last_refresh_time: float = 0.0
         self.refresh_task: asyncio.Task | None = None
 
     async def start(self):

--- a/miner/pearl-gateway/src/pearl_gateway/submission_service.py
+++ b/miner/pearl-gateway/src/pearl_gateway/submission_service.py
@@ -20,7 +20,7 @@ class SubmissionService:
     def __init__(self, pearl_client: PearlNodeClient, debug_mode: bool = False):
         self.pearl_client = pearl_client
         self.submission_lock = asyncio.Lock()  # Ensure serialized submissions
-        self.submission_log = set()
+        self.submission_log: set[bytes] = set()
         self.debug_mode = debug_mode
         self.submitted_blocks = 0
         self.accepted_blocks = 0


### PR DESCRIPTION
Fixes type annotation errors found by mypy in pearl-gateway:

- `pearl_client.py`: `params` default `None` typed as `list[Any] | None`; `session` field annotated as `aiohttp.ClientSession | None`
- `scheduler.py`: `last_refresh_time` initialized as `float` to match `time.time()` return type
- `submission_service.py`: `submission_log` typed as `set[bytes]` since `serialize_without_proof_commitment()` returns `bytes`