### PR TITLE
fix(chaincfg): disable HasFiltering for mainnet DNS seeds

### DIFF
--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -274,9 +274,9 @@ var MainNetParams = Params{
 	Net:         wire.MainNet,
 	DefaultPort: "44108",
 	DNSSeeds: []DNSSeed{
-		{"seeder1.pearlresearch.ai", true},
-		{"seeder2.pearlresearch.ai", true},
-		{"seeder3.pearlresearch.ai", true},
+		{"seeder1.pearlresearch.ai", false},
+		{"seeder2.pearlresearch.ai", false},
+		{"seeder3.pearlresearch.ai", false},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
## Summary

SPV wallets (neutrino) fail to discover peers via DNS because `SeedFromDNS` queries `x49.seeder1.pearlresearch.ai` when `HasFiltering` is `true`. Our DNS seeders do not implement service-flag subdomain routing, so these queries resolve to nothing.

- Set `HasFiltering` to `false` for all mainnet DNS seeds
- SPV clients now query the bare domain and receive valid peer addresses
- No functional loss: all mainnet nodes already advertise full services (network, witness, compact filters)