### PR TITLE
fix(blockchain): reject sub-checkpoint forks in ProcessBlock

### DIFF
--- a/node/blockchain/process.go
+++ b/node/blockchain/process.go
@@ -182,6 +182,19 @@ func (b *BlockChain) ProcessBlock(block *btcutil.Block, flags BehaviorFlags) (bo
 		return false, false, err
 	}
 	if checkpointNode != nil {
+		// Reject blocks that fork the chain before the previous
+		// checkpoint. Orphans (parent not in our index) are deferred
+		// and re-evaluated when the parent arrives.
+		if prevNode := b.index.LookupNode(&blockHeader.PrevBlock); prevNode != nil &&
+			prevNode.height+1 < checkpointNode.height {
+
+			str := fmt.Sprintf("block at height %d forks the main "+
+				"chain before the previous checkpoint at "+
+				"height %d", prevNode.height+1,
+				checkpointNode.height)
+			return false, false, ruleError(ErrForkTooOld, str)
+		}
+
 		// Ensure the block timestamp is after the checkpoint timestamp.
 		checkpointTime := time.Unix(checkpointNode.timestamp, 0)
 		if blockHeader.Timestamp.Before(checkpointTime) {

--- a/node/blockchain/process_test.go
+++ b/node/blockchain/process_test.go
@@ -127,4 +127,19 @@ func TestProcessBlock_CheckpointDifficulty(t *testing.T) {
 					"with ErrDifficultyTooLow, got %v", okRuleErr.ErrorCode)
 		}
 	}
+
+	// Sub-checkpoint fork: a block whose parent is below the checkpoint
+	// height must be rejected with ErrForkTooOld, not the difficulty or
+	// timestamp floor.
+	subCheckpointParent := blocks[0].Hash()
+	_, _, err = chain.ProcessBlock(
+		makeTestBlock(chain.chainParams.PowLimitBits, *subCheckpointParent),
+		BFNoPoWCheck,
+	)
+	require.Error(t, err)
+	var subErr RuleError
+	require.ErrorAs(t, err, &subErr)
+	assert.Equal(t, ErrForkTooOld, subErr.ErrorCode,
+		"sub-checkpoint fork should be rejected with ErrForkTooOld, "+
+			"got %v", subErr.ErrorCode)
 }


### PR DESCRIPTION
## Summary

The `ProcessBlock` checkpoint enforcement runs in this order today:

1. `ErrCheckpointTimeTooOld` — reject if block timestamp < checkpoint timestamp.
2. `ErrDifficultyTooLow` — reject if block's bits decode to a target above `calcEasiestDifficulty(checkpointBits, blockTime - checkpointTime)`.

The `ErrForkTooOld` height check ("block forks the chain before the previous checkpoint") lives downstream in `CheckBlockHeaderContext` and only fires for blocks that pass both gates above. For a block whose parent is in our index but is far below the checkpoint height with PowLimit-bits difficulty and a recent timestamp, the difficulty floor fires first and the rejection comes out as `ErrDifficultyTooLow` — semantically wrong (it's a deep historical fork, not an underweight extension of the post-checkpoint chain) and the log message is misleading.

This PR adds an explicit height-based fork check at the top of the `ProcessBlock` checkpoint block, before the timestamp and difficulty floors. When the parent is in our index and `parent.height + 1 < checkpointNode.height`, we return `ErrForkTooOld` with the accurate "block at height N forks the main chain before the previous checkpoint at height M" message. Orphans (parent not in our index) are deferred to the existing `CheckBlockHeaderContext` gate, which still runs on orphan promotion via `maybeAcceptBlock`.

## Behaviour change

| Block | Before | After |
|---|---|---|
| sub-checkpoint fork, low difficulty | `ErrDifficultyTooLow` (disconnect) | `ErrForkTooOld` (disconnect) |
| post-checkpoint fork, low difficulty | `ErrDifficultyTooLow` (unchanged) | `ErrDifficultyTooLow` (unchanged) |
| post-checkpoint fork, old timestamp | `ErrCheckpointTimeTooOld` (unchanged) | `ErrCheckpointTimeTooOld` (unchanged) |
| orphan promoted into sub-checkpoint position | `ErrForkTooOld` via `CheckBlockHeaderContext` | `ErrForkTooOld` via `CheckBlockHeaderContext` (unchanged) |

DoS protection (the disconnect on receipt) is unaffected — both `ErrForkTooOld` and `ErrDifficultyTooLow` route through the same disconnect bucket in `server.go`. This is an error-classification correctness fix.

## Test

Extends `TestProcessBlock_CheckpointDifficulty` with a case exercising the new path: a PowLimit-difficulty block whose parent is below the checkpoint is rejected with `ErrForkTooOld` rather than `ErrDifficultyTooLow`. The existing synthetic-parent test case still passes because it's treated as an orphan and falls through to the difficulty floor.

## Verification

- `go test -race -tags='zkpow xmss' ./blockchain/...` clean.