### PR TITLE
chore(mainnet): pin first checkpoint and fix headers-first sync stall

### DIFF
--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -1114,6 +1114,20 @@ func (b *BlockChain) ChainParams() *chaincfg.Params {
 	return b.chainParams
 }
 
+// CheckHeaderSanity is the header-only equivalent of CheckBlockSanity,
+// wired with the chain's own time source and chain parameters.
+func (b *BlockChain) CheckHeaderSanity(header *wire.BlockHeader,
+	cert wire.BlockCertificate) error {
+
+	return CheckBlockHeaderSanity(
+		header, cert,
+		b.chainParams.PowLimit,
+		b.timeSource,
+		b.chainParams.MaxTimeOffsetMinutes,
+		BFNone,
+	)
+}
+
 // VerifyCheckpoint checks that the height and hash match the stored
 // checkpoints.
 //

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -1115,16 +1115,24 @@ func (b *BlockChain) ChainParams() *chaincfg.Params {
 }
 
 // CheckHeaderSanity is the header-only equivalent of CheckBlockSanity,
-// wired with the chain's own time source and chain parameters.
+// wired with the chain's own time source and chain parameters. It mirrors
+// checkBlockSanity's SimNet special-case so that headers-only validation
+// stays consistent with full-block validation: SimNet uses dummy
+// certificates from SolveBlock and depends on PoW verification being
+// skipped at the validation layer.
 func (b *BlockChain) CheckHeaderSanity(header *wire.BlockHeader,
 	cert wire.BlockCertificate) error {
 
+	flags := BFNone
+	if b.chainParams.Net == wire.SimNet {
+		flags |= BFNoPoWCheck
+	}
 	return CheckBlockHeaderSanity(
 		header, cert,
 		b.chainParams.PowLimit,
 		b.timeSource,
 		b.chainParams.MaxTimeOffsetMinutes,
-		BFNone,
+		flags,
 	)
 }
 

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -293,7 +293,9 @@ var MainNetParams = Params{
 	MaxTimeOffsetMinutes: 5,
 
 	// Checkpoints ordered from oldest to newest.
-	Checkpoints: nil,
+	Checkpoints: []Checkpoint{
+		{50000, newHashFromStr("608f32e5390b2ae964c986a53e1be10ba4a640f3ccecf96d6b7838e06cb517ff")},
+	},
 
 	// Consensus rule change deployments.
 	//

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -1025,6 +1025,16 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		}
 	}
 
+	// Update the last progress time to prevent the stall handler from
+	// disconnecting the sync peer during the headers-only phase of
+	// headers-first sync. Without this, lastProgressTime only ticks when a
+	// full block is accepted (handleBlockMsg), so a headers-only window
+	// longer than maxStallDuration would trip the stall handler even though
+	// the peer is actively delivering valid, checkpoint-bound headers.
+	if peer == sm.syncPeer {
+		sm.lastProgressTime = time.Now()
+	}
+
 	// When this header is a checkpoint, switch to fetching the blocks for
 	// all of the headers since the last checkpoint.
 	if receivedCheckpoint {

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -48,14 +48,6 @@ const (
 	// sync has stalled.
 	stallSampleInterval = 30 * time.Second
 
-	// headerProgressGrace is the amount of stall-budget credited per
-	// validated header received during headers-first sync. It is sized so
-	// that a full wire.MaxBlockHeadersPerMsg batch credits exactly
-	// maxStallDuration, while a malicious peer that trickle-feeds fewer
-	// headers per round only earns a proportional fraction of the budget
-	// and cannot indefinitely hold the sync slot.
-	headerProgressGrace = maxStallDuration / wire.MaxBlockHeadersPerMsg
-
 	// syncPeerCooldown is how long an address that stalled as syncnode
 	// is excluded from re-selection.
 	syncPeerCooldown = 10 * time.Minute
@@ -985,6 +977,18 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		blockHash := blockHeader.BlockHash()
 		finalHash = &blockHash
 
+		// Verify proof of work and certificate per header. getheaders
+		// always requests certificates, so a missing or invalid one
+		// is a protocol violation.
+		if err := sm.chain.CheckHeaderSanity(
+			blockHeader, msgHeader.BlockCertificate(),
+		); err != nil {
+			log.Warnf("Header from peer %s failed sanity check: "+
+				"%v -- disconnecting", peer.Addr(), err)
+			peer.Disconnect()
+			return
+		}
+
 		// Ensure there is a previous header to compare against.
 		prevNodeEl := sm.headerList.Back()
 		if prevNodeEl == nil {
@@ -1033,22 +1037,12 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		}
 	}
 
-	// Credit progress proportionally to the number of validated headers
-	// received, capped at time.Now(). A legitimate sync peer always fills
-	// batches to wire.MaxBlockHeadersPerMsg, so a full batch resets the
-	// stall window. A peer that trickle-feeds a small number of headers
-	// per round only earns a proportional fraction of the budget and is
-	// dropped by the stall handler instead of holding the sync slot
-	// indefinitely. Without any credit, lastProgressTime would only tick
-	// in handleBlockMsg, so legitimate headers-first sync to a far
-	// checkpoint would trip the stall handler before any block lands.
+	// Tick the stall clock now that the sync peer has delivered a batch
+	// of fully verified headers. Otherwise the stall handler could
+	// disconnect the peer during a long headers-first window before any
+	// block lands.
 	if peer == sm.syncPeer {
-		grace := time.Duration(numHeaders) * headerProgressGrace
-		newProgress := sm.lastProgressTime.Add(grace)
-		if now := time.Now(); newProgress.After(now) {
-			newProgress = now
-		}
-		sm.lastProgressTime = newProgress
+		sm.lastProgressTime = time.Now()
 	}
 
 	// When this header is a checkpoint, switch to fetching the blocks for

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -48,6 +48,14 @@ const (
 	// sync has stalled.
 	stallSampleInterval = 30 * time.Second
 
+	// headerProgressGrace is the amount of stall-budget credited per
+	// validated header received during headers-first sync. It is sized so
+	// that a full wire.MaxBlockHeadersPerMsg batch credits exactly
+	// maxStallDuration, while a malicious peer that trickle-feeds fewer
+	// headers per round only earns a proportional fraction of the budget
+	// and cannot indefinitely hold the sync slot.
+	headerProgressGrace = maxStallDuration / wire.MaxBlockHeadersPerMsg
+
 	// syncPeerCooldown is how long an address that stalled as syncnode
 	// is excluded from re-selection.
 	syncPeerCooldown = 10 * time.Minute
@@ -1025,14 +1033,22 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		}
 	}
 
-	// Update the last progress time to prevent the stall handler from
-	// disconnecting the sync peer during the headers-only phase of
-	// headers-first sync. Without this, lastProgressTime only ticks when a
-	// full block is accepted (handleBlockMsg), so a headers-only window
-	// longer than maxStallDuration would trip the stall handler even though
-	// the peer is actively delivering valid, checkpoint-bound headers.
+	// Credit progress proportionally to the number of validated headers
+	// received, capped at time.Now(). A legitimate sync peer always fills
+	// batches to wire.MaxBlockHeadersPerMsg, so a full batch resets the
+	// stall window. A peer that trickle-feeds a small number of headers
+	// per round only earns a proportional fraction of the budget and is
+	// dropped by the stall handler instead of holding the sync slot
+	// indefinitely. Without any credit, lastProgressTime would only tick
+	// in handleBlockMsg, so legitimate headers-first sync to a far
+	// checkpoint would trip the stall handler before any block lands.
 	if peer == sm.syncPeer {
-		sm.lastProgressTime = time.Now()
+		grace := time.Duration(numHeaders) * headerProgressGrace
+		newProgress := sm.lastProgressTime.Add(grace)
+		if now := time.Now(); newProgress.After(now) {
+			newProgress = now
+		}
+		sm.lastProgressTime = newProgress
 	}
 
 	// When this header is a checkpoint, switch to fetching the blocks for

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -963,6 +963,13 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		return
 	}
 
+	// Only the sync peer may drive the headers-first state machine;
+	// other peers' headers can race sm.headerList and break linkage for
+	// the sync peer's legitimate batches.
+	if peer != sm.syncPeer {
+		return
+	}
+
 	// Nothing to do for an empty headers message.
 	if numHeaders == 0 {
 		return
@@ -1037,11 +1044,13 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		}
 	}
 
-	// Tick the stall clock now that the sync peer has delivered a batch
-	// of fully verified headers. Otherwise the stall handler could
-	// disconnect the peer during a long headers-first window before any
-	// block lands.
-	if peer == sm.syncPeer {
+	// Tick the stall clock only for full batches or the final batch that
+	// reaches the next checkpoint. The producer always fills batches to
+	// MaxBlockHeadersPerMsg until it runs into a stop condition, so an
+	// undersized non-final batch is the producer's signal that no real
+	// progress remains -- a peer trickling small batches to extend the
+	// stall window earns no credit and gets rotated by the stall handler.
+	if numHeaders == wire.MaxBlockHeadersPerMsg || receivedCheckpoint {
 		sm.lastProgressTime = time.Now()
 	}
 

--- a/node/peer/peer_test.go
+++ b/node/peer/peer_test.go
@@ -22,6 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testWaitTimeout bounds how long any single signal/message wait may block
+// before the test is failed. Sized generously so loaded CI runners don't
+// flake on goroutine scheduling delays -- locally these waits complete in
+// well under 10ms.
+const testWaitTimeout = 5 * time.Second
+
 // conn mocks a network connection by implementing the net.Conn interface.
 type conn struct {
 	io.Reader
@@ -216,7 +222,7 @@ func TestPeerConnection(t *testing.T) {
 	// Each peer fires 2 signals: OnVerAck (received) + OnWrite(verack sent).
 	// 2 peers x 2 signals = 4 total.
 	for i := 0; i < 4; i++ {
-		waitForSignal(t, verack, time.Second, "verack signal %d", i)
+		waitForSignal(t, verack, testWaitTimeout, "verack signal %d", i)
 	}
 
 	wantUA := wire.DefaultUserAgent + "peer:1.0(comment)/"
@@ -300,7 +306,7 @@ func TestPeerListeners(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 2; i++ {
-		waitForSignal(t, verack, time.Second, "verack timeout")
+		waitForSignal(t, verack, testWaitTimeout, "verack timeout")
 	}
 
 	// During the handshake, inPeer's OnVersion and OnSendAddrV2 listeners
@@ -367,7 +373,7 @@ func TestPeerListeners(t *testing.T) {
 			case msg := <-ok:
 				assert.Equal(t, tt.msg.Command(), msg.Command(),
 					"expected %s callback to fire", tt.listener)
-			case <-time.After(time.Second):
+			case <-time.After(testWaitTimeout):
 				t.Fatalf("timeout waiting for %s", tt.listener)
 			}
 		})
@@ -411,7 +417,7 @@ func TestOutboundPeer(t *testing.T) {
 			p.WaitForDisconnect()
 			close(disconnected)
 		}()
-		waitForSignal(t, disconnected, 5*time.Second, "peer did not disconnect")
+		waitForSignal(t, disconnected, testWaitTimeout, "peer did not disconnect")
 
 		assert.False(t, p.Connected())
 
@@ -532,19 +538,19 @@ func TestDuplicateVersionMsg(t *testing.T) {
 
 	// One verack per peer direction.
 	for i := 0; i < 2; i++ {
-		waitForSignal(t, verack, time.Second, "verack timeout")
+		waitForSignal(t, verack, testWaitTimeout, "verack timeout")
 	}
 
 	done := make(chan struct{})
 	outPeer.QueueMessage(&wire.MsgVersion{}, done)
-	waitForSignal(t, done, time.Second, "send duplicate version timeout")
+	waitForSignal(t, done, testWaitTimeout, "send duplicate version timeout")
 
 	disconnected := make(chan struct{}, 1)
 	go func() {
 		inPeer.WaitForDisconnect()
 		close(disconnected)
 	}()
-	waitForSignal(t, disconnected, time.Second,
+	waitForSignal(t, disconnected, testWaitTimeout,
 		"inPeer did not disconnect after receiving duplicate version")
 }
 
@@ -580,7 +586,7 @@ func TestUpdateLastBlockHeight(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < 2; i++ {
-		waitForSignal(t, verack, time.Second, "verack timeout")
+		waitForSignal(t, verack, testWaitTimeout, "verack timeout")
 	}
 
 	assert.Equal(t, int32(remotePeerHeight), localPeer.LastBlock(),

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 3
+	Patch uint = 4
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 2
+	Patch uint = 3
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 4
+	Patch uint = 3
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

Two related changes, the second uncovered while validating the first:

- **`chore(chaincfg)`: pin first mainnet checkpoint at height 50000.** `MainNetParams.Checkpoints` was `nil`, so none of the block-checkpoint defenses had any effect on mainnet. The new entry pins height 50000 / hash `608f32e5390b2ae964c986a53e1be10ba4a640f3ccecf96d6b7838e06cb517ff` (the agreed mainnet tip at time of writing), which immediately activates the checkpoint-driven validation gates in `node/blockchain/`: any incoming block at height ≤ 50000 with a non-matching hash is rejected via `ErrBadCheckpoint`/`ErrForkTooOld` at the cheapest validation stage, any block whose timestamp predates the checkpoint is rejected via `ErrCheckpointTimeTooOld`, and `calcEasiestDifficulty` enforces a min-PoW floor for everything above. SPV peers gain a known anchor for filter-header sync. The slice's single-element sort-order invariant in `blockchain.New` is trivially satisfied.

- **`fix(netsync)`: harden headers-first sync.** With the checkpoint in place, a fresh node entering headers-first sync gets disconnected from its sync peer exactly `maxStallDuration` (3 min) after `startSync`, even though the peer is healthily returning 100 headers per `getheaders` round every few seconds. Root cause: `lastProgressTime` was only written in `handleBlockMsg`, never in `handleHeadersMsg`. During the headers-only window between `startSync` and the first checkpoint-bound block download, no full blocks land, so the stall handler trips and `updateSyncPeer(true)` disconnects the peer. `startSync` then picks the next candidate, resets `lastProgressTime`, and the same 3-minute death loop repeats. The fix has four layered parts:

  1. **Per-header certificate verification in `handleHeadersMsg`.** The previous netsync handler used the header's certificate field for nothing -- it was deserialized off the wire and discarded. Meanwhile, the SPV blockmanager has been calling `blockchain.CheckBlockHeaderSanity` (proof-of-work bits range + ZK certificate verification + timestamp sanity) on every received header all along. This PR brings netsync to parity: each header in a `MsgHeaders` batch is fully verified before linkage/checkpoint bookkeeping, and a missing or invalid certificate is a protocol violation that disconnects the peer. `getheaders` always sets `IncludeCertificates = true`, so a cooperating peer always supplies one. A small `BlockChain.CheckHeaderSanity` wrapper is added so the caller doesn't have to plumb chain params and time source through; it mirrors `checkBlockSanity`'s SimNet `BFNoPoWCheck` special-case so headers-only validation stays consistent with full-block validation.

  2. **Sync-peer guard at the entry of `handleHeadersMsg`.** Only the current sync peer may drive the headers-first state machine; other peers' headers are silently dropped. Without this guard, an unsolicited peer could race the sync peer's batch by pushing onto `sm.headerList` between our `getheaders` and the sync peer's response, causing the legitimate response to fail the linkage check and disconnecting the sync peer. The bug was latent before this PR because `headersFirstMode` was never enabled on mainnet; the new checkpoint activates the code path. (Note: this fix is identical to the one already on `node/peer-quality`'s `95081927`; whichever lands first wins, the other rebases.)

  3. **Tick `lastProgressTime` only for full batches or the final batch that reaches the next checkpoint.** The producer always fills batches to `MaxBlockHeadersPerMsg` until it runs into a stop condition, so an undersized non-final batch is the producer's signal that no real progress remains. A peer trickling small batches to extend the stall window earns no credit and gets rotated by the existing stall handler instead of camping the sync slot.

  4. **Test-only**: widen the 1-second per-signal timeouts in `node/peer/peer_test.go` to a single 5-second `testWaitTimeout` constant. `TestPeerConnection` and friends finish in <10ms locally but were flaking on loaded shared CI runners; the same flake pattern is hitting `TestPreVerackDisconnect`, `TestSyncManagerRaceCorruption`, `TestHarness`, etc. on multiple other branches.

Without the netsync fix, the checkpoint alone makes mainnet IBD non-functional for any new node whose tip is more than ~3 minutes of header download behind the checkpoint. The changes ship together for that reason.

## Commits

- `chore(chaincfg): pin first mainnet checkpoint at height 50000`
- `fix(netsync): tick lastProgressTime during headers-first sync`
- `refactor(netsync): verify cert per header instead of rate-limiting stall credit`
- `fix(netsync): scope headers-first to sync peer and require full batches`
- `test(peer): widen signal-wait timeouts to deflake CI runs`
- `fix(blockchain): skip PoW in CheckHeaderSanity on SimNet`

## Verification

- `go build ./...` clean from repo root and `node/`.
- `task fmt:go tidy` clean.
- `go test -race -tags='rpctest xmss zkpow' ./netsync/... ./blockchain/... ./peer/... ./wallet/chain/...` clean locally; remaining CI flakes (`TestPeerConnection`, `TestPrunedBlockDispatcherQuerySameBlock`) are unrelated time-sensitive tests shared by branches without our changes, confirmed by reruns of the same commit passing.
- Header-sync stall bug reproduced from a debug-level pearld log against the new checkpoint: `Received headers (num 100)` every 3-9s for 3 minutes, then `SYNC: Updating sync peer, no progress for: 3m0.000818541s` immediately followed by `V2TR: Receive failed ... use of closed network connection`.

## Known follow-ups (not in this PR)

- **Post-checkpoint header window** (flagged by automated review on `node/netsync/manager.go:1054`). Between accepting the checkpoint header in `handleHeadersMsg` and connecting the checkpoint block in `handleBlockMsg`, `headersFirstMode` is still `true`. A malicious sync peer can send unsolicited full batches *beyond* the checkpoint, link them onto `sm.headerList`, and keep `lastProgressTime` fresh without ever delivering the blocks we asked for via `fetchHeaderBlocks` -- an eclipse-DoS that stalls IBD without tripping the stall handler. Threat model requires full peer-set eclipse; outcome is DoS-only (no consensus break). The right structural fix is the per-peer trust gate landing on `node/peer-quality` (`874d17fa` introduces `nonTipStrikes` for inv-driven downloads; extending the same gate to the headers-first window is a natural follow-up there). Deferred to that branch.
- The SPV filter-header checkpoint map in `spv/chainsync/filtercontrol.go` still has a `TODO Or:` marker -- left alone here; that's a separate hard-coded set of CF-header checkpoints, unrelated to block-checkpoint enforcement.
- Testnet / testnet2 / signet / simnet / regtest checkpoints remain `nil` as before.
- A larger refactor that moves Pearl off the checkpoint-keyed headers-first state machine onto a bestHeader-keyed full IBD model (mirroring the recent upstream rework) is a worthwhile follow-up but out of scope here.