### PR TITLE
feat(rpc): add ProofCommitment to getblock verbose response

### DIFF
--- a/node/btcjson/chainsvrresults.go
+++ b/node/btcjson/chainsvrresults.go
@@ -28,8 +28,9 @@ type GetBlockHeaderVerboseResult struct {
 	Time          int64   `json:"time"`
 	Bits          string  `json:"bits"`
 	Difficulty    float64 `json:"difficulty"`
-	PreviousHash  string  `json:"previousblockhash,omitempty"`
-	NextHash      string  `json:"nextblockhash,omitempty"`
+	PreviousHash     string  `json:"previousblockhash,omitempty"`
+	NextHash         string  `json:"nextblockhash,omitempty"`
+	ProofCommitment  string  `json:"proofcommitment"`
 }
 
 // GetBlockStatsResult models the data from the getblockstats command.

--- a/node/btcjson/chainsvrresults.go
+++ b/node/btcjson/chainsvrresults.go
@@ -83,8 +83,9 @@ type GetBlockVerboseResult struct {
 	Time          int64         `json:"time"`
 	Bits          string        `json:"bits"`
 	Difficulty    float64       `json:"difficulty"`
-	PreviousHash  string        `json:"previousblockhash"`
-	NextHash      string        `json:"nextblockhash,omitempty"`
+	PreviousHash     string        `json:"previousblockhash"`
+	NextHash         string        `json:"nextblockhash,omitempty"`
+	ProofCommitment  string        `json:"proofcommitment"`
 }
 
 // GetBlockVerboseTxResult models the data from the getblock command when the
@@ -107,8 +108,9 @@ type GetBlockVerboseTxResult struct {
 	Time          int64         `json:"time"`
 	Bits          string        `json:"bits"`
 	Difficulty    float64       `json:"difficulty"`
-	PreviousHash  string        `json:"previousblockhash"`
-	NextHash      string        `json:"nextblockhash,omitempty"`
+	PreviousHash     string        `json:"previousblockhash"`
+	NextHash         string        `json:"nextblockhash,omitempty"`
+	ProofCommitment  string        `json:"proofcommitment"`
 }
 
 // GetChainTipsResult models the data from the getchaintips command.

--- a/node/rpcserver.go
+++ b/node/rpcserver.go
@@ -1363,7 +1363,8 @@ func handleGetBlockHeader(s *rpcServer, cmd interface{}, closeChan <-chan struct
 		PreviousHash:  blockHeader.PrevBlock.String(),
 		Time:          blockHeader.Timestamp.Unix(),
 		Bits:          strconv.FormatInt(int64(blockHeader.Bits), 16),
-		Difficulty:    getDifficultyRatio(blockHeader.Bits, params),
+		Difficulty:      getDifficultyRatio(blockHeader.Bits, params),
+		ProofCommitment: blockHeader.ProofCommitment.String(),
 	}
 	return blockHeaderReply, nil
 }

--- a/node/rpcserver.go
+++ b/node/rpcserver.go
@@ -1111,8 +1111,9 @@ func handleGetBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 		Vsize:         int32(blockchain.GetBlockVsize(blk)),
 		StrippedSize:  int32(blk.MsgBlock().SerializeSizeStripped()),
 		Bits:          strconv.FormatInt(int64(blockHeader.Bits), 16),
-		Difficulty:    getDifficultyRatio(blockHeader.Bits, params),
-		NextHash:      nextHashString,
+		Difficulty:      getDifficultyRatio(blockHeader.Bits, params),
+		NextHash:        nextHashString,
+		ProofCommitment: blockHeader.ProofCommitment.String(),
 	}
 
 	if *c.Verbosity == 1 {


### PR DESCRIPTION
Pearl blocks contain a ZK proof commitment in the block header, but `GetBlockVerboseResult` and `GetBlockVerboseTxResult` did not expose this field in the `getblock` RPC response.

This PR adds `proofcommitment` to the verbose block output so RPC clients and block explorers can access it directly.

**Before:**
```json
{ "hash": "...", "height": 9728, ... }
```

**After:**
```json
{ "hash": "...", "height": 9728, "proofcommitment": "21e77d33...", ... }
```

Found by running a testnet node and querying `getblock`.