### PR TITLE
feat(xmss): add P2MR post-quantum transaction proof

### DIFF
--- a/node/integration/p2mr_xmss_test.go
+++ b/node/integration/p2mr_xmss_test.go
@@ -1,0 +1,189 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build rpctest && xmss
+
+package integration
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/pearl-research-labs/pearl/node/btcutil"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+	"github.com/pearl-research-labs/pearl/node/integration/rpctest"
+	"github.com/pearl-research-labs/pearl/node/txscript"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/pearl-research-labs/pearl/wallet/wallet/xmsstxn"
+	"github.com/pearl-research-labs/pearl/xmss"
+	"github.com/stretchr/testify/require"
+)
+
+// TestP2MRXMSSRoundtripSimnet drives a real pearld in simnet through a
+// three-tx P2MR-XMSS sequence:
+//
+//  1. T_fund:     coinbase P2TR -> P2MR_A         (memWallet-signed)
+//  2. T_spend_AB: P2MR_A         -> P2MR_B        (XMSS-signed, both ends PQ)
+//  3. T_spend_B:  P2MR_B         -> harness P2TR  (XMSS-signed)
+//
+// (2) is the fully post-quantum hop; (3) confirms P2MR_B is spendable
+// and not a one-way trap.
+//
+// Distinct seeds are required for A and B (and for any other run that
+// reuses this file's bytes): signing two different sighashes with the
+// same XMSS keypair under msgUID=0 leaks the seed.
+func TestP2MRXMSSRoundtripSimnet(t *testing.T) {
+	// --rejectnonstd matches mainnet IsStandardTx checks; --txindex
+	// lets GetRawTransaction find the funding output without a block scan.
+	r, err := rpctest.New(&chaincfg.SimNetParams, nil,
+		[]string{"--rejectnonstd", "--txindex"}, "")
+	require.NoError(t, err)
+
+	// CoinbaseMaturity=100 on simnet -> SetUp mines 100+25 blocks.
+	require.NoError(t, r.SetUp(true, 25))
+	t.Cleanup(func() { require.NoError(t, r.TearDown()) })
+
+	descA, err := deriveTestAddress(0x11, 0x22, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	descB, err := deriveTestAddress(0x33, 0x44, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+	require.NotEqual(t, descA.Addr.String(), descB.Addr.String())
+	for _, a := range []*xmsstxn.Descriptor{descA, descB} {
+		require.True(t, a.Addr.IsForNet(&chaincfg.SimNetParams))
+		require.Equal(t, byte(2), a.Addr.WitnessVersion())
+	}
+	t.Logf("P2MR-XMSS address A: %s", descA.Addr.String())
+	t.Logf("P2MR-XMSS address B: %s", descB.Addr.String())
+
+	// T_fund.
+	const fundAmt = int64(1_000_000_000) // 10 PRL
+	fundTxHash, err := r.SendOutputs(
+		[]*wire.TxOut{{Value: fundAmt, PkScript: descA.PkScript}},
+		100, // grains/byte
+	)
+	require.NoError(t, err)
+	t.Logf("T_fund:     coinbase P2TR -> P2MR_A: %s", fundTxHash)
+
+	_, err = r.Client.Generate(1)
+	require.NoError(t, err)
+	fundTxRaw, err := waitForRawTransaction(t, r, fundTxHash)
+	require.NoError(t, err)
+
+	voutA := findOutput(t, fundTxRaw.MsgTx(), descA.PkScript)
+	require.Equal(t, fundAmt, fundTxRaw.MsgTx().TxOut[voutA].Value)
+
+	// T_spend_AB.
+	const feeAB = int64(50_000)
+	const valueB = fundAmt - feeAB
+	spendAB, err := xmsstxn.BuildSpend(xmsstxn.SpendRequest{
+		PrevOut: xmsstxn.UTXO{
+			OutPoint: wire.OutPoint{Hash: *fundTxHash, Index: uint32(voutA)},
+			Value:    fundAmt,
+		},
+		DestinationPkScript: descB.PkScript,
+		Fee:                 feeAB,
+		Descriptor:          descA,
+	})
+	require.NoError(t, err)
+
+	spendABHash, err := r.Client.SendRawTransaction(spendAB, false)
+	require.NoError(t, err)
+	t.Logf("T_spend_AB: P2MR_A -> P2MR_B (XMSS-signed): %s", spendABHash)
+	requireMined(t, r, spendABHash)
+
+	// T_spend_B.
+	destAddr, err := r.NewAddress()
+	require.NoError(t, err)
+	destScript, err := txscript.PayToAddrScript(destAddr)
+	require.NoError(t, err)
+
+	const feeB = int64(50_000)
+	spendB, err := xmsstxn.BuildSpend(xmsstxn.SpendRequest{
+		PrevOut: xmsstxn.UTXO{
+			OutPoint: wire.OutPoint{Hash: *spendABHash, Index: 0},
+			Value:    valueB,
+		},
+		DestinationPkScript: destScript,
+		Fee:                 feeB,
+		Descriptor:          descB,
+	})
+	require.NoError(t, err)
+
+	spendBHash, err := r.Client.SendRawTransaction(spendB, false)
+	require.NoError(t, err)
+	t.Logf("T_spend_B:  P2MR_B -> P2TR  (XMSS-signed): %s", spendBHash)
+	requireMined(t, r, spendBHash)
+}
+
+// deriveTestAddress derives a P2MR-XMSS address from constant-byte seeds
+// filled with privFill / pubFill.
+func deriveTestAddress(privFill, pubFill byte,
+	net *chaincfg.Params) (*xmsstxn.Descriptor, error) {
+
+	var priv [xmss.PrivateSeedLen]byte
+	var pub [xmss.PublicSeedLen]byte
+	for i := range priv {
+		priv[i] = privFill
+	}
+	for i := range pub {
+		pub[i] = pubFill
+	}
+	return xmsstxn.DeriveDescriptor(priv, pub, net)
+}
+
+// findOutput returns the vout of the output paying targetScript.
+func findOutput(t *testing.T, tx *wire.MsgTx, targetScript []byte) int {
+	t.Helper()
+	for i, o := range tx.TxOut {
+		if bytes.Equal(o.PkScript, targetScript) {
+			return i
+		}
+	}
+	t.Fatalf("tx %s has no output paying %x", tx.TxHash(), targetScript)
+	return -1
+}
+
+// requireMined mines one block and asserts spendHash is included.
+func requireMined(t *testing.T, r *rpctest.Harness,
+	spendHash *chainhash.Hash) {
+
+	t.Helper()
+
+	blocks, err := r.Client.Generate(1)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	blk, err := r.Client.GetBlock(blocks[0])
+	require.NoError(t, err)
+
+	for _, tx := range blk.Transactions {
+		if h := tx.TxHash(); h == *spendHash {
+			return
+		}
+	}
+	t.Fatalf("tx %s not mined into block %s", spendHash, blocks[0])
+}
+
+// waitForRawTransaction polls GetRawTransaction until pearld returns the
+// tx or the deadline expires; Generate can return before the just-mined
+// block is indexed for raw-tx lookups.
+func waitForRawTransaction(t *testing.T, r *rpctest.Harness,
+	txHash *chainhash.Hash) (*btcutil.Tx, error) {
+
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		tx, err := r.Client.GetRawTransaction(txHash)
+		if err == nil {
+			return tx, nil
+		}
+		lastErr = err
+		time.Sleep(50 * time.Millisecond)
+	}
+	return nil, lastErr
+}

--- a/node/integration/rpctest/btcd.go
+++ b/node/integration/rpctest/btcd.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 )
 
@@ -21,19 +22,16 @@ var (
 	// string until pearld is compiled. This should not be accessed directly;
 	// instead use the function pearldExecutablePath().
 	executablePath string
+
+	pearldBuildTags []string
 )
 
-// pearldExecutablePath returns a path to the pearld executable to be used by
-// rpctests. To ensure the code tests against the most up-to-date version of
-// pearld, this method compiles pearld the first time it is called. After that, the
-// generated binary is used for subsequent test harnesses. The executable file
-// is not cleaned up, but since it lives at a static path in a temp directory,
-// it is not a big deal.
+// pearldExecutablePath returns the path to the pearld test binary, building it
+// on first call and caching the result for subsequent harness instances.
 func pearldExecutablePath() (string, error) {
 	compileMtx.Lock()
 	defer compileMtx.Unlock()
 
-	// If pearld has already been compiled, just use that.
 	if len(executablePath) != 0 {
 		return executablePath, nil
 	}
@@ -43,20 +41,21 @@ func pearldExecutablePath() (string, error) {
 		return "", err
 	}
 
-	// Build pearld and output an executable in a static temp path.
 	outputPath := filepath.Join(testDir, "pearld")
 	if runtime.GOOS == "windows" {
 		outputPath += ".exe"
 	}
-	cmd := exec.Command(
-		"go", "build", "-o", outputPath, "github.com/pearl-research-labs/pearl/node",
-	)
+	args := []string{"build", "-o", outputPath}
+	if len(pearldBuildTags) > 0 {
+		args = append(args, "-tags", strings.Join(pearldBuildTags, ","))
+	}
+	args = append(args, "github.com/pearl-research-labs/pearl/node")
+	cmd := exec.Command("go", args...)
 	err = cmd.Run()
 	if err != nil {
 		return "", fmt.Errorf("Failed to build pearld: %v", err)
 	}
 
-	// Save executable path so future calls do not recompile.
 	executablePath = outputPath
 	return executablePath, nil
 }

--- a/node/integration/rpctest/btcd_tags_xmss.go
+++ b/node/integration/rpctest/btcd_tags_xmss.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build xmss
+
+package rpctest
+
+func init() {
+	// Build tags are not propagated to the child "go build" that compiles
+	// pearld, so mirror xmss explicitly so the harness node uses the real
+	// cgo-backed XMSS verifier instead of the always-fail stub.
+	pearldBuildTags = append(pearldBuildTags, "xmss")
+}

--- a/node/txscript/opcode.go
+++ b/node/txscript/opcode.go
@@ -2018,8 +2018,8 @@ func opcodeCheckSig(op *opcode, data []byte, vm *Engine) error {
 }
 
 // opcodeCheckXmssSig verifies an XMSS post-quantum signature.
-// The signature is split into 5 chunks of 468 bytes each to fit within
-// the 520-byte stack element limit.
+// The signature is split into XMSSSigChunks chunks of XMSSSigChunkSize bytes
+// each to fit within the 520-byte stack element limit.
 // Stack transformation: [... sig1 sig2 sig3 sig4 sig5 pubkey] -> [... bool]
 func opcodeCheckXmssSig(op *opcode, data []byte, vm *Engine) error {
 	// OP_CHECKXMSSSIG is only valid in tapscript context.
@@ -2029,23 +2029,21 @@ func opcodeCheckXmssSig(op *opcode, data []byte, vm *Engine) error {
 		return scriptError(ErrReservedOpcode, str)
 	}
 
-	const numSigChunks = 5
-	const sigChunkSize = xmss.SignatureLen / numSigChunks // 468 bytes = 2340 / 5
-
 	// Pop the public key (64 bytes for XMSS).
 	pkBytes, err := vm.dstack.PopByteArray()
 	if err != nil {
 		return err
 	}
 
-	// Pop the 5 signature chunks [sig1, sig2, sig3, sig4, sig5]
-	sigChunks := make([][]byte, numSigChunks)
-	for i := range numSigChunks {
+	// Pop the XMSSSigChunks signature chunks in reverse so sigChunks[0]
+	// is the bottom-of-stack element and sigChunks[last] is the top.
+	var sigChunks [XMSSSigChunks][]byte
+	for i := range XMSSSigChunks {
 		chunk, err := vm.dstack.PopByteArray()
 		if err != nil {
 			return err
 		}
-		sigChunks[numSigChunks-1-i] = chunk
+		sigChunks[XMSSSigChunks-1-i] = chunk
 	}
 
 	// Validate public key length.
@@ -2054,9 +2052,9 @@ func opcodeCheckXmssSig(op *opcode, data []byte, vm *Engine) error {
 		return nil
 	}
 
-	// Validate each signature chunk is exactly sigChunkSize bytes.
+	// Validate each signature chunk is exactly XMSSSigChunkSize bytes.
 	for _, chunk := range sigChunks {
-		if len(chunk) != sigChunkSize {
+		if len(chunk) != XMSSSigChunkSize {
 			vm.dstack.PushBool(false)
 			return nil
 		}

--- a/node/txscript/xmss.go
+++ b/node/txscript/xmss.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txscript
+
+import (
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/pearl-research-labs/pearl/xmss"
+)
+
+// XMSSSigChunks is the number of witness stack elements OP_CHECKXMSSSIG
+// pops to reconstruct an XMSS signature. The 2340-byte signature is split
+// across this many elements so each piece fits under MaxScriptElementSize
+// (the 520-byte BIP 342 stack cap).
+const XMSSSigChunks = 5
+
+// XMSSSigChunkSize is the byte length of each chunk.
+const XMSSSigChunkSize = xmss.SignatureLen / XMSSSigChunks
+
+// Compile-time check: xmss.SignatureLen must divide evenly into XMSSSigChunks
+// or the last chunk would be silently truncated.
+const _ = uint(0 - (xmss.SignatureLen % XMSSSigChunks))
+
+// XMSSLeafScript returns the tapscript leaf `<xmss_pk> OP_CHECKXMSSSIG`.
+func XMSSLeafScript(xmssPK [xmss.PKLen]byte) ([]byte, error) {
+	return NewScriptBuilder().
+		AddData(xmssPK[:]).
+		AddOp(OP_CHECKXMSSSIG).
+		Script()
+}
+
+// XMSSScriptPathWitness assembles the witness for a script-path spend of a
+// leaf ending in OP_CHECKXMSSSIG. The signature is split into XMSSSigChunks
+// elements of XMSSSigChunkSize bytes each to satisfy the BIP 342 stack cap.
+func XMSSScriptPathWitness(sig [xmss.SignatureLen]byte, leafScript,
+	controlBlock []byte) wire.TxWitness {
+
+	w := make(wire.TxWitness, 0, XMSSSigChunks+2)
+	for i := range XMSSSigChunks {
+		lo := i * XMSSSigChunkSize
+		hi := lo + XMSSSigChunkSize
+		w = append(w, sig[lo:hi])
+	}
+	w = append(w, leafScript, controlBlock)
+	return w
+}

--- a/wallet/wallet/xmss_p2mr_mainnet_test.go
+++ b/wallet/wallet/xmss_p2mr_mainnet_test.go
@@ -1,0 +1,272 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build xmss
+
+package wallet
+
+// On-chain proof artifact for a P2MR + XMSS round trip on Pearl mainnet:
+// the spending tx is unlocked by an XMSS signature against seed A and
+// pays to a P2MR pkScript committing to a second XMSS leaf derived from
+// seed B, so both ends are post-quantum.
+//
+// The file is filled in by the operator in three passes:
+//
+//	Pass 1 (pre-funding): set the four xmss*SeedHex constants and
+//	    mainnetFee, then `go test -tags xmss -run TestP2MRXMSSDeriveAddress`
+//	    to print the funding (A) and destination (B) addresses.
+//
+//	Pass 2 (post-funding): send to address A from oyster, set the
+//	    mainnetFunding* constants from the confirmed UTXO, then
+//	    `go test -tags xmss -run TestP2MRXMSSBuildSpend` to print the
+//	    raw spend hex; broadcast it via `oyster sendrawtransaction`.
+//
+//	Pass 3 (post-broadcast): set the four expected* constants from
+//	    the mined tx. The committed test then enforces byte-exact
+//	    reproducibility forever.
+//
+// Each XMSS keypair is single-use: msgUID=0 over two distinct sighashes
+// leaks the seed. Seed A signs the spend once; seed B is committed to
+// on chain only as part of the destination pkScript. Neither may be
+// reused for any other sighash.
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/pearl-research-labs/pearl/wallet/wallet/xmsstxn"
+	"github.com/pearl-research-labs/pearl/xmss"
+	"github.com/stretchr/testify/require"
+)
+
+// Pass 1: seeds for the funding (A) and destination (B) P2MR-XMSS
+// addresses, plus the absolute fee (grains). Seed pairs MUST be
+// distinct from each other and from any seed used elsewhere.
+const (
+	// Seed A: bytes 0x00–0x3f (private) and 0x40–0x5f (public).
+	xmssAPrivSeedHex = "000102030405060708090a0b0c0d0e0f" +
+		"101112131415161718191a1b1c1d1e1f" +
+		"202122232425262728292a2b2c2d2e2f" +
+		"303132333435363738393a3b3c3d3e3f"
+	xmssAPubSeedHex = "404142434445464748494a4b4c4d4e4f" +
+		"505152535455565758595a5b5c5d5e5f"
+
+	// Seed B: bytes 0x80–0xbf (private) and 0xc0–0xdf (public).
+	xmssBPrivSeedHex = "808182838485868788898a8b8c8d8e8f" +
+		"909192939495969798999a9b9c9d9e9f" +
+		"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf" +
+		"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+	xmssBPubSeedHex = "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+		"d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+
+	mainnetFee = int64(50_000) // grains; ~670 vB XMSS spend
+)
+
+// Pass 2: the confirmed funding UTXO. fundingValue must match the
+// on-chain output exactly -- it is hashed into the BIP-341 sighash.
+const (
+	mainnetFundingTxID  = "fb7b5dfd0e9a2ff7a86ec89a697b611b5e0e98fb02e6f33ab44d32967875356d"
+	mainnetFundingVout  = uint32(1)            // vout 1: P2MR output; vout 0 is the P2TR change
+	mainnetFundingValue = int64(1_000_000_000) // 10 PRL, confirmed in block 56303
+)
+
+// Pass 3: the on-chain artifacts asserted byte-exact for reproducibility.
+const (
+	expectedP2MRAddressA = "prl1zjrmn44f7n9cqekf9h4f2wl5hgp3apn0a2t7l09gcyc580gqsxm3ss67e3p"
+	expectedP2MRAddressB = "prl1zxxlkld5f4c723urfqemt3mzv9h8z6kf8yrxd8txa3fv2l0r6hkhqhryssk"
+	expectedSpendTxID    = "1fc2168472af90dfbcd9cd6392b914c40150ce5eedaefa5d0bd60a02fbaa2b53"
+	// Mined in block 56313. Input: P2MR_A (10 PRL, XMSS-signed). Output: P2MR_B (9.9995 PRL).
+	// Witness: 2340-byte XMSS signature split into 5×468-byte chunks, leaf script, control block.
+	expectedSpendTxHex = "020000000001016d35757896324db43af3e602fb980e5e1b617b699ac86ea8f72f9a0efd5d7bfb" +
+		"0100000000ffffffff01b0069a3b0000000022522031bf6fb689ae3ca8f0690676b8ec4c2dce2d59272" +
+		"0ccd3acdd8a58afbc7abdae07fdd40100000000180b7c7b62823b7db1b25e6daeea27cdaa01759f50f6" +
+		"a99e097b7a3be1855ba21e8bbeb5aac2e73539b7bca95c904277e21ed1d11557f85bcc11666300a255a" +
+		"9c0ab39d3a832a4d57b8dc2d026262d3820f2f95d555f02d759b82936034bf57345d4f06007557a7419" +
+		"194d151e61f7aeb9c8459d422a633db0ce805bffaf5606a75bc4fd040c660ab75e42c9735cbaa149b7e" +
+		"dc5b10f673aa246c3a97408a262bc9f824a54eacc3ad2d12a7fa3de63db900b277fd2ea673f22caf0aa" +
+		"a45b464e54300815c28642f4de8f6170a37d7ff1e548d1415276d98a2b23d2d134ea2d76646d8707320" +
+		"644afd6c96e3ea2172bdad47866f94b57e25dd7cb84b5065b7413eda42615920f6fe8316f39b41b215e" +
+		"66c2a43ef35982df863f443487e360d1f62f753271f96b988d070710bcabff7ca0597864a468ff1436f" +
+		"ed10bd740f93703870ec6feb75db0cc8fcb8fe4b7bcc0dfebfc7d0fd271f2dbf6056209c5427ef6e721" +
+		"642d71e313d6249ad6b94b1fbbf172b43cc16bdd80cc1761e7fdc9af11028e6135149a1b85952c46fd5" +
+		"2c1f02cc2c7e5a7c7bbcbb43351b38c2df0152c94de4e88cba4699647bab5a1912a84e52fa739aedf61" +
+		"fb616f5db433ff02c45ee82b9129ae782e9627ffc716cb977c4858fdd40184837066a4f7c11edd26678" +
+		"834d697bb1c82515431e78f58f980f69b4180a23c5d378aa0137fe8861f476c90aae9275c91df760a71" +
+		"f4f11c5b88cfb0861014b709f0d0c9634878494709c0d420987cbb0e0eb346458d8154f6afd4060e281" +
+		"6e6701aeebc08653c280c83facc2978a63a828e4a8adabffe6e33369b0bf2030160a1f4021d85d40efd" +
+		"cc5ba9fd6074082a985de4cd82922f8de2d093e813183651ded943136e3cb36237b6654f05aad13000d" +
+		"c2764d3a91abdaa62d12c201cf2ec2dcf35bcb79eaca358e329a6e95e0f3067e76e6491847971846784" +
+		"5717533205d1dd54679b155e42004cf9471d586c375abc5a9761fa852a3ee90a1108db959feb0aff4df" +
+		"edfc50df0f11aac959da216a115e82c14a5bdab5dcba6311c63b3d57ef708bd08c05fe50e1b05135f94" +
+		"264dce8d037e4ffd2d40b7ace51cd34fd22f581aa8882b235cb619c05ee46af62aee3a722a0010cd3c4" +
+		"bd59b7d764caf9c898fd184ec129ae27544b467feee02d5db75cf1bdd1bef5cf82802061b317c009c24" +
+		"76443459e1add5e4fb4f7062dbc8609372d8ee8db7a09f94e0b7001d5491041f5f6ac03d8c54b538eba" +
+		"e26409b7cc003a422a454fe67e7b56ff361a6ceaa5a790a94a874d7103a0805a19db518a06d11a8e1b6" +
+		"fdd4015a969316a1a1610b505ca43f2c00460a77c49612b137c0e939a645a1ee365badd023c434da884" +
+		"f515f9774b981a86ce8c22e73e98b3d1b062db23caa3509af869773f3b27a9582f6c596c37b3c9c3ab4" +
+		"3b68415bf777a198fb528743cd495a07cb64bcea892807cfab44f37c5e0b88853c5a9fe701ec515be74" +
+		"725332e8cad64a9809d81b488dbedf8447024e592813645eb5f3405a1310a49905bf29983cb77e859829" +
+		"670b8b755478ae166beae6369e1f7878e644399f10beac23e10270a7bed2adf00cb7d86e36e69a66b51" +
+		"5b64cf277002f95dbfc0d6040ec9e088e608bbd5b9726f01b86ee58b0de7ed4a1434159e9abf81ea9d4" +
+		"13c653ccc9e2abbdd389481350a003fc9649fa6f531b80f02408285d9a7cf40417bb37d1d74e8b23116" +
+		"d2cad1fff4926b7dbaaaf7cf0aed12153607005a365fbbb9e26ecee0099023880d190d59a249929133b" +
+		"989619c92dd664ab0242eed643f50b8ab48c9a0d923007817dc868ff808c5a9b35468dc1dc0556d6128" +
+		"65c6c474698a53f0ef7a63414a4bdc6c44156faffa39981433193922528c21091de9bedee885b23f86f" +
+		"cbd8436653e2da09ff0ed70bc4b9430fd13515c154506509cea4018de35b9d05bb4fc5125ebfe302a43" +
+		"e2efe166b92878000d26b6f06da7fdd40193c9d29fc80fbf335024c52f1aaae2850b25ccfd5142e6430" +
+		"e26da5a9704a7e9c4d9885c2041d16e838365465e3995a38681c5ba33bbc2845063ab64df60d2a00742" +
+		"a3a5c0fdecc1edeb80c3626cb5496d33474202dcbea23fa006c844385ca85840a57dd724e494ca94a2b" +
+		"56e202b8b33e149803678aaf4419786546978798336650132e6fce577b244e1e876f8028e7294d0a489" +
+		"066fb44caab85963b39c076df605b27ec371f8b4edb795778dd2b3828e476c129e5199f045580bdae42" +
+		"90a0d074a23285fac88522d4a511340466994eb1c89cf909e46829a4a981083b702bbad0b8d0fdf86737" +
+		"8c6285aaa2e83f76976f4188ba4c2e2d27ef52b00d37fc4cdb7930b585cdfb1c0758135599631fffd6a" +
+		"c0b3c8b97a29a943a19818b351a6daa1da791572597f0e3738628a5c937918ffc170b420b8878e32f7f" +
+		"164a5a541dd72cfd5598eb6f2c35785a58fb8782813b6e465df57ae9255fb09439f4cd70abb147676de" +
+		"f99c8b086cdf6f43fe009cfeb8758a095d6f6fadb44d965699a7356f3cec0df3f69988f42faa6303c83" +
+		"d20c58bb1574bc3c6e586b312fb2d680fbc40eefc1e171b3282ca0eb8ff50c1246f26e9eda94986d16f" +
+		"300df9390e5cecf4331a4ac55d0d496092202f643364be89fb068a61fdd4014d1878275cb7bd241664b" +
+		"a4596b54f44f5d25f29dae18236a0b1bf0c036cbfb1a92ed0b4e89fe83b13223633bc2cdcfdcfca3bfc" +
+		"391f6d16917e5db8adf6c3e0890d18da7217a17cd4dfce9db5c5f81365a658333ee553ed629ed73eea4" +
+		"bf3c30b6fad648cf6b942dc5d2affbdec0a07ea7a12f35cd1c2b1776089d296374c272fd309dd1e5c3d" +
+		"a577e35fefc4236ca6d91a0d3c8e5bde3cde9e5a2554fdbecd4b885509d483a2628760dc43137cd1080" +
+		"347092c055d69622aade712ac5a86391ebf64ae2de07185f862906e95eedac52c704547dc8d6c46c7fb" +
+		"d317489664f8420fe88c0d479d227dd16dec247f8d467a44dbe159aa4d30450b99436c56a84e07a2b80" +
+		"4ca56eb2879f9bc1c03435dea3c9ed9bef5f2a17ddca13159604e1fd929bea02f0da6717edba686612b" +
+		"0bc79f99142c9db1d89b62839a63788e6b4c6484f7e336eff0e7b6609db5d5788d3cf7ba18d7c3dc049" +
+		"7558e55fa0cc761046b62999592bab476047eeac222fd23ae00281a1c24831f49d39924c4ba42364d3bc" +
+		"ee83236052b4ecf65a41f01cccd437d78b45f3e132d4666b2cb35b58e6f6e6c347f2ec48aa584e90249" +
+		"9ea79b11e95163ed52fbb3507e9c9b9e823cc166f2965795784cf97b0c23a0f7b5d1c5ca02c457c84a2" +
+		"d42409df35bcfadb2a6626b7dec561f5f470525f3b755ba4b6c3d78cdeb11d83af1fb404142434445464" +
+		"748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5fde01c100000000"
+)
+
+// loadSeed decodes the hex seed constants for the named address into
+// fixed-size arrays.
+func loadSeed(t *testing.T, privHex, pubHex, label string) (
+	priv [xmss.PrivateSeedLen]byte, pub [xmss.PublicSeedLen]byte) {
+
+	t.Helper()
+	privBytes, err := hex.DecodeString(privHex)
+	require.NoError(t, err, "decode %s private seed", label)
+	require.Len(t, privBytes, xmss.PrivateSeedLen,
+		"%s private seed must decode to %d bytes",
+		label, xmss.PrivateSeedLen)
+
+	pubBytes, err := hex.DecodeString(pubHex)
+	require.NoError(t, err, "decode %s public seed", label)
+	require.Len(t, pubBytes, xmss.PublicSeedLen,
+		"%s public seed must decode to %d bytes",
+		label, xmss.PublicSeedLen)
+
+	copy(priv[:], privBytes)
+	copy(pub[:], pubBytes)
+	return priv, pub
+}
+
+// TestP2MRXMSSDeriveAddress prints the funding (A) and destination (B)
+// mainnet P2MR-XMSS addresses derived from the committed seeds. After
+// pass 3 it also asserts both match the expectedP2MRAddress* constants.
+func TestP2MRXMSSDeriveAddress(t *testing.T) {
+	privA, pubA := loadSeed(t, xmssAPrivSeedHex, xmssAPubSeedHex, "A")
+	privB, pubB := loadSeed(t, xmssBPrivSeedHex, xmssBPubSeedHex, "B")
+
+	descA, err := xmsstxn.DeriveDescriptor(
+		privA, pubA, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+	require.True(t, descA.Addr.IsForNet(&chaincfg.MainNetParams))
+
+	descB, err := xmsstxn.DeriveDescriptor(
+		privB, pubB, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+	require.True(t, descB.Addr.IsForNet(&chaincfg.MainNetParams))
+
+	require.NotEqual(t, descA.Addr.String(), descB.Addr.String(),
+		"xmssA*SeedHex must differ from xmssB*SeedHex")
+
+	t.Logf("address A (fund this): %s", descA.Addr.String())
+	t.Logf("  merkle root: %x", descA.Addr.WitnessProgram())
+	t.Logf("  xmss pk:     %x", descA.PublicKey[:])
+	t.Logf("  leaf script: %x", descA.LeafScript)
+	t.Logf("  ctrl block:  %x", descA.ControlBlock)
+	t.Logf("  pkScript:    %x", descA.PkScript)
+	t.Logf("address B (spend destination): %s", descB.Addr.String())
+	t.Logf("  merkle root: %x", descB.Addr.WitnessProgram())
+	t.Logf("  xmss pk:     %x", descB.PublicKey[:])
+	t.Logf("  leaf script: %x", descB.LeafScript)
+	t.Logf("  ctrl block:  %x", descB.ControlBlock)
+	t.Logf("  pkScript:    %x", descB.PkScript)
+
+	// Pass 3 reproducibility gate.
+	require.Equal(t, expectedP2MRAddressA, descA.Addr.String())
+	require.Equal(t, expectedP2MRAddressB, descB.Addr.String())
+}
+
+// TestP2MRXMSSBuildSpend reconstructs the P2MR_A -> P2MR_B spending tx,
+// prints its hex for broadcast in pass 2, and asserts byte-exact equality
+// with expectedSpendTxHex in pass 3. The underlying helper runs the
+// script VM and min-relay-fee guard, so a green test implies the hex is
+// ready to broadcast.
+func TestP2MRXMSSBuildSpend(t *testing.T) {
+	privA, pubA := loadSeed(t, xmssAPrivSeedHex, xmssAPubSeedHex, "A")
+	privB, pubB := loadSeed(t, xmssBPrivSeedHex, xmssBPubSeedHex, "B")
+
+	descA, err := xmsstxn.DeriveDescriptor(
+		privA, pubA, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+	require.True(t, descA.Addr.IsForNet(&chaincfg.MainNetParams))
+
+	descB, err := xmsstxn.DeriveDescriptor(
+		privB, pubB, &chaincfg.MainNetParams,
+	)
+	require.NoError(t, err)
+	require.True(t, descB.Addr.IsForNet(&chaincfg.MainNetParams))
+
+	fundingHash, err := chainhash.NewHashFromStr(mainnetFundingTxID)
+	require.NoError(t, err, "parse mainnetFundingTxID")
+	outpoint := wire.OutPoint{
+		Hash:  *fundingHash,
+		Index: mainnetFundingVout,
+	}
+
+	spendTx, err := xmsstxn.BuildSpend(xmsstxn.SpendRequest{
+		PrevOut: xmsstxn.UTXO{
+			OutPoint: outpoint,
+			Value:    mainnetFundingValue,
+		},
+		DestinationPkScript: descB.PkScript,
+		Fee:                 mainnetFee,
+		Descriptor:          descA,
+	})
+	require.NoError(t, err)
+	require.Len(t, spendTx.TxIn, 1)
+	require.Len(t, spendTx.TxOut, 1)
+	require.Equal(t, mainnetFundingValue-mainnetFee,
+		spendTx.TxOut[0].Value)
+	require.Equal(t, descB.PkScript, spendTx.TxOut[0].PkScript)
+
+	spendHex := mustSerializeHex(t, spendTx)
+	spendTxID := spendTx.TxHash().String()
+	t.Logf("P2MR_A -> P2MR_B spend tx:")
+	t.Logf("  txid:        %s", spendTxID)
+	t.Logf("  destination: %s", descB.Addr.String())
+	t.Logf("  hex:         %s", spendHex)
+
+	require.Equal(t, expectedSpendTxHex, spendHex)
+	require.Equal(t, expectedSpendTxID, spendTxID)
+}
+
+// mustSerializeHex returns tx serialized to hex (witness included).
+func mustSerializeHex(t *testing.T, tx *wire.MsgTx) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, tx.Serialize(&buf))
+	return hex.EncodeToString(buf.Bytes())
+}

--- a/wallet/wallet/xmss_test.go
+++ b/wallet/wallet/xmss_test.go
@@ -148,14 +148,11 @@ func TestXMSSScriptPathSigning(t *testing.T) {
 	sig, err := xmss.Sign(0, s.xmssSK, msg)
 	require.NoError(t, err)
 
-	// Build witness: [sig_chunks..., script, control_block]
-	// XMSS signature is 2340 bytes, split into 5 chunks of 468 bytes each
 	ctrlBlock := s.tapTree.LeafMerkleProofs[0].ToControlBlock(s.internalKey)
 	ctrlBytes, _ := ctrlBlock.ToBytes()
-	tx.TxIn[0].Witness = wire.TxWitness{
-		sig[0:468], sig[468:936], sig[936:1404], sig[1404:1872], sig[1872:2340],
-		s.xmssScript, ctrlBytes,
-	}
+	tx.TxIn[0].Witness = txscript.XMSSScriptPathWitness(
+		sig, s.xmssScript, ctrlBytes,
+	)
 
 	// Verify XMSS signature via script engine
 	flags := txscript.StandardVerifyFlags
@@ -163,9 +160,10 @@ func TestXMSSScriptPathSigning(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, vm.Execute(), "XMSS script-path spend should succeed")
 
-	// Verify corrupted signature is rejected
-	sig[467] ^= 0x01
-	tx.TxIn[0].Witness[0] = sig[0:468]
+	// Verify corrupted signature is rejected (flip a bit in the last byte
+	// of the first chunk).
+	sig[txscript.XMSSSigChunkSize-1] ^= 0x01
+	tx.TxIn[0].Witness[0] = sig[:txscript.XMSSSigChunkSize]
 	vm, _ = txscript.NewEngine(s.pkScript, tx, 0, flags, nil, sigHashes, prevOut.Value, prevFetcher)
 	require.Error(t, vm.Execute(), "corrupted signature should be rejected")
 }

--- a/wallet/wallet/xmsstxn/xmsstxn.go
+++ b/wallet/wallet/xmsstxn/xmsstxn.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// Package xmsstxn builds P2MR transactions that spend with XMSS
+// post-quantum signatures.
+//
+// Script-level primitives such as the leaf script, witness layout, and
+// chunk constants live in node/txscript. This package is the wallet-facing
+// layer: it derives spendable P2MR-XMSS addresses, builds transactions, signs
+// them, and applies wallet policy such as the minimum relay fee.
+package xmsstxn
+
+import (
+	"fmt"
+
+	"github.com/pearl-research-labs/pearl/node/btcutil"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/txscript"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/pearl-research-labs/pearl/wallet/wallet/txrules"
+	"github.com/pearl-research-labs/pearl/xmss"
+)
+
+// Descriptor describes a P2MR-XMSS output and carries the script material
+// and key pair needed to recognize and spend a UTXO paid to it.
+//
+// SecretKey is sensitive. Clear it after use if the caller does not need to
+// keep spending authority in memory.
+type Descriptor struct {
+	Addr         *btcutil.AddressMerkleRoot
+	PkScript     []byte
+	LeafScript   []byte
+	ControlBlock []byte
+	PublicKey    [xmss.PKLen]byte
+	SecretKey    [xmss.SKLen]byte
+}
+
+// UTXO describes a previous P2MR-XMSS output being spent.
+type UTXO struct {
+	OutPoint wire.OutPoint
+	Value    int64
+}
+
+// SpendRequest describes a 1-in / 1-out P2MR-XMSS spend.
+type SpendRequest struct {
+	PrevOut             UTXO
+	DestinationPkScript []byte
+	Fee                 int64
+	Descriptor          *Descriptor
+	MsgUID              uint32
+}
+
+// DeriveDescriptor deterministically derives a spendable P2MR-XMSS
+// descriptor from raw XMSS seeds for the given chain.
+func DeriveDescriptor(privSeed [xmss.PrivateSeedLen]byte,
+	pubSeed [xmss.PublicSeedLen]byte, net *chaincfg.Params) (*Descriptor, error) {
+
+	xmssPK, xmssSK, err := xmss.Keygen(privSeed, pubSeed)
+	if err != nil {
+		return nil, fmt.Errorf("xmss keygen: %w", err)
+	}
+
+	leafScript, err := txscript.XMSSLeafScript(xmssPK)
+	if err != nil {
+		return nil, fmt.Errorf("build leaf script: %w", err)
+	}
+
+	tree := txscript.AssembleTaprootScriptTree(
+		txscript.NewBaseTapLeaf(leafScript),
+	)
+	merkleRoot := tree.RootNode.TapHash()
+
+	addr, err := btcutil.NewAddressMerkleRoot(merkleRoot[:], net)
+	if err != nil {
+		return nil, fmt.Errorf("encode p2mr address: %w", err)
+	}
+
+	pkScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		return nil, fmt.Errorf("build p2mr pkScript: %w", err)
+	}
+
+	controlBlock, err := (&txscript.MerkleRootControlBlock{
+		LeafVersion:    txscript.BaseLeafVersion,
+		InclusionProof: tree.LeafMerkleProofs[0].InclusionProof,
+	}).ToBytes()
+	if err != nil {
+		return nil, fmt.Errorf("serialize control block: %w", err)
+	}
+
+	return &Descriptor{
+		Addr:         addr,
+		PkScript:     pkScript,
+		LeafScript:   leafScript,
+		ControlBlock: controlBlock,
+		PublicKey:    xmssPK,
+		SecretKey:    xmssSK,
+	}, nil
+}
+
+// BuildSpend signs and returns a 1-in / 1-out P2MR-XMSS transaction.
+// A non-nil return is consensus-valid and meets the network minimum relay fee.
+func BuildSpend(req SpendRequest) (*wire.MsgTx, error) {
+	if req.Descriptor == nil {
+		return nil, fmt.Errorf("descriptor is nil")
+	}
+	if req.Fee < 0 {
+		return nil, fmt.Errorf("fee must be non-negative, got %d", req.Fee)
+	}
+	if req.PrevOut.Value <= req.Fee {
+		return nil, fmt.Errorf("fundingValue %d must exceed fee %d",
+			req.PrevOut.Value, req.Fee)
+	}
+	if len(req.DestinationPkScript) == 0 {
+		return nil, fmt.Errorf("destPkScript is empty")
+	}
+
+	desc := req.Descriptor
+	if len(desc.LeafScript) == 0 {
+		return nil, fmt.Errorf("leafScript is empty")
+	}
+	if len(desc.ControlBlock) == 0 {
+		return nil, fmt.Errorf("controlBlock is empty")
+	}
+
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: req.PrevOut.OutPoint,
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	tx.AddTxOut(&wire.TxOut{
+		Value:    req.PrevOut.Value - req.Fee,
+		PkScript: req.DestinationPkScript,
+	})
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		desc.PkScript, req.PrevOut.Value,
+	)
+	sigHashes := txscript.NewTxSigHashes(tx, prevFetcher)
+
+	tapLeaf := txscript.NewBaseTapLeaf(desc.LeafScript)
+	sigHash, err := txscript.CalcTapscriptSignaturehash(
+		sigHashes, txscript.SigHashDefault, tx, 0, prevFetcher, tapLeaf,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("compute tapscript sighash: %w", err)
+	}
+
+	var msg [xmss.MsgLen]byte
+	copy(msg[:], sigHash)
+	sig, err := xmss.Sign(req.MsgUID, desc.SecretKey, msg)
+	if err != nil {
+		return nil, fmt.Errorf("xmss sign: %w", err)
+	}
+
+	tx.TxIn[0].Witness = txscript.XMSSScriptPathWitness(
+		sig, desc.LeafScript, desc.ControlBlock,
+	)
+
+	finalSigHashes := txscript.NewTxSigHashes(tx, prevFetcher)
+	vm, err := txscript.NewEngine(
+		desc.PkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		finalSigHashes, req.PrevOut.Value, prevFetcher,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create script engine: %w", err)
+	}
+	if err := vm.Execute(); err != nil {
+		return nil, fmt.Errorf("script engine rejected XMSS spend: %w", err)
+	}
+
+	if err := checkRelayFee(tx, req.Fee); err != nil {
+		return nil, err
+	}
+
+	return tx, nil
+}
+
+// checkRelayFee returns an error if fee is below DefaultRelayFeePerKb
+// scaled to the signed virtual size of tx.
+func checkRelayFee(tx *wire.MsgTx, fee int64) error {
+	baseSize := tx.SerializeSizeStripped()
+	witnessSize := tx.SerializeSize() - baseSize
+	const witnessScaleFactor = 4
+	vsize := baseSize + (witnessSize+witnessScaleFactor-1)/witnessScaleFactor
+
+	minFee := txrules.FeeForSerializeSize(
+		txrules.DefaultRelayFeePerKb, vsize,
+	)
+	if btcutil.Amount(fee) < minFee {
+		return fmt.Errorf(
+			"fee %d grains below min relay fee %d grains for "+
+				"vsize=%d (relay=%d grains/kvB)",
+			fee, int64(minFee), vsize,
+			int64(txrules.DefaultRelayFeePerKb),
+		)
+	}
+	return nil
+}

--- a/wallet/wallet/xmsstxn/xmsstxn_test.go
+++ b/wallet/wallet/xmsstxn/xmsstxn_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build xmss
+
+package xmsstxn
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/pearl-research-labs/pearl/node/btcec"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+	"github.com/pearl-research-labs/pearl/node/txscript"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/pearl-research-labs/pearl/xmss"
+	"github.com/stretchr/testify/require"
+)
+
+// testSeeds returns a fixed (private, public) XMSS seed pair so tests are
+// deterministic across runs.
+func testSeeds() ([xmss.PrivateSeedLen]byte, [xmss.PublicSeedLen]byte) {
+	var priv [xmss.PrivateSeedLen]byte
+	var pub [xmss.PublicSeedLen]byte
+	for i := range priv {
+		priv[i] = byte(0x11 + i)
+	}
+	for i := range pub {
+		pub[i] = byte(0x22 + i)
+	}
+	return priv, pub
+}
+
+// destP2TRScript returns a throwaway P2TR pkScript to use as the
+// destination of a synthetic spend.
+func destP2TRScript(t *testing.T) []byte {
+	t.Helper()
+	priv, err := btcec.NewPrivateKey()
+	require.NoError(t, err)
+	outKey := txscript.ComputeTaprootKeyNoScript(priv.PubKey())
+	script, err := txscript.PayToTaprootScript(outKey)
+	require.NoError(t, err)
+	return script
+}
+
+// TestDeriveDescriptor_DeterministicAddress verifies that the same XMSS
+// seeds always produce the same P2MR address, leaf script, control block,
+// and pkScript on a given chain.
+func TestDeriveDescriptor_DeterministicAddress(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := testSeeds()
+
+	addr1, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	addr2, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	require.Equal(t, addr1.Addr.String(), addr2.Addr.String(),
+		"address must be deterministic in seed")
+	require.Equal(t, addr1.PkScript, addr2.PkScript)
+	require.Equal(t, addr1.LeafScript, addr2.LeafScript)
+	require.Equal(t, addr1.ControlBlock, addr2.ControlBlock)
+	require.Equal(t, addr1.PublicKey, addr2.PublicKey)
+	require.Equal(t, addr1.SecretKey, addr2.SecretKey)
+
+	require.True(t, addr1.Addr.IsForNet(&chaincfg.SimNetParams))
+	require.Equal(t, byte(2), addr1.Addr.WitnessVersion())
+	require.Len(t, addr1.Addr.WitnessProgram(), 32)
+	require.True(t, txscript.IsPayToMerkleRoot(addr1.PkScript))
+}
+
+// TestDeriveDescriptor_DifferentNetsDifferentHRP confirms that the same
+// seeds yield the same witness program (and therefore the same on-chain
+// commitment) but encode under different bech32m HRPs per network.
+func TestDeriveDescriptor_DifferentNetsDifferentHRP(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := testSeeds()
+
+	mainAddr, err := DeriveDescriptor(priv, pub, &chaincfg.MainNetParams)
+	require.NoError(t, err)
+
+	simAddr, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	require.Equal(t, mainAddr.Addr.WitnessProgram(), simAddr.Addr.WitnessProgram(),
+		"witness program is independent of net params")
+	require.NotEqual(t, mainAddr.Addr.String(), simAddr.Addr.String(),
+		"bech32m encoding must differ per HRP")
+}
+
+// TestBuildSpend_RoundTrip derives a fresh P2MR-XMSS address,
+// fabricates a UTXO at it, builds a spend back to a throwaway P2TR, and
+// asserts the script engine accepts the constructed witness.
+func TestBuildSpend_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := testSeeds()
+
+	desc, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	const (
+		fundingValue = int64(1_000_000_000) // 10 PRL
+		// Well above checkRelayFee's floor for the ~670 vB signed
+		// size; exact min is asserted in TestBuildSpend_FeeGuard.
+		fee = int64(50_000)
+	)
+
+	// Any 32-byte hash works for the synthetic prev-outpoint: the prev
+	// fetcher supplies the pkScript+value the VM actually uses.
+	prevHash, err := chainhash.NewHashFromStr(
+		"0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef",
+	)
+	require.NoError(t, err)
+	outpoint := wire.OutPoint{Hash: *prevHash, Index: 0}
+
+	destScript := destP2TRScript(t)
+
+	tx, err := BuildSpend(SpendRequest{
+		PrevOut: UTXO{
+			OutPoint: outpoint,
+			Value:    fundingValue,
+		},
+		DestinationPkScript: destScript,
+		Fee:                 fee,
+		Descriptor:          desc,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, tx.TxIn, 1)
+	require.Len(t, tx.TxOut, 1)
+	require.Equal(t, fundingValue-fee, tx.TxOut[0].Value)
+	require.Equal(t, destScript, tx.TxOut[0].PkScript)
+
+	w := tx.TxIn[0].Witness
+	require.Len(t, w, txscript.XMSSSigChunks+2)
+	for i := range txscript.XMSSSigChunks {
+		require.Len(t, w[i], txscript.XMSSSigChunkSize)
+	}
+	require.Equal(t, desc.LeafScript, []byte(w[txscript.XMSSSigChunks]))
+	require.Equal(t, desc.ControlBlock, []byte(w[txscript.XMSSSigChunks+1]))
+}
+
+// TestBuildSpend_CorruptedSigRejected confirms the internal VM run
+// rejects a tampered signature, so a successful BuildSpend
+// return implies actual signature validity (not a no-op).
+func TestBuildSpend_CorruptedSigRejected(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := testSeeds()
+	desc, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	prevHash, err := chainhash.NewHashFromStr(
+		"0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef",
+	)
+	require.NoError(t, err)
+
+	tx, err := BuildSpend(SpendRequest{
+		PrevOut: UTXO{
+			OutPoint: wire.OutPoint{Hash: *prevHash, Index: 0},
+			Value:    1_000_000_000,
+		},
+		DestinationPkScript: destP2TRScript(t),
+		Fee:                 50_000,
+		Descriptor:          desc,
+	})
+	require.NoError(t, err)
+
+	// Flip a bit in the first signature chunk; the engine must reject.
+	tampered := bytes.Clone(tx.TxIn[0].Witness[0])
+	tampered[10] ^= 0xff
+	tx.TxIn[0].Witness[0] = tampered
+
+	prevFetcher := txscript.NewCannedPrevOutputFetcher(
+		desc.PkScript, 1_000_000_000,
+	)
+	hashes := txscript.NewTxSigHashes(tx, prevFetcher)
+	vm, err := txscript.NewEngine(
+		desc.PkScript, tx, 0, txscript.StandardVerifyFlags, nil,
+		hashes, 1_000_000_000, prevFetcher,
+	)
+	require.NoError(t, err)
+	require.Error(t, vm.Execute())
+}
+
+// TestBuildSpend_FeeGuard verifies the min-relay-fee guard refuses
+// to return a transaction whose fee is below the network minimum for its
+// actual signed virtual size.
+func TestBuildSpend_FeeGuard(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := testSeeds()
+	desc, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	prevHash, err := chainhash.NewHashFromStr(
+		"0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef",
+	)
+	require.NoError(t, err)
+	outpoint := wire.OutPoint{Hash: *prevHash, Index: 0}
+	destScript := destP2TRScript(t)
+
+	// 1 grain is below the relay floor for any real-sized tx.
+	_, err = BuildSpend(SpendRequest{
+		PrevOut: UTXO{
+			OutPoint: outpoint,
+			Value:    1_000_000_000,
+		},
+		DestinationPkScript: destScript,
+		Fee:                 1,
+		Descriptor:          desc,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "below min relay fee")
+}
+
+// TestBuildSpend_InputValidation covers the helper's argument validation
+// branches.
+func TestBuildSpend_InputValidation(t *testing.T) {
+	t.Parallel()
+
+	priv, pub := testSeeds()
+	desc, err := DeriveDescriptor(priv, pub, &chaincfg.SimNetParams)
+	require.NoError(t, err)
+
+	prevHash, err := chainhash.NewHashFromStr(
+		"0123456789abcdef0123456789abcdef" +
+			"0123456789abcdef0123456789abcdef",
+	)
+	require.NoError(t, err)
+	outpoint := wire.OutPoint{Hash: *prevHash, Index: 0}
+	destScript := destP2TRScript(t)
+
+	cases := []struct {
+		name       string
+		fundingVal int64
+		fee        int64
+		destPkSc   []byte
+		descriptor *Descriptor
+		wantErr    string
+	}{
+		{
+			name:       "nil descriptor",
+			fundingVal: 1_000_000_000,
+			fee:        50_000,
+			destPkSc:   destScript,
+			descriptor: nil,
+			wantErr:    "descriptor is nil",
+		},
+		{
+			name:       "negative fee",
+			fundingVal: 1_000_000_000,
+			fee:        -1,
+			destPkSc:   destScript,
+			descriptor: desc,
+			wantErr:    "must be non-negative",
+		},
+		{
+			name:       "fee greater than funding",
+			fundingVal: 100,
+			fee:        200,
+			destPkSc:   destScript,
+			descriptor: desc,
+			wantErr:    "must exceed fee",
+		},
+		{
+			name:       "empty dest pkScript",
+			fundingVal: 1_000_000_000,
+			fee:        50_000,
+			destPkSc:   nil,
+			descriptor: desc,
+			wantErr:    "destPkScript is empty",
+		},
+		{
+			name:       "empty leaf script",
+			fundingVal: 1_000_000_000,
+			fee:        50_000,
+			destPkSc:   destScript,
+			descriptor: &Descriptor{
+				PkScript:     desc.PkScript,
+				ControlBlock: desc.ControlBlock,
+				SecretKey:    desc.SecretKey,
+			},
+			wantErr: "leafScript is empty",
+		},
+		{
+			name:       "empty control block",
+			fundingVal: 1_000_000_000,
+			fee:        50_000,
+			destPkSc:   destScript,
+			descriptor: &Descriptor{
+				PkScript:   desc.PkScript,
+				LeafScript: desc.LeafScript,
+				SecretKey:  desc.SecretKey,
+			},
+			wantErr: "controlBlock is empty",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := BuildSpend(SpendRequest{
+				PrevOut:             UTXO{OutPoint: outpoint, Value: tc.fundingVal},
+				DestinationPkScript: tc.destPkSc,
+				Fee:                 tc.fee,
+				Descriptor:          tc.descriptor,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add wallet-facing P2MR/XMSS transaction helpers for deriving descriptors and building 1-in/1-out XMSS-signed spends.
- Add script-level XMSS witness helpers and chunk constants used by `OP_CHECKXMSSSIG` producers and tests.
- Add a simnet integration test that funds P2MR_A, spends P2MR_A -> P2MR_B with XMSS, and then spends P2MR_B onward to prove the destination P2MR is spendable.
- Add a reproducible mainnet proof test with committed seeds, funding UTXO, expected addresses, txid, and raw tx hex.

## On-chain proof

Fully post-quantum transaction: P2MR -> P2MR, where both addresses are derived from XMSS tapscript leaves (`<xmss_pk> OP_CHECKXMSSSIG`).

- Blockbook: https://blockbook.pearlresearch.ai/tx/1fc2168472af90dfbcd9cd6392b914c40150ce5eedaefa5d0bd60a02fbaa2b53
- Input: P2MR_A `prl1zjrmn44f7n9cqekf9h4f2wl5hgp3apn0a2t7l09gcyc580gqsxm3ss67e3p`
- Output: P2MR_B `prl1zxxlkld5f4c723urfqemt3mzv9h8z6kf8yrxd8txa3fv2l0r6hkhqhryssk`

## Test plan

- `go test -tags xmss -count=1 ./wallet/wallet/xmsstxn/ ./node/txscript/`
- `go test -tags xmss -count=1 -run 'TestP2MRXMSS|TestXMSS' -v ./wallet/wallet/`
- `go test -tags 'rpctest xmss' -run TestP2MRXMSSRoundtripSimnet -count=1 -timeout=180s -v ./node/integration/`