### PR TITLE
fix(netsync): skip sync from peers that don't advertise a higher block

### DIFF
--- a/node/integration/sync_race_test.go
+++ b/node/integration/sync_race_test.go
@@ -107,14 +107,14 @@ func TestSyncManagerRaceCorruption(t *testing.T) {
 	require.NoError(t, newHarness.SetUp(true, 0))
 	defer func() { _ = newHarness.TearDown() }()
 
-	require.NoError(t, rpctest.ConnectNode(stressedHarness, newHarness),
-		"stressed node must connect to the new node")
+	_, err = newHarness.Client.Generate(syncRaceProofBlocks)
+	require.NoError(t, err)
 
 	_, heightBefore, err := stressedHarness.Client.GetBestBlock()
 	require.NoError(t, err)
 
-	_, err = newHarness.Client.Generate(syncRaceProofBlocks)
-	require.NoError(t, err)
+	require.NoError(t, rpctest.ConnectNode(stressedHarness, newHarness),
+		"stressed node must connect to the new node")
 
 	time.Sleep(syncRaceProofWait)
 
@@ -177,13 +177,13 @@ func TestPreVerackDisconnect(t *testing.T) {
 	require.NoError(t, helper.SetUp(true, 0))
 	defer func() { _ = helper.TearDown() }()
 
-	require.NoError(t, rpctest.ConnectNode(harness, helper))
+	_, err = helper.Client.Generate(3)
+	require.NoError(t, err)
 
 	_, heightBefore, err := harness.Client.GetBestBlock()
 	require.NoError(t, err)
 
-	_, err = helper.Client.Generate(3)
-	require.NoError(t, err)
+	require.NoError(t, rpctest.ConnectNode(harness, helper))
 
 	time.Sleep(5 * time.Second)
 

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -322,27 +322,29 @@ func (sm *SyncManager) startSync() {
 		return
 	}
 
-	best := sm.chain.BestSnapshot()
 	bestPeer := sm.pickSyncCandidate()
+	if bestPeer == nil {
+		log.Warnf("No sync peer candidates available")
+		return
+	}
+
+	best := sm.chain.BestSnapshot()
 
 	// Skip peers that have nothing new to offer. If the peer announced
 	// a block we already have, skip it. Otherwise fall back to the
 	// version-message height: a peer at or below our height is skipped.
-	if bestPeer != nil {
-		if announced := bestPeer.LastAnnouncedBlock(); announced != nil {
-			if have, _ := sm.chain.HaveBlock(announced); have {
-				log.Debugf("Skipping sync: candidate %s only "+
-					"announced blocks we already have",
-					bestPeer.Addr())
-				return
-			}
-		} else if bestPeer.LastBlock() <= best.Height {
-			log.Debugf("Skipping sync: candidate %s advertises "+
-				"height %d, our best is %d",
-				bestPeer.Addr(), bestPeer.LastBlock(),
-				best.Height)
+	if announced := bestPeer.LastAnnouncedBlock(); announced != nil {
+		if have, _ := sm.chain.HaveBlock(announced); have {
+			log.Debugf("Skipping sync: candidate %s only "+
+				"announced blocks we already have",
+				bestPeer.Addr())
 			return
 		}
+	} else if bestPeer.LastBlock() <= best.Height {
+		log.Debugf("Skipping sync: candidate %s advertises "+
+			"height %d, our best is %d",
+			bestPeer.Addr(), bestPeer.LastBlock(), best.Height)
+		return
 	}
 
 	// Start syncing from the best peer if one was selected.

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -330,7 +330,10 @@ func (sm *SyncManager) startSync() {
 	// but it is safe to use as a negative filter: a peer at our
 	// height (or below) has nothing to offer as a syncPeer.
 	if bestPeer != nil && bestPeer.LastBlock() <= best.Height {
-		bestPeer = nil
+		log.Debugf("Skipping sync: candidate %s advertises "+
+			"height %d, our best is %d",
+			bestPeer.Addr(), bestPeer.LastBlock(), best.Height)
+		return
 	}
 
 	// Start syncing from the best peer if one was selected.

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -347,61 +347,56 @@ func (sm *SyncManager) startSync() {
 		return
 	}
 
-	// Start syncing from the best peer if one was selected.
-	if bestPeer != nil {
-		// Clear the requestedBlocks if the sync peer changes, otherwise
-		// we may ignore blocks we need that the last sync peer failed
-		// to send.
-		sm.requestedBlocks = make(map[chainhash.Hash]struct{})
+	// Clear the requestedBlocks if the sync peer changes, otherwise
+	// we may ignore blocks we need that the last sync peer failed
+	// to send.
+	sm.requestedBlocks = make(map[chainhash.Hash]struct{})
 
-		locator, err := sm.chain.LatestBlockLocator()
-		if err != nil {
-			log.Errorf("Failed to get block locator for the "+
-				"latest block: %v", err)
-			return
-		}
-
-		log.Infof("Syncing to block height %d from peer %v",
-			bestPeer.LastBlock(), bestPeer.Addr())
-
-		// When the current height is less than a known checkpoint we
-		// can use block headers to learn about which blocks comprise
-		// the chain up to the checkpoint and perform less validation
-		// for them.  This is possible since each header contains the
-		// hash of the previous header and a merkle root.  Therefore if
-		// we validate all of the received headers link together
-		// properly and the checkpoint hashes match, we can be sure the
-		// hashes for the blocks in between are accurate.  Further, once
-		// the full blocks are downloaded, the merkle root is computed
-		// and compared against the value in the header which proves the
-		// full block hasn't been tampered with.
-		//
-		// Once we have passed the final checkpoint, or checkpoints are
-		// disabled, use standard inv messages learn about the blocks
-		// and fully validate them.  Finally, regression test mode does
-		// not support the headers-first approach so do normal block
-		// downloads when in regression test mode.
-		if sm.nextCheckpoint != nil &&
-			best.Height < sm.nextCheckpoint.Height &&
-			sm.chainParams != &chaincfg.RegressionNetParams {
-
-			bestPeer.PushGetHeadersMsg(locator, sm.nextCheckpoint.Hash)
-			sm.headersFirstMode = true
-			log.Infof("Downloading headers for blocks %d to "+
-				"%d from peer %s", best.Height+1,
-				sm.nextCheckpoint.Height, bestPeer.Addr())
-		} else {
-			bestPeer.PushGetBlocksMsg(locator, &zeroHash)
-		}
-		sm.syncPeer = bestPeer
-
-		// Reset the last progress time now that we have a non-nil
-		// syncPeer to avoid instantly detecting it as stalled in the
-		// event the progress time hasn't been updated recently.
-		sm.lastProgressTime = time.Now()
-	} else {
-		log.Warnf("No sync peer candidates available")
+	locator, err := sm.chain.LatestBlockLocator()
+	if err != nil {
+		log.Errorf("Failed to get block locator for the "+
+			"latest block: %v", err)
+		return
 	}
+
+	log.Infof("Syncing to block height %d from peer %v",
+		bestPeer.LastBlock(), bestPeer.Addr())
+
+	// When the current height is less than a known checkpoint we
+	// can use block headers to learn about which blocks comprise
+	// the chain up to the checkpoint and perform less validation
+	// for them.  This is possible since each header contains the
+	// hash of the previous header and a merkle root.  Therefore if
+	// we validate all of the received headers link together
+	// properly and the checkpoint hashes match, we can be sure the
+	// hashes for the blocks in between are accurate.  Further, once
+	// the full blocks are downloaded, the merkle root is computed
+	// and compared against the value in the header which proves the
+	// full block hasn't been tampered with.
+	//
+	// Once we have passed the final checkpoint, or checkpoints are
+	// disabled, use standard inv messages learn about the blocks
+	// and fully validate them.  Finally, regression test mode does
+	// not support the headers-first approach so do normal block
+	// downloads when in regression test mode.
+	if sm.nextCheckpoint != nil &&
+		best.Height < sm.nextCheckpoint.Height &&
+		sm.chainParams != &chaincfg.RegressionNetParams {
+
+		bestPeer.PushGetHeadersMsg(locator, sm.nextCheckpoint.Hash)
+		sm.headersFirstMode = true
+		log.Infof("Downloading headers for blocks %d to "+
+			"%d from peer %s", best.Height+1,
+			sm.nextCheckpoint.Height, bestPeer.Addr())
+	} else {
+		bestPeer.PushGetBlocksMsg(locator, &zeroHash)
+	}
+	sm.syncPeer = bestPeer
+
+	// Reset the last progress time now that we have a non-nil
+	// syncPeer to avoid instantly detecting it as stalled in the
+	// event the progress time hasn't been updated recently.
+	sm.lastProgressTime = time.Now()
 }
 
 // isSyncCandidate returns whether or not the peer is a candidate to consider

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -325,15 +325,24 @@ func (sm *SyncManager) startSync() {
 	best := sm.chain.BestSnapshot()
 	bestPeer := sm.pickSyncCandidate()
 
-	// Skip peers that don't claim to have more blocks than us.
-	// LastBlock() is unauthenticated so it is not used for ranking,
-	// but it is safe to use as a negative filter: a peer at our
-	// height (or below) has nothing to offer as a syncPeer.
-	if bestPeer != nil && bestPeer.LastBlock() <= best.Height {
-		log.Debugf("Skipping sync: candidate %s advertises "+
-			"height %d, our best is %d",
-			bestPeer.Addr(), bestPeer.LastBlock(), best.Height)
-		return
+	// Skip peers that have nothing new to offer. If the peer announced
+	// a block we already have, skip it. Otherwise fall back to the
+	// version-message height: a peer at or below our height is skipped.
+	if bestPeer != nil {
+		if announced := bestPeer.LastAnnouncedBlock(); announced != nil {
+			if have, _ := sm.chain.HaveBlock(announced); have {
+				log.Debugf("Skipping sync: candidate %s only "+
+					"announced blocks we already have",
+					bestPeer.Addr())
+				return
+			}
+		} else if bestPeer.LastBlock() <= best.Height {
+			log.Debugf("Skipping sync: candidate %s advertises "+
+				"height %d, our best is %d",
+				bestPeer.Addr(), bestPeer.LastBlock(),
+				best.Height)
+			return
+		}
 	}
 
 	// Start syncing from the best peer if one was selected.

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -325,6 +325,14 @@ func (sm *SyncManager) startSync() {
 	best := sm.chain.BestSnapshot()
 	bestPeer := sm.pickSyncCandidate()
 
+	// Skip peers that don't claim to have more blocks than us.
+	// LastBlock() is unauthenticated so it is not used for ranking,
+	// but it is safe to use as a negative filter: a peer at our
+	// height (or below) has nothing to offer as a syncPeer.
+	if bestPeer != nil && bestPeer.LastBlock() <= best.Height {
+		bestPeer = nil
+	}
+
 	// Start syncing from the best peer if one was selected.
 	if bestPeer != nil {
 		// Clear the requestedBlocks if the sync peer changes, otherwise

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 3
+	Patch uint = 4
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

- A fully-synced node with no active `syncPeer` would pick a random outbound peer in `startSync()` and send `getblocks`, even when that peer advertised the same (or lower) block height. The peer had nothing to reply with, so the peer-layer 30s `stallResponseTimeout` for `CmdInv` would fire and disconnect the peer.
- Added a negative height filter in `startSync()`: candidates whose `LastBlock()` is not strictly greater than our best chain height are skipped. `LastBlock()` is still not used for ranking (it's unauthenticated), only as a gate to avoid sending requests the peer cannot answer.

## Observed symptoms
```
Syncing to block height XXX from peer YYY:44108...
Receive failed after reading 0 bytes ... use of closed network connection
Lost peer YYY:44108 (outbound)
```

## Test plan

- [ ] Verify a fully-synced node no longer initiates sync with peers at the same height
- [ ] Verify a node that is behind (e.g. 20h offline, peer advertises higher block) still syncs correctly
- [ ] Run existing integration tests (`TestSyncPeerLiesAboutHeight`, `TestSyncFromInboundDuringIBD`)