### PR TITLE
bugfix for bitcoin utils package serializing OP_PUSHDATA1 opcode

### DIFF
--- a/miner/conftest.py
+++ b/miner/conftest.py
@@ -255,7 +255,11 @@ def sample_pearl_block(sample_block_template):
         header,
         ZKProof(bytes(PUBLICDATA_SIZE), bytes(10000)),  # dummy proof
     )
-    return PearlBlock(header, sample_block_template.get_transactions(), zk_certificate)
+    return PearlBlock(
+        header,
+        raw_txns=sample_block_template.get_raw_transactions(),
+        zk_certificate=zk_certificate,
+    )
 
 
 @pytest.fixture

--- a/miner/pearl-gateway/src/pearl_gateway/blockchain_utils/blockchain_utils.py
+++ b/miner/pearl-gateway/src/pearl_gateway/blockchain_utils/blockchain_utils.py
@@ -10,41 +10,19 @@ def double_sha256(data: bytes) -> bytes:
     return sha256(sha256(data).digest()).digest()
 
 
-def is_coinbase(transaction: Transaction) -> bool:
-    """Check if a transaction is a coinbase transaction."""
-    return (
-        hasattr(transaction.inputs[0], "txid")
-        and transaction.inputs[0].txid == "0" * 64
-        and hasattr(transaction.inputs[0], "txout_index")
-        and transaction.inputs[0].txout_index == 0xFFFFFFFF
-    )
-
-
-def calculate_merkle_root(transactions: list[Transaction]) -> bytes:
+def calculate_merkle_root(txids: list[str]) -> bytes:
     """
-    Calculate the merkle root of transactions.
-
-    This function implements the standard merkle tree algorithm:
-    1. Hash all transactions (coinbase first, then regular transactions)
-    2. If odd number of hashes, duplicate the last one
-    3. Pair up hashes and double SHA256 them
-    4. Repeat until only one hash remains (the merkle root)
+    Calculate the merkle root from a list of txid hex strings.
 
     Args:
-        transactions: List of transactions with coinbase first
+        txids: List of txid hex strings in display order (big-endian),
+               with the coinbase txid first.
 
     Returns:
         bytes: The 32-byte merkle root hash
     """
-    # Collect all transaction hashes starting with coinbase
-    tx_hashes = []
-    assert is_coinbase(transactions[0]), "First transaction must be coinbase"
-
-    # Add regular transaction hashes
-    for tx in transactions:
-        # bitcoin-utils get_txid() returns hex string of txid in display order (big-endian)
-        # We need to reverse it to little-endian for merkle tree calculation
-        tx_hashes.append(bytes.fromhex(tx.get_txid())[::-1])
+    # Txids are in display order (big-endian); reverse to little-endian for merkle calc
+    tx_hashes = [bytes.fromhex(txid)[::-1] for txid in txids]
 
     # Calculate merkle root using the standard algorithm
     return _compute_merkle_root(tx_hashes)

--- a/miner/pearl-gateway/src/pearl_gateway/blockchain_utils/pearl_block.py
+++ b/miner/pearl-gateway/src/pearl_gateway/blockchain_utils/pearl_block.py
@@ -1,11 +1,15 @@
-from bitcoinutils.transactions import Transaction
-from bitcoinutils.utils import encode_varint, get_transaction_length, parse_compact_size
+from bitcoinutils.utils import encode_varint
 from pearl_gateway.blockchain_utils.pearl_header import PearlHeader
 from pearl_gateway.blockchain_utils.zk_certificate import ZKCertificate
 
 
 class PearlBlock:
-    def __init__(self, header: PearlHeader, txns: list[Transaction], zk_certificate: ZKCertificate):
+    def __init__(
+        self,
+        header: PearlHeader,
+        raw_txns: list[bytes],
+        zk_certificate: ZKCertificate,
+    ):
         self.header = header
 
         if header.proof_commitment is None:
@@ -13,37 +17,8 @@ class PearlBlock:
         elif header.proof_commitment != zk_certificate.get_proof_commitment():
             raise ValueError("Proof commitment mismatch")
 
-        self.txns = txns
+        self.raw_txns = raw_txns
         self.zk_certificate = zk_certificate
-
-    @staticmethod
-    def _deserialize_transactions(data: bytes) -> list[Transaction]:
-        txn_count, txn_offset = parse_compact_size(data)
-        transactions = []
-        for _ in range(txn_count):
-            txn_len = get_transaction_length(data[txn_offset:])
-            txn_bytes = data[txn_offset : txn_offset + txn_len]
-            transactions.append(Transaction.from_raw(txn_bytes.hex()))
-            txn_offset += txn_len
-        return transactions
-
-    @classmethod
-    def deserialize(cls, data: bytes) -> "PearlBlock":
-        """
-        The structure is ZK_CERTIFICATE|PEARL_HEADER|TRANSACTIONS|
-        """
-        zk_certificate = ZKCertificate.deserialize(data)
-        # zk certificate size is not constant, so we need to get it from the serialized data
-        zk_certificate_size = zk_certificate.get_serialized_size()
-
-        pearl_header_offset = zk_certificate_size
-        pearl_header_size = PearlHeader.get_serialized_header_size()
-        pearl_header_bytes = data[pearl_header_offset : pearl_header_offset + pearl_header_size]
-        pearl_header = PearlHeader.deserialize(pearl_header_bytes)
-
-        txn_offset = pearl_header_offset + pearl_header_size
-        transactions = cls._deserialize_transactions(data[txn_offset:])
-        return cls(pearl_header, transactions, zk_certificate)
 
     def serialize(self) -> bytes:
         """
@@ -51,6 +26,6 @@ class PearlBlock:
         """
         zk_certificate_bytes = self.zk_certificate.serialize()
         header_bytes = self.header.serialize()
-        tx_count_bytes = encode_varint(len(self.txns))
-        transactions_bytes = b"".join(tx.to_bytes(tx.has_segwit) for tx in self.txns)
+        tx_count_bytes = encode_varint(len(self.raw_txns))
+        transactions_bytes = b"".join(self.raw_txns)
         return zk_certificate_bytes + header_bytes + tx_count_bytes + transactions_bytes

--- a/miner/pearl-gateway/src/pearl_gateway/comm/dataclasses.py
+++ b/miner/pearl-gateway/src/pearl_gateway/comm/dataclasses.py
@@ -45,7 +45,7 @@ class BlockTemplate:
 
     header: PearlHeader
     height: int
-    transactions: list[Transaction]
+    raw_transactions: list[bytes]
     coinbase_tx: Transaction
 
     @classmethod
@@ -64,8 +64,11 @@ class BlockTemplate:
             coinbase_aux=data.coinbaseaux.model_dump(),
             default_witness_commitment=data.default_witness_commitment,
         )
-        transactions = [Transaction.from_raw(tx.data) for tx in data.transactions]
-        merkle_root = calculate_merkle_root([coinbase_tx] + transactions)
+        raw_transactions = [bytes.fromhex(tx.data) for tx in data.transactions]
+        txids = [tx.txid for tx in data.transactions]
+
+        coinbase_txid = coinbase_tx.get_txid()
+        merkle_root = calculate_merkle_root([coinbase_txid] + txids)
         height = data.height
 
         bits_translation = bits_to_target(int(bits, 16))
@@ -83,12 +86,15 @@ class BlockTemplate:
                 ),
             ),
             height=height,
-            transactions=transactions,
+            raw_transactions=raw_transactions,
             coinbase_tx=coinbase_tx,
         )
 
-    def get_transactions(self) -> list[Transaction]:
-        return [self.coinbase_tx] + self.transactions
+    def get_raw_transactions(self) -> list[bytes]:
+        """Return all transactions as raw bytes, coinbase first."""
+        # Safe to use to_bytes() here: the coinbase is constructed by us.
+        coinbase_bytes = self.coinbase_tx.to_bytes(self.coinbase_tx.has_segwit)
+        return [coinbase_bytes] + self.raw_transactions
 
     @property
     def bits(self) -> int:

--- a/miner/pearl-gateway/src/pearl_gateway/proof_generator.py
+++ b/miner/pearl-gateway/src/pearl_gateway/proof_generator.py
@@ -35,7 +35,9 @@ class ProofGenerator:
         header = copy(template.header)
         zk_certificate = ZKCertificate.from_pearl_header(header, zk_proof)
         block = PearlBlock(
-            header=header, txns=template.get_transactions(), zk_certificate=zk_certificate
+            header=header,
+            raw_txns=template.get_raw_transactions(),
+            zk_certificate=zk_certificate,
         )
         _LOGGER.debug("Generated block")
         return block

--- a/miner/pearl-gateway/tests/miner_rpc/test_performance.py
+++ b/miner/pearl-gateway/tests/miner_rpc/test_performance.py
@@ -311,7 +311,7 @@ async def mock_work_cache():
             ),
         ),
         height=100,
-        transactions=[],
+        raw_transactions=[],
         coinbase_tx=Transaction.from_raw(
             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0502a1050101ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
         ),

--- a/miner/pearl-gateway/tests/test_transaction_merkle_tree.py
+++ b/miner/pearl-gateway/tests/test_transaction_merkle_tree.py
@@ -1,5 +1,5 @@
 """
-Tests for btcpy-based merkle root calculation using real Bitcoin block data.
+Tests for merkle root calculation using real Bitcoin block data.
 """
 
 import json
@@ -10,7 +10,6 @@ from bitcoinutils.transactions import Transaction
 from pearl_gateway.blockchain_utils.blockchain_utils import (
     calculate_merkle_root,
     double_sha256,
-    is_coinbase,
 )
 
 
@@ -30,50 +29,42 @@ class TestMerkleBtcpy:
         # Extract the expected merkle root from the block data
         expected_merkle_root = bytes.fromhex(block_data["Data"]["METADATA"]["merkleroot"])
 
-        # Load transactions using bitcoin-utils
-        transactions = []
+        # Collect txids from each transaction
+        txids = []
         for tx in block_data["Data"]["TRANSACTIONS"]:
             try:
-                tx = Transaction.from_raw(tx["hex"])
-                transactions.append(tx)
+                parsed_tx = Transaction.from_raw(tx["hex"])
+                txids.append(parsed_tx.get_txid())
             except Exception as e:
                 pytest.fail(f"Failed to parse transaction hex {tx['hex'][:16]}...: {e}")
 
-        # Verify the first transaction is a coinbase
-        assert is_coinbase(transactions[0]), "First transaction should be coinbase"
-
         # Calculate merkle root using our function
-        calculated_merkle_root = calculate_merkle_root(transactions)
+        calculated_merkle_root = calculate_merkle_root(txids)
 
         # Verify the merkle roots match
         assert calculated_merkle_root == expected_merkle_root
 
     def test_empty_transactions(self):
         """Test merkle root calculation with only coinbase transaction."""
-        # Create a simple coinbase transaction for testing
         coinbase_hex = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020602ffffffff0100f2052a010000004341041b0e8c2567c12536aa13357b79a073dc4444acb83c4ec7a0e2f99dd7457516c5817242da796924ca4e99947d087fedf9ce467cb9f7c6287078f801df276fdf84ac00000000"
         coinbase_tx = Transaction.from_raw(coinbase_hex)
+        coinbase_txid = coinbase_tx.get_txid()
 
-        # Calculate merkle root with no additional transactions
-        result = calculate_merkle_root([coinbase_tx])
+        result = calculate_merkle_root([coinbase_txid])
 
-        # Should be the coinbase transaction hash
-        expected = bytes.fromhex(coinbase_tx.get_txid())
+        expected = bytes.fromhex(coinbase_txid)
         assert result == expected
 
     def test_single_additional_transaction(self):
         """Test merkle root with coinbase + one additional transaction."""
-        # Use real transaction data from block 100k
         coinbase_hex = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020602ffffffff0100f2052a010000004341041b0e8c2567c12536aa13357b79a073dc4444acb83c4ec7a0e2f99dd7457516c5817242da796924ca4e99947d087fedf9ce467cb9f7c6287078f801df276fdf84ac00000000"
         tx1_hex = "0100000001032e38e9c0a84c6046d687d10556dcacc41d275ec55fc00779ac88fdf357a187000000008c493046022100c352d3dd993a981beba4a63ad15c209275ca9470abfcd57da93b58e4eb5dce82022100840792bc1f456062819f15d33ee7055cf7b5ee1af1ebcc6028d9cdb1c3af7748014104f46db5e9d61a9dc27b8d64ad23e7383a4e6ca164593c2527c038c0857eb67ee8e825dca65046b82c9331586c82e0fd1f633f25f87c161bc6f8a630121df2b3d3ffffffff0200e32321000000001976a914c398efa9c392ba6013c5e04ee729755ef7f58b3288ac000fe208010000001976a914948c765a6914d43f2a7ac177da2c2f6b52de3d7c88ac00000000"
 
         coinbase_tx = Transaction.from_raw(coinbase_hex)
         tx1 = Transaction.from_raw(tx1_hex)
 
-        result = calculate_merkle_root([coinbase_tx, tx1])
+        result = calculate_merkle_root([coinbase_tx.get_txid(), tx1.get_txid()])
 
-        # bitcoin-utils get_txid() returns hex string of txid in display order (big-endian)
-        # Merkle tree calculation reverses these to little-endian internally
         coinbase_hash = bytes.fromhex(coinbase_tx.get_txid())[::-1]
         tx1_hash = bytes.fromhex(tx1.get_txid())[::-1]
         expected = double_sha256(coinbase_hash + tx1_hash)[::-1]

--- a/miner/pearl-gateway/tests/test_work_cache.py
+++ b/miner/pearl-gateway/tests/test_work_cache.py
@@ -37,7 +37,7 @@ def different_block_template():
         coinbase_tx=Transaction.from_raw(
             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0502a1050101ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
         ),
-        transactions=[],
+        raw_transactions=[],
     )
 
 


### PR DESCRIPTION
## Summary

Fix "witness commitment does not match" block rejections caused by bitcoin-utils corrupting OP_PUSHDATA1 scripts during parse/re-serialize round-trips. The gateway now stores raw transaction bytes from getblocktemplate and serializes them verbatim, eliminating the lossy Transaction.from_raw() -> to_bytes() round-trip entirely.

## Type

fix

## Scope

miner (pearl-gateway)

## Changes

- Replace `Transaction.from_raw()` parsing of GBT template transactions with raw bytes storage (`list[bytes]`) and direct use of GBT-provided txid strings for merkle root calculation
- Refactor `calculate_merkle_root` to accept txid hex strings instead of `Transaction` objects
- Refactor `PearlBlock` to accept and serialize raw transaction bytes directly via `b"".join()`, removing all dependency on `Transaction.to_bytes()` for block assembly
- Add `BlockTemplate.get_raw_transactions()` which returns all transactions (coinbase + template txs) as raw bytes
- Remove dead code: `PearlBlock.deserialize()`, `_deserialize_transactions()`, and unused `is_coinbase()` helper

## Root cause

`bitcoin-utils` `Script.from_raw()` silently skips OP_PUSHDATA1/2/4 data consumption when `has_segwit=True`. PEPEARL minting transactions embed 135-byte OP_RETURN payloads requiring OP_PUSHDATA1 (0x4c). When the gateway parsed these transactions and re-serialized them, the output scripts were corrupted, changing the wtxid. The coinbase still carried the original `default_witness_commitment` from the node, but the submitted block had different witness hashes, causing the node to correctly reject with "witness commitment does not match".