### PR TITLE
perf(blockchain): reduce UTXO cache flush contention with chainLock

### DIFF
--- a/node/blockchain/chain.go
+++ b/node/blockchain/chain.go
@@ -700,6 +700,10 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 
 	// Since we may have changed the UTXO cache, we make sure it didn't exceed its
 	// maximum size.  If we're pruned and have flushed already, this will be a no-op.
+	// Fast-path: skip db.Update if no flush is needed.
+	if !b.utxoCache.shouldFlush(FlushIfNeeded, state) {
+		return nil
+	}
 	return b.db.Update(func(dbTx database.Tx) error {
 		return b.utxoCache.flush(dbTx, FlushIfNeeded, state)
 	})

--- a/node/blockchain/utxocache.go
+++ b/node/blockchain/utxocache.go
@@ -500,11 +500,12 @@ func (s *utxoCache) connectTransactions(block *btcutil.Block, stxos *[]SpentTxOu
 }
 
 // writeCache writes all the entries that are cached in memory to the database atomically.
-func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState) error {
+func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState, eraseCache bool) error {
 	// Update commits and flushes the cache to the database.
 	// NOTE: The database has its own cache which gets atomically written
 	// to leveldb.
 	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+	var deletedMem uint64
 	for i := range s.cachedEntries.maps {
 		for outpoint, entry := range s.cachedEntries.maps[i] {
 			switch {
@@ -526,11 +527,34 @@ func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState) error {
 				}
 			}
 
+		if eraseCache {
 			delete(s.cachedEntries.maps[i], outpoint)
+		} else {
+			if entry == nil {
+				delete(s.cachedEntries.maps[i], outpoint)
+			} else if entry.IsSpent() {
+				delete(s.cachedEntries.maps[i], outpoint)
+				deletedMem += entry.memoryUsage()
+			} else if entry.isModified() {
+				entry.packedFlags &^= tfModified | tfFresh
+			}
+		}
 		}
 	}
-	s.cachedEntries.deleteMaps()
-	s.totalEntryMemory = 0
+
+	if eraseCache {
+		s.cachedEntries.deleteMaps()
+		s.totalEntryMemory = 0
+	} else {
+		// Non-erasing flush: partially-empty maps retain their allocated
+		// bucket memory.  Compaction is deferred to the next erasing flush
+		// (triggered by FlushRequired or when memory hits the max).
+		if s.totalEntryMemory >= deletedMem {
+			s.totalEntryMemory -= deletedMem
+		} else {
+			s.totalEntryMemory = 0
+		}
+	}
 
 	// When done, store the best state hash in the database to indicate the state
 	// is consistent until that hash.
@@ -546,10 +570,9 @@ func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState) error {
 	return nil
 }
 
-// flush flushes the UTXO state to the database if a flush is needed with the given flush mode.
-//
-// This function MUST be called with the chain state lock held (for writes).
-func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState) error {
+// shouldFlush returns whether the UTXO cache needs to be flushed to the database
+// with the given flush mode and best state.
+func (s *utxoCache) shouldFlush(mode FlushMode, bestState *BestState) bool {
 	var threshold uint64
 	switch mode {
 	case FlushRequired:
@@ -558,7 +581,7 @@ func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState
 	case FlushIfNeeded:
 		// If we performed a flush in the current best state, we have nothing to do.
 		if bestState.Hash == s.lastFlushHash {
-			return nil
+			return false
 		}
 
 		threshold = s.maxTotalMemoryUsage
@@ -573,16 +596,28 @@ func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState
 		}
 	}
 
-	if s.totalMemoryUsage() >= threshold {
-		// Add one to round up the integer division.
-		totalMiB := s.totalMemoryUsage() / ((1024 * 1024) + 1)
-		log.Infof("Flushing UTXO cache of %d MiB with %d entries to disk. For large sizes, "+
-			"this can take up to several minutes...", totalMiB, s.cachedEntries.length())
+	return s.totalMemoryUsage() >= threshold
+}
 
-		return s.writeCache(dbTx, bestState)
+// flush flushes the UTXO state to the database if a flush is needed with the given flush mode.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState) error {
+	if !s.shouldFlush(mode, bestState) {
+		return nil
 	}
 
-	return nil
+	var eraseCache bool
+	if mode == FlushRequired || s.totalMemoryUsage() >= s.maxTotalMemoryUsage {
+		eraseCache = true
+	}
+
+	// Add one to round up the integer division.
+	totalMiB := s.totalMemoryUsage() / ((1024 * 1024) + 1)
+	log.Infof("Flushing UTXO cache of %d MiB with %d entries to disk. For large sizes, "+
+		"this can take up to several minutes...", totalMiB, s.cachedEntries.length())
+
+	return s.writeCache(dbTx, bestState, eraseCache)
 }
 
 // FlushUtxoCache flushes the UTXO state to the database if a flush is needed with the
@@ -592,6 +627,13 @@ func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState
 func (b *BlockChain) FlushUtxoCache(mode FlushMode) error {
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
+
+	// Fast-path: check if a flush is needed before starting a database
+	// transaction.  This avoids acquiring the database write lock when no
+	// flush is required, preventing unnecessary contention with chainLock.
+	if !b.utxoCache.shouldFlush(mode, b.BestSnapshot()) {
+		return nil
+	}
 
 	return b.db.Update(func(dbTx database.Tx) error {
 		return b.utxoCache.flush(dbTx, mode, b.BestSnapshot())
@@ -701,11 +743,15 @@ func (b *BlockChain) InitConsistentState(tip *blockNode, interrupt <-chan struct
 
 		// Flush the utxo cache if needed.  This will in turn update the
 		// consistent state to this block.
-		err = s.db.Update(func(dbTx database.Tx) error {
-			return s.flush(dbTx, FlushIfNeeded, &BestState{Hash: node.hash, Height: node.height})
-		})
-		if err != nil {
-			return err
+		bestState := &BestState{Hash: node.hash, Height: node.height}
+		// Fast-path: skip db.Update if no flush is needed.
+		if s.shouldFlush(FlushIfNeeded, bestState) {
+			err = s.db.Update(func(dbTx database.Tx) error {
+				return s.flush(dbTx, FlushIfNeeded, bestState)
+			})
+			if err != nil {
+				return err
+			}
 		}
 
 		if interruptRequested(interrupt) {

--- a/node/blockchain/utxocache.go
+++ b/node/blockchain/utxocache.go
@@ -527,18 +527,18 @@ func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState, eraseCach
 				}
 			}
 
-		if eraseCache {
-			delete(s.cachedEntries.maps[i], outpoint)
-		} else {
-			if entry == nil {
+			if eraseCache {
 				delete(s.cachedEntries.maps[i], outpoint)
-			} else if entry.IsSpent() {
-				delete(s.cachedEntries.maps[i], outpoint)
-				deletedMem += entry.memoryUsage()
-			} else if entry.isModified() {
-				entry.packedFlags &^= tfModified | tfFresh
+			} else {
+				if entry == nil {
+					delete(s.cachedEntries.maps[i], outpoint)
+				} else if entry.IsSpent() {
+					delete(s.cachedEntries.maps[i], outpoint)
+					deletedMem += entry.memoryUsage()
+				} else if entry.isModified() {
+					entry.packedFlags &^= tfModified | tfFresh
+				}
 			}
-		}
 		}
 	}
 

--- a/node/blockchain/utxocache_test.go
+++ b/node/blockchain/utxocache_test.go
@@ -618,6 +618,204 @@ func TestUtxoCacheFlush(t *testing.T) {
 	}
 }
 
+func TestShouldFlush(t *testing.T) {
+	require := require.New(t)
+	cache := newUtxoCache(nil, 1*1024*1024)
+
+	bestState := &BestState{Hash: chainhash.Hash{0x01}}
+	otherState := &BestState{Hash: chainhash.Hash{0x02}}
+
+	// FlushRequired always returns true, even with an empty cache.
+	require.True(cache.shouldFlush(FlushRequired, bestState))
+
+	// FlushIfNeeded returns false when bestState hash matches lastFlushHash.
+	cache.lastFlushHash = bestState.Hash
+	require.False(cache.shouldFlush(FlushIfNeeded, bestState))
+
+	// FlushIfNeeded returns false when cache is below max and hash differs.
+	cache.lastFlushHash = chainhash.Hash{}
+	require.False(cache.shouldFlush(FlushIfNeeded, otherState))
+
+	// FlushIfNeeded returns true when cache exceeds max.
+	cache.maxTotalMemoryUsage = 1
+	require.True(cache.shouldFlush(FlushIfNeeded, otherState))
+	cache.maxTotalMemoryUsage = 1 * 1024 * 1024
+
+	// FlushPeriodic returns false when timer is recent and cache is below max.
+	cache.lastFlushTime = time.Now()
+	require.False(cache.shouldFlush(FlushPeriodic, bestState))
+
+	// FlushPeriodic returns true when timer has expired.
+	cache.lastFlushTime = time.Now().Add(-utxoFlushPeriodicInterval - time.Second)
+	require.True(cache.shouldFlush(FlushPeriodic, bestState))
+
+	// FlushPeriodic returns false again after timer is reset.
+	cache.lastFlushTime = time.Now()
+	require.False(cache.shouldFlush(FlushPeriodic, bestState))
+}
+
+func TestNonErasingFlushWithSpentEntries(t *testing.T) {
+	require := require.New(t)
+	chain, _, tearDown := utxoCacheTestChain("TestNonErasingFlushSpent")
+	defer tearDown()
+	cache := chain.utxoCache
+
+	// Add 10 entries and seed the database with an erasing flush.
+	outPoints := make([]wire.OutPoint, 10)
+	for i := range outPoints {
+		op := outpointFromInt(i)
+		outPoints[i] = op
+		txOut := wire.TxOut{Value: 10000, PkScript: getValidP2PKHScript()}
+		cache.addTxOut(op, &txOut, true, int32(i))
+	}
+
+	err := chain.db.Update(func(dbTx database.Tx) error {
+		return cache.flush(dbTx, FlushRequired, chain.stateSnapshot)
+	})
+	require.NoError(err)
+	require.Equal(0, cache.cachedEntries.length())
+	require.NoError(assertNbEntriesOnDisk(chain, 10))
+
+	// Fetch entries back from DB so they're cached as non-fresh, non-modified.
+	entries, err := cache.fetchEntries(outPoints)
+	require.NoError(err)
+	for _, e := range entries {
+		require.NotNil(e)
+		require.False(e.isFresh())
+		require.False(e.isModified())
+	}
+
+	// Spend 3 entries. They're not fresh, so they stay in cache as spent.
+	for i := 0; i < 3; i++ {
+		cache.addTxIn(&wire.TxIn{PreviousOutPoint: outPoints[i]}, nil)
+	}
+	require.Equal(10, cache.cachedEntries.length(),
+		"spent non-fresh entries should remain in cache until flushed")
+
+	// Add 2 new fresh entries.
+	newOutPoints := make([]wire.OutPoint, 2)
+	for i := range newOutPoints {
+		op := outpointFromInt(100 + i)
+		newOutPoints[i] = op
+		txOut := wire.TxOut{Value: 10000, PkScript: getValidP2PKHScript()}
+		cache.addTxOut(op, &txOut, true, 100+int32(i))
+	}
+	require.Equal(12, cache.cachedEntries.length())
+	memBefore := cache.totalEntryMemory
+
+	// Trigger a non-erasing periodic flush.
+	cache.lastFlushTime = time.Now().Add(-utxoFlushPeriodicInterval - time.Second)
+	err = chain.db.Update(func(dbTx database.Tx) error {
+		return cache.flush(dbTx, FlushPeriodic, chain.stateSnapshot)
+	})
+	require.NoError(err)
+
+	// Spent entries (3) removed; unspent fetched (7) + new flushed (2) = 9 remain.
+	require.Equal(9, cache.cachedEntries.length())
+
+	// Memory should have decreased by the spent entries' memory.
+	require.Less(cache.totalEntryMemory, memBefore)
+
+	// All remaining entries should have modified and fresh flags cleared.
+	for _, m := range cache.cachedEntries.maps {
+		for _, entry := range m {
+			if entry == nil {
+				continue
+			}
+			require.False(entry.isModified())
+			require.False(entry.isFresh())
+		}
+	}
+
+	// DB should have 10 - 3 spent + 2 new = 9 entries.
+	require.NoError(assertNbEntriesOnDisk(chain, 9))
+}
+
+func TestNonErasingFlushThenSpend(t *testing.T) {
+	require := require.New(t)
+	chain, _, tearDown := utxoCacheTestChain("TestNonErasingFlushThenSpend")
+	defer tearDown()
+	cache := chain.utxoCache
+
+	// Add 5 entries.
+	outPoints := make([]wire.OutPoint, 5)
+	for i := range outPoints {
+		op := outpointFromInt(i)
+		outPoints[i] = op
+		txOut := wire.TxOut{Value: 10000, PkScript: getValidP2PKHScript()}
+		cache.addTxOut(op, &txOut, true, int32(i))
+	}
+
+	// Non-erasing periodic flush writes entries to DB but keeps them in cache.
+	cache.lastFlushTime = time.Now().Add(-utxoFlushPeriodicInterval - time.Second)
+	err := chain.db.Update(func(dbTx database.Tx) error {
+		return cache.flush(dbTx, FlushPeriodic, chain.stateSnapshot)
+	})
+	require.NoError(err)
+	require.Equal(5, cache.cachedEntries.length())
+	require.NoError(assertNbEntriesOnDisk(chain, 5))
+
+	// Verify tfFresh was cleared (critical: without this, spending would
+	// delete the entry from cache but leave it orphaned in the database).
+	for _, m := range cache.cachedEntries.maps {
+		for _, entry := range m {
+			if entry != nil {
+				require.False(entry.isFresh())
+			}
+		}
+	}
+
+	// Spend 2 entries. Since tfFresh was cleared by the non-erasing flush,
+	// addTxIn keeps them in cache as spent markers so writeCache can delete
+	// them from the database on the next flush.
+	cache.addTxIn(&wire.TxIn{PreviousOutPoint: outPoints[0]}, nil)
+	cache.addTxIn(&wire.TxIn{PreviousOutPoint: outPoints[1]}, nil)
+	require.Equal(5, cache.cachedEntries.length(),
+		"spent non-fresh entries must remain in cache until flushed to DB")
+
+	// Erasing flush removes spent entries from DB and clears cache.
+	err = chain.db.Update(func(dbTx database.Tx) error {
+		return cache.flush(dbTx, FlushRequired, chain.stateSnapshot)
+	})
+	require.NoError(err)
+	require.Equal(0, cache.cachedEntries.length())
+	require.Equal(uint64(0), cache.totalEntryMemory)
+
+	// DB should have 5 - 2 spent = 3 entries.
+	require.NoError(assertNbEntriesOnDisk(chain, 3))
+}
+
+func TestPeriodicFlushErasesWhenCacheFull(t *testing.T) {
+	require := require.New(t)
+	chain, _, tearDown := utxoCacheTestChain("TestPeriodicFlushErasesWhenFull")
+	defer tearDown()
+	cache := chain.utxoCache
+
+	numEntries := 10
+	for i := 0; i < numEntries; i++ {
+		op := outpointFromInt(i)
+		txOut := wire.TxOut{Value: 10000, PkScript: getValidP2PKHScript()}
+		cache.addTxOut(op, &txOut, true, int32(i))
+	}
+
+	// Lower the threshold below current usage to simulate a full cache.
+	cache.maxTotalMemoryUsage = cache.totalMemoryUsage() - 1
+	cache.cachedEntries.maxTotalMemoryUsage = cache.maxTotalMemoryUsage
+
+	// Periodic flush with expired timer AND cache exceeding max should
+	// perform an erasing flush (eraseCache = true).
+	cache.lastFlushTime = time.Now().Add(-utxoFlushPeriodicInterval - time.Second)
+	err := chain.db.Update(func(dbTx database.Tx) error {
+		return cache.flush(dbTx, FlushPeriodic, chain.stateSnapshot)
+	})
+	require.NoError(err)
+
+	require.Equal(0, cache.cachedEntries.length(),
+		"periodic flush should erase cache when memory exceeds max")
+	require.Equal(uint64(0), cache.totalEntryMemory)
+	require.NoError(assertNbEntriesOnDisk(chain, numEntries))
+}
+
 func TestFlushNeededAfterPrune(t *testing.T) {
 	// Construct a synthetic block chain with a block index consisting of
 	// the following structure.

--- a/node/blockchain/utxocache_test.go
+++ b/node/blockchain/utxocache_test.go
@@ -597,8 +597,15 @@ func TestUtxoCacheFlush(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while flushing cache: %v", err)
 	}
-	if cache.cachedEntries.length() != 0 {
-		t.Fatalf("Expected 0 entries, has %d instead", cache.cachedEntries.length())
+	if cache.cachedEntries.length() != len(outPoints1) {
+		t.Fatalf("Expected %d entries, has %d instead", len(outPoints1), cache.cachedEntries.length())
+	}
+	for _, m := range cache.cachedEntries.maps {
+		for _, entry := range m {
+			if entry != nil && entry.isModified() {
+				t.Fatalf("Expected entry to not be modified after periodic flush")
+			}
+		}
 	}
 
 	err = assertConsistencyState(chain, tip.Hash())

--- a/node/btcd.go
+++ b/node/btcd.go
@@ -383,7 +383,7 @@ func loadBlockDB() (database.DB, error) {
 	removeRegressionDB(dbPath)
 
 	prldLog.Infof("Loading block database from '%s'", dbPath)
-	db, err := database.Open(cfg.DbType, dbPath, activeNetParams.Net)
+	db, err := database.Open(cfg.DbType, dbPath, activeNetParams.Net, cfg.DbCacheFlushIntervalSecs)
 	if err != nil {
 		// Return the error if it's not because the database doesn't
 		// exist.
@@ -398,7 +398,7 @@ func loadBlockDB() (database.DB, error) {
 		if err != nil {
 			return nil, err
 		}
-		db, err = database.Create(cfg.DbType, dbPath, activeNetParams.Net)
+		db, err = database.Create(cfg.DbType, dbPath, activeNetParams.Net, cfg.DbCacheFlushIntervalSecs)
 		if err != nil {
 			return nil, err
 		}

--- a/node/config.go
+++ b/node/config.go
@@ -37,34 +37,35 @@ import (
 )
 
 const (
-	defaultConfigFilename        = "pearld.conf"
-	defaultDataDirname           = "data"
-	defaultLogLevel              = "info"
-	defaultLogDirname            = "logs"
-	defaultLogFilename           = "pearld.log"
-	defaultMaxPeers              = 125
-	defaultBanDuration           = time.Hour * 24
-	defaultBanThreshold          = 100
-	defaultConnectTimeout        = time.Second * 30
-	defaultMaxRPCClients         = 10
-	defaultMaxRPCWebsockets      = 25
-	defaultMaxRPCConcurrentReqs  = 20
-	defaultDbType                = "ffldb"
-	defaultFreeTxRelayLimit      = 15.0
-	defaultTrickleInterval       = peer.DefaultTrickleInterval
-	defaultBlockMinVsize         = 0
-	defaultBlockMaxVsize         = 999000
-	blockMaxVsizeMin             = 1000
-	blockMaxVsizeMax             = blockchain.MaxBlockVsize - 1000
-	defaultGenerate              = false
-	defaultMaxOrphanTransactions = 100
-	defaultMaxOrphanTxSize       = 100000
-	defaultSigCacheMaxSize       = 100000
-	defaultUtxoCacheMaxSizeMiB   = 250
-	sampleConfigFilename         = "sample-pearld.conf"
-	defaultTxIndex               = false
-	defaultAddrIndex             = false
-	pruneMinSize                 = 1536
+	defaultConfigFilename           = "pearld.conf"
+	defaultDataDirname              = "data"
+	defaultLogLevel                 = "info"
+	defaultLogDirname               = "logs"
+	defaultLogFilename              = "pearld.log"
+	defaultMaxPeers                 = 125
+	defaultBanDuration              = time.Hour * 24
+	defaultBanThreshold             = 100
+	defaultConnectTimeout           = time.Second * 30
+	defaultMaxRPCClients            = 10
+	defaultMaxRPCWebsockets         = 25
+	defaultMaxRPCConcurrentReqs     = 20
+	defaultDbType                   = "ffldb"
+	defaultFreeTxRelayLimit         = 15.0
+	defaultTrickleInterval          = peer.DefaultTrickleInterval
+	defaultBlockMinVsize            = 0
+	defaultBlockMaxVsize            = 999000
+	blockMaxVsizeMin                = 1000
+	blockMaxVsizeMax                = blockchain.MaxBlockVsize - 1000
+	defaultGenerate                 = false
+	defaultMaxOrphanTransactions    = 100
+	defaultMaxOrphanTxSize          = 100000
+	defaultSigCacheMaxSize          = 100000
+	defaultUtxoCacheMaxSizeMiB      = 250
+	defaultDbCacheFlushIntervalSecs = 3600
+	sampleConfigFilename            = "sample-pearld.conf"
+	defaultTxIndex                  = false
+	defaultAddrIndex                = false
+	pruneMinSize                    = 1536
 )
 
 var (
@@ -94,94 +95,95 @@ func minUint32(a, b uint32) uint32 {
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	AddCheckpoints       []string      `long:"addcheckpoint" description:"Add a custom checkpoint.  Format: '<height>:<hash>'"`
-	AddPeers             []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
-	AddrIndex            bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
-	AgentBlacklist       []string      `long:"agentblacklist" description:"A comma separated list of user-agent substrings which will cause the node to reject any peers whose user-agent contains any of the blacklisted substrings."`
-	AgentWhitelist       []string      `long:"agentwhitelist" description:"A comma separated list of user-agent substrings which will cause the node to require all peers' user-agents to contain one of the whitelisted substrings. The blacklist is applied before the whitelist, and an empty whitelist will allow all agents that do not fail the blacklist."`
-	BanDuration          time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
-	BanThreshold         uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
-	BlockMaxVsize        uint32        `long:"blockmaxvsize" description:"Maximum block vsize to be used when creating a block"`
-	BlockMinVsize        uint32        `long:"blockminvsize" description:"Minimum block vsize to be used when creating a block"`
-	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
-	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
-	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
-	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	MemoryProfile        string        `long:"memprofile" description:"Write memory profile to the specified file"`
-	TraceProfile         string        `long:"traceprofile" description:"Write execution trace to the specified file"`
-	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
-	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
-	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	DropAddrIndex        bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
-	DropCfIndex          bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
-	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
-	ExternalIPs          []string      `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
-	Generate             bool          `long:"generate" description:"Generate (mine) blocks using the CPU"`
-	FreeTxRelayLimit     float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
-	Listeners            []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 44108, testnet: 44110)"`
-	LogDir               string        `long:"logdir" description:"Directory to log output."`
-	MaxMempool           uint64        `long:"maxmempool" description:"Maximum mempool size in MB (default: 300)"`
-	MaxOrphanTxs         int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
-	MaxPeers             int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
-	MiningAddrs          []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
-	MinRelayTxFee        float64       `long:"minrelaytxfee" description:"The minimum transaction fee in PRL/kB to be considered a non-zero fee."`
-	DisableBanning       bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
-	NoCFilters           bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
-	DisableCheckpoints   bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
-	DisableDNSSeed       bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
-	DisableListen        bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
-	NoOnion              bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
-	NoPeerBloomFilters   bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
-	NoRelayPriority      bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
-	NoWinService         bool          `long:"nowinservice" description:"Do not start as a background service on Windows -- NOTE: This flag only works on the command line, not in the config file"`
-	DisableRPC           bool          `long:"norpc" description:"Disable built-in RPC server -- NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified"`
-	DisableStallHandler  bool          `long:"nostalldetect" description:"Disables the stall handler system for each peer, useful in simnet/regtest integration tests frameworks"`
-	DisableTLS           bool          `long:"notls" description:"Disable TLS for the RPC server"`
-	OnionProxy           string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	OnionProxyPass       string        `long:"onionpass" default-mask:"-" description:"Password for onion proxy server"`
-	OnionProxyUser       string        `long:"onionuser" description:"Username for onion proxy server"`
-	Profile              string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	Proxy                string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	ProxyPass            string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
-	ProxyUser            string        `long:"proxyuser" description:"Username for proxy server"`
-	Prune                uint64        `long:"prune" description:"Prune already validated blocks from the database. Must specify a target size in MiB (minimum value of 1536, default value of 0 will disable pruning)"`
-	RegressionTest       bool          `long:"regtest" description:"Use the regression test network"`
-	RejectNonStd         bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
-	RejectReplacement    bool          `long:"rejectreplacement" description:"Reject transactions that attempt to replace existing transactions within the mempool through the Replace-By-Fee (RBF) signaling policy."`
-	RelayNonStd          bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
-	RPCCert              string        `long:"rpccert" description:"File containing the certificate file"`
-	RPCKey               string        `long:"rpckey" description:"File containing the certificate key"`
-	RPCLimitPass         string        `long:"rpclimitpass" default-mask:"-" description:"Password for limited RPC connections"`
-	RPCLimitUser         string        `long:"rpclimituser" description:"Username for limited RPC connections"`
-	RPCListeners         []string      `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 44107, testnet: 44109)"`
-	RPCMaxClients        int           `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
-	RPCMaxConcurrentReqs int           `long:"rpcmaxconcurrentreqs" description:"Max number of concurrent RPC requests that may be processed concurrently"`
-	RPCMaxWebsockets     int           `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
-	RPCQuirks            bool          `long:"rpcquirks" description:"Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE: Discouraged unless interoperability issues need to be worked around"`
-	RPCPass              string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	RPCUser              string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
-	SigCacheMaxSize      uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
-	SimNet               bool          `long:"simnet" description:"Use the simulation test network"`
-	SigNet               bool          `long:"signet" description:"Use the signet test network"`
-	SigNetChallenge      string        `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
-	SigNetSeedNode       []string      `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
-	TestNet              bool          `long:"testnet" description:"Use the test network"`
-	TestNet2             bool          `long:"testnet2" description:"Use the test network v2 (fresh genesis)"`
-	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
-	TrickleInterval      time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
-	UtxoCacheMaxSizeMiB  uint          `long:"utxocachemaxsize" description:"The maximum size in MiB of the UTXO cache"`
-	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
-	UserAgentComments    []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
-	Upnp                 bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
-	ShowVersion          bool          `short:"V" long:"version" description:"Display version information and exit"`
-	Whitelists           []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
-	lookup               func(string) ([]net.IP, error)
-	oniondial            func(string, string, time.Duration) (net.Conn, error)
-	dial                 func(string, string, time.Duration) (net.Conn, error)
-	addCheckpoints       []chaincfg.Checkpoint
-	miningAddrs          []btcutil.Address
-	minRelayTxFee        btcutil.Amount
-	whitelists           []*net.IPNet
+	AddCheckpoints           []string      `long:"addcheckpoint" description:"Add a custom checkpoint.  Format: '<height>:<hash>'"`
+	AddPeers                 []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
+	AddrIndex                bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
+	AgentBlacklist           []string      `long:"agentblacklist" description:"A comma separated list of user-agent substrings which will cause the node to reject any peers whose user-agent contains any of the blacklisted substrings."`
+	AgentWhitelist           []string      `long:"agentwhitelist" description:"A comma separated list of user-agent substrings which will cause the node to require all peers' user-agents to contain one of the whitelisted substrings. The blacklist is applied before the whitelist, and an empty whitelist will allow all agents that do not fail the blacklist."`
+	BanDuration              time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
+	BanThreshold             uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
+	BlockMaxVsize            uint32        `long:"blockmaxvsize" description:"Maximum block vsize to be used when creating a block"`
+	BlockMinVsize            uint32        `long:"blockminvsize" description:"Minimum block vsize to be used when creating a block"`
+	BlocksOnly               bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
+	ConfigFile               string        `short:"C" long:"configfile" description:"Path to configuration file"`
+	ConnectPeers             []string      `long:"connect" description:"Connect only to the specified peers at startup"`
+	CPUProfile               string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemoryProfile            string        `long:"memprofile" description:"Write memory profile to the specified file"`
+	TraceProfile             string        `long:"traceprofile" description:"Write execution trace to the specified file"`
+	DataDir                  string        `short:"b" long:"datadir" description:"Directory to store data"`
+	DbType                   string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
+	DebugLevel               string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	DropAddrIndex            bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
+	DropCfIndex              bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
+	DropTxIndex              bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
+	ExternalIPs              []string      `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
+	Generate                 bool          `long:"generate" description:"Generate (mine) blocks using the CPU"`
+	FreeTxRelayLimit         float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
+	Listeners                []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 44108, testnet: 44110)"`
+	LogDir                   string        `long:"logdir" description:"Directory to log output."`
+	MaxMempool               uint64        `long:"maxmempool" description:"Maximum mempool size in MB (default: 300)"`
+	MaxOrphanTxs             int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
+	MaxPeers                 int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	MiningAddrs              []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
+	MinRelayTxFee            float64       `long:"minrelaytxfee" description:"The minimum transaction fee in PRL/kB to be considered a non-zero fee."`
+	DisableBanning           bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
+	NoCFilters               bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
+	DisableCheckpoints       bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
+	DisableDNSSeed           bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
+	DisableListen            bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
+	NoOnion                  bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
+	NoPeerBloomFilters       bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
+	NoRelayPriority          bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
+	NoWinService             bool          `long:"nowinservice" description:"Do not start as a background service on Windows -- NOTE: This flag only works on the command line, not in the config file"`
+	DisableRPC               bool          `long:"norpc" description:"Disable built-in RPC server -- NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified"`
+	DisableStallHandler      bool          `long:"nostalldetect" description:"Disables the stall handler system for each peer, useful in simnet/regtest integration tests frameworks"`
+	DisableTLS               bool          `long:"notls" description:"Disable TLS for the RPC server"`
+	OnionProxy               string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
+	OnionProxyPass           string        `long:"onionpass" default-mask:"-" description:"Password for onion proxy server"`
+	OnionProxyUser           string        `long:"onionuser" description:"Username for onion proxy server"`
+	Profile                  string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
+	Proxy                    string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
+	ProxyPass                string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
+	ProxyUser                string        `long:"proxyuser" description:"Username for proxy server"`
+	Prune                    uint64        `long:"prune" description:"Prune already validated blocks from the database. Must specify a target size in MiB (minimum value of 1536, default value of 0 will disable pruning)"`
+	RegressionTest           bool          `long:"regtest" description:"Use the regression test network"`
+	RejectNonStd             bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
+	RejectReplacement        bool          `long:"rejectreplacement" description:"Reject transactions that attempt to replace existing transactions within the mempool through the Replace-By-Fee (RBF) signaling policy."`
+	RelayNonStd              bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
+	RPCCert                  string        `long:"rpccert" description:"File containing the certificate file"`
+	RPCKey                   string        `long:"rpckey" description:"File containing the certificate key"`
+	RPCLimitPass             string        `long:"rpclimitpass" default-mask:"-" description:"Password for limited RPC connections"`
+	RPCLimitUser             string        `long:"rpclimituser" description:"Username for limited RPC connections"`
+	RPCListeners             []string      `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 44107, testnet: 44109)"`
+	RPCMaxClients            int           `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
+	RPCMaxConcurrentReqs     int           `long:"rpcmaxconcurrentreqs" description:"Max number of concurrent RPC requests that may be processed concurrently"`
+	RPCMaxWebsockets         int           `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
+	RPCQuirks                bool          `long:"rpcquirks" description:"Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE: Discouraged unless interoperability issues need to be worked around"`
+	RPCPass                  string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	RPCUser                  string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
+	SigCacheMaxSize          uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
+	SimNet                   bool          `long:"simnet" description:"Use the simulation test network"`
+	SigNet                   bool          `long:"signet" description:"Use the signet test network"`
+	SigNetChallenge          string        `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
+	SigNetSeedNode           []string      `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
+	TestNet                  bool          `long:"testnet" description:"Use the test network"`
+	TestNet2                 bool          `long:"testnet2" description:"Use the test network v2 (fresh genesis)"`
+	TorIsolation             bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
+	TrickleInterval          time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
+	UtxoCacheMaxSizeMiB      uint          `long:"utxocachemaxsize" description:"The maximum size in MiB of the UTXO cache"`
+	DbCacheFlushIntervalSecs uint32        `long:"dbcacheflushinterval" description:"The database cache flush interval in seconds"`
+	TxIndex                  bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
+	UserAgentComments        []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
+	Upnp                     bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
+	ShowVersion              bool          `short:"V" long:"version" description:"Display version information and exit"`
+	Whitelists               []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
+	lookup                   func(string) ([]net.IP, error)
+	oniondial                func(string, string, time.Duration) (net.Conn, error)
+	dial                     func(string, string, time.Duration) (net.Conn, error)
+	addCheckpoints           []chaincfg.Checkpoint
+	miningAddrs              []btcutil.Address
+	minRelayTxFee            btcutil.Amount
+	whitelists               []*net.IPNet
 }
 
 // serviceOptions defines the configuration options for the daemon as a service on
@@ -409,31 +411,32 @@ func newConfigParser(cfg *config, so *serviceOptions, options flags.Options) *fl
 func loadConfig() (*config, []string, error) {
 	// Default config.
 	cfg := config{
-		ConfigFile:           defaultConfigFile,
-		DebugLevel:           defaultLogLevel,
-		MaxPeers:             defaultMaxPeers,
-		BanDuration:          defaultBanDuration,
-		BanThreshold:         defaultBanThreshold,
-		RPCMaxClients:        defaultMaxRPCClients,
-		RPCMaxWebsockets:     defaultMaxRPCWebsockets,
-		RPCMaxConcurrentReqs: defaultMaxRPCConcurrentReqs,
-		DataDir:              defaultDataDir,
-		LogDir:               defaultLogDir,
-		DbType:               defaultDbType,
-		RPCKey:               defaultRPCKeyFile,
-		RPCCert:              defaultRPCCertFile,
-		MinRelayTxFee:        mempool.DefaultMinRelayTxFee.ToPRL(),
-		FreeTxRelayLimit:     defaultFreeTxRelayLimit,
-		TrickleInterval:      defaultTrickleInterval,
-		BlockMinVsize:        defaultBlockMinVsize,
-		BlockMaxVsize:        defaultBlockMaxVsize,
-		MaxMempool:           mempool.DefaultMaxMempoolSize / 1000 / 1000,
-		MaxOrphanTxs:         defaultMaxOrphanTransactions,
-		SigCacheMaxSize:      defaultSigCacheMaxSize,
-		UtxoCacheMaxSizeMiB:  defaultUtxoCacheMaxSizeMiB,
-		Generate:             defaultGenerate,
-		TxIndex:              defaultTxIndex,
-		AddrIndex:            defaultAddrIndex,
+		ConfigFile:               defaultConfigFile,
+		DebugLevel:               defaultLogLevel,
+		MaxPeers:                 defaultMaxPeers,
+		BanDuration:              defaultBanDuration,
+		BanThreshold:             defaultBanThreshold,
+		RPCMaxClients:            defaultMaxRPCClients,
+		RPCMaxWebsockets:         defaultMaxRPCWebsockets,
+		RPCMaxConcurrentReqs:     defaultMaxRPCConcurrentReqs,
+		DataDir:                  defaultDataDir,
+		LogDir:                   defaultLogDir,
+		DbType:                   defaultDbType,
+		RPCKey:                   defaultRPCKeyFile,
+		RPCCert:                  defaultRPCCertFile,
+		MinRelayTxFee:            mempool.DefaultMinRelayTxFee.ToPRL(),
+		FreeTxRelayLimit:         defaultFreeTxRelayLimit,
+		TrickleInterval:          defaultTrickleInterval,
+		BlockMinVsize:            defaultBlockMinVsize,
+		BlockMaxVsize:            defaultBlockMaxVsize,
+		MaxMempool:               mempool.DefaultMaxMempoolSize / 1000 / 1000,
+		MaxOrphanTxs:             defaultMaxOrphanTransactions,
+		SigCacheMaxSize:          defaultSigCacheMaxSize,
+		UtxoCacheMaxSizeMiB:      defaultUtxoCacheMaxSizeMiB,
+		DbCacheFlushIntervalSecs: defaultDbCacheFlushIntervalSecs,
+		Generate:                 defaultGenerate,
+		TxIndex:                  defaultTxIndex,
+		AddrIndex:                defaultAddrIndex,
 	}
 
 	// Service options which are only added on Windows.

--- a/node/database/ffldb/README.md
+++ b/node/database/ffldb/README.md
@@ -19,7 +19,8 @@ Package ffldb is licensed under the copyfree ISC license.
 
 This package is a driver to the database package and provides the database type
 of "ffldb".  The parameters the Open and Create functions take are the
-database path as a string and the block network.
+database path as a string, the block network, and an optional cache flush
+interval in seconds (defaults to 3600).
 
 ```Go
 db, err := database.Open("ffldb", "path/to/database", wire.MainNet)

--- a/node/database/ffldb/db.go
+++ b/node/database/ffldb/db.go
@@ -2061,7 +2061,7 @@ func initDB(ldb *leveldb.DB) error {
 
 // openDB opens the database at the provided path.  database.ErrDbDoesNotExist
 // is returned if the database doesn't exist and the create flag is not set.
-func openDB(dbPath string, network wire.PearlNet, create bool) (database.DB, error) {
+func openDB(dbPath string, network wire.PearlNet, create bool, flushIntervalSecs uint32) (database.DB, error) {
 	// Error if the database doesn't exist and the create flag is not set.
 	metadataDbPath := filepath.Join(dbPath, metadataDbName)
 	dbExists := fileExists(metadataDbPath)
@@ -2099,7 +2099,7 @@ func openDB(dbPath string, network wire.PearlNet, create bool) (database.DB, err
 	if err != nil {
 		return nil, convertErr(err.Error(), err)
 	}
-	cache := newDbCache(ldb, store, defaultCacheSize, defaultFlushSecs)
+	cache := newDbCache(ldb, store, defaultCacheSize, flushIntervalSecs)
 	pdb := &db{store: store, cache: cache}
 
 	// Perform any reconciliation needed between the block and metadata as

--- a/node/database/ffldb/dbcache.go
+++ b/node/database/ffldb/dbcache.go
@@ -26,7 +26,7 @@ const (
 	// defaultFlushSecs is the default number of seconds to use as a
 	// threshold in between database cache flushes when the cache size has
 	// not been exceeded.
-	defaultFlushSecs = 300 // 5 minutes
+	defaultFlushSecs = 3600 // 1 hour
 
 	// ldbBatchHeaderSize is the size of a leveldb batch header which
 	// includes the sequence header and record counter.

--- a/node/database/ffldb/doc.go
+++ b/node/database/ffldb/doc.go
@@ -14,7 +14,8 @@ ensure data integrity.
 
 This package is a driver to the database package and provides the database type
 of "ffldb".  The parameters the Open and Create functions take are the
-database path as a string and the block network:
+database path as a string, the block network, and an optional cache flush
+interval in seconds (defaults to 3600):
 
 	db, err := database.Open("ffldb", "path/to/database", wire.MainNet)
 	if err != nil {

--- a/node/database/ffldb/driver.go
+++ b/node/database/ffldb/driver.go
@@ -19,48 +19,58 @@ const (
 )
 
 // parseArgs parses the arguments from the database Open/Create methods.
-func parseArgs(funcName string, args ...interface{}) (string, wire.PearlNet, error) {
-	if len(args) != 2 {
-		return "", 0, fmt.Errorf("invalid arguments to %s.%s -- "+
-			"expected database path and block network", dbType,
+func parseArgs(funcName string, args ...interface{}) (string, wire.PearlNet, uint32, error) {
+	if len(args) != 2 && len(args) != 3 {
+		return "", 0, 0, fmt.Errorf("invalid arguments to %s.%s -- "+
+			"expected database path, block network, and optional flush interval", dbType,
 			funcName)
 	}
 
 	dbPath, ok := args[0].(string)
 	if !ok {
-		return "", 0, fmt.Errorf("first argument to %s.%s is invalid -- "+
+		return "", 0, 0, fmt.Errorf("first argument to %s.%s is invalid -- "+
 			"expected database path string", dbType, funcName)
 	}
 
 	network, ok := args[1].(wire.PearlNet)
 	if !ok {
-		return "", 0, fmt.Errorf("second argument to %s.%s is invalid -- "+
+		return "", 0, 0, fmt.Errorf("second argument to %s.%s is invalid -- "+
 			"expected block network", dbType, funcName)
 	}
 
-	return dbPath, network, nil
+	var flushInterval uint32 = defaultFlushSecs
+	if len(args) == 3 {
+		var ok bool
+		flushInterval, ok = args[2].(uint32)
+		if !ok {
+			return "", 0, 0, fmt.Errorf("third argument to %s.%s is invalid -- "+
+				"expected flush interval in seconds", dbType, funcName)
+		}
+	}
+
+	return dbPath, network, flushInterval, nil
 }
 
 // openDBDriver is the callback provided during driver registration that opens
 // an existing database for use.
 func openDBDriver(args ...interface{}) (database.DB, error) {
-	dbPath, network, err := parseArgs("Open", args...)
+	dbPath, network, flushIntervalSecs, err := parseArgs("Open", args...)
 	if err != nil {
 		return nil, err
 	}
 
-	return openDB(dbPath, network, false)
+	return openDB(dbPath, network, false, flushIntervalSecs)
 }
 
 // createDBDriver is the callback provided during driver registration that
 // creates, initializes, and opens a database for use.
 func createDBDriver(args ...interface{}) (database.DB, error) {
-	dbPath, network, err := parseArgs("Create", args...)
+	dbPath, network, flushIntervalSecs, err := parseArgs("Create", args...)
 	if err != nil {
 		return nil, err
 	}
 
-	return openDB(dbPath, network, true)
+	return openDB(dbPath, network, true, flushIntervalSecs)
 }
 
 // useLogger is the callback provided during driver registration that sets the

--- a/node/database/ffldb/driver_test.go
+++ b/node/database/ffldb/driver_test.go
@@ -30,7 +30,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure that attempting to open a database that doesn't exist returns
 	// the expected error.
 	wantErrCode := database.ErrDbDoesNotExist
-	_, err := database.Open(dbType, "noexist", blockDataNet)
+	_, err := database.Open(dbType, "noexist", blockDataNet, uint32(300))
 	if !checkDbError(t, "Open", err, wantErrCode) {
 		return
 	}
@@ -38,8 +38,8 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure that attempting to open a database with the wrong number of
 	// parameters returns the expected error.
 	wantErr := fmt.Errorf("invalid arguments to %s.Open -- expected "+
-		"database path and block network", dbType)
-	_, err = database.Open(dbType, 1, 2, 3)
+		"database path, block network, and optional flush interval", dbType)
+	_, err = database.Open(dbType, 1, 2, 3, 4)
 	if err.Error() != wantErr.Error() {
 		t.Errorf("Open: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
@@ -71,8 +71,8 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure that attempting to create a database with the wrong number of
 	// parameters returns the expected error.
 	wantErr = fmt.Errorf("invalid arguments to %s.Create -- expected "+
-		"database path and block network", dbType)
-	_, err = database.Create(dbType, 1, 2, 3)
+		"database path, block network, and optional flush interval", dbType)
+	_, err = database.Create(dbType, 1, 2, 3, 4)
 	if err.Error() != wantErr.Error() {
 		t.Errorf("Create: did not receive expected error - got %v, "+
 			"want %v", err, wantErr)
@@ -105,7 +105,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// error.
 	dbPath := filepath.Join(t.TempDir(), "ffldb-createfail")
 	_ = os.RemoveAll(dbPath)
-	db, err := database.Create(dbType, dbPath, blockDataNet)
+	db, err := database.Create(dbType, dbPath, blockDataNet, uint32(300))
 	if err != nil {
 		t.Errorf("Create: unexpected error: %v", err)
 		return
@@ -155,7 +155,7 @@ func TestPersistence(t *testing.T) {
 	// Create a new database to run tests against.
 	dbPath := filepath.Join(t.TempDir(), "ffldb-persistencetest")
 	_ = os.RemoveAll(dbPath)
-	db, err := database.Create(dbType, dbPath, blockDataNet)
+	db, err := database.Create(dbType, dbPath, blockDataNet, uint32(300))
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
@@ -206,7 +206,7 @@ func TestPersistence(t *testing.T) {
 
 	// Close and reopen the database to ensure the values persist.
 	db.Close()
-	db, err = database.Open(dbType, dbPath, blockDataNet)
+	db, err = database.Open(dbType, dbPath, blockDataNet, uint32(300))
 	if err != nil {
 		t.Errorf("Failed to open test database (%s) %v", dbType, err)
 		return
@@ -260,7 +260,7 @@ func TestPrune(t *testing.T) {
 
 	// Create a new database to run tests against.
 	dbPath := t.TempDir()
-	db, err := database.Create(dbType, dbPath, blockDataNet)
+	db, err := database.Create(dbType, dbPath, blockDataNet, uint32(300))
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
@@ -449,7 +449,7 @@ func TestInterface(t *testing.T) {
 	// Create a new database to run tests against.
 	dbPath := filepath.Join(t.TempDir(), "ffldb-interfacetest")
 	_ = os.RemoveAll(dbPath)
-	db, err := database.Create(dbType, dbPath, blockDataNet)
+	db, err := database.Create(dbType, dbPath, blockDataNet, uint32(300))
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return

--- a/node/database/ffldb/whitebox_test.go
+++ b/node/database/ffldb/whitebox_test.go
@@ -179,7 +179,7 @@ func TestCornerCases(t *testing.T) {
 	// directory is needed.
 	testName := "openDB: fail due to file at target location"
 	wantErrCode := database.ErrDriverSpecific
-	idb, err := openDB(dbPath, blockDataNet, true)
+	idb, err := openDB(dbPath, blockDataNet, true, defaultFlushSecs)
 	if !checkDbError(t, testName, err, wantErrCode) {
 		if err == nil {
 			idb.Close()
@@ -191,7 +191,7 @@ func TestCornerCases(t *testing.T) {
 	// Remove the file and create the database to run tests against.  It
 	// should be successful this time.
 	_ = os.RemoveAll(dbPath)
-	idb, err = openDB(dbPath, blockDataNet, true)
+	idb, err = openDB(dbPath, blockDataNet, true, defaultFlushSecs)
 	if err != nil {
 		t.Errorf("openDB: unexpected error: %v", err)
 		return

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 0
-	Patch uint = 5
+	Patch uint = 6
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

During block connection, `connectBlock` holds `chainLock` and calls `db.Update` to flush the UTXO cache. `db.Update` acquires the database write lock, and if the ffldb cache needs flushing (every 5 minutes), `commitTx` performs an expensive LevelDB write + fsync while both locks are held. GBT requests that arrive during this window block on `chainLock` and can time out.

Three changes address this:

- **Fast-path `shouldFlush` before `db.Update`:** Extract the flush decision into `shouldFlush()` and call it before entering `db.Update` in `connectBlock`, `FlushUtxoCache`, and `InitConsistentState`. When no flush is needed, the database write lock is never acquired.
- **Non-erasing periodic flushes:** When `FlushPeriodic` triggers due to the 5-minute timer but memory is below the max, write modified entries to the database and clear their `tfModified`/`tfFresh` flags without evicting them from the in-memory cache. Spent/nil entries are removed. This avoids re-reading entries from disk on subsequent blocks while still persisting state for crash recovery.
- **Configurable ffldb cache flush interval:** Increase `defaultFlushSecs` from 300 to 3600 and expose it as `--dbcacheflushinterval` so node operators can tune the I/O profile. This reduces the frequency of the expensive LevelDB flush inside `commitTx` by 12x.

Additionally, the patch version is incremented to 1.0.6.

## Test plan

- [ ] `go test ./node/blockchain/ -run 'TestShouldFlush'` — verifies `shouldFlush` returns correct decisions for all `FlushMode` values and edge cases (hash match, timer expiry, memory threshold).
- [ ] `go test ./node/blockchain/ -run 'TestNonErasingFlushWithSpentEntries'` — verifies non-erasing flush removes spent entries from cache, keeps unspent entries with flags cleared, and correctly updates memory accounting and on-disk state.
- [ ] `go test ./node/blockchain/ -run 'TestNonErasingFlushThenSpend'` — verifies the full cycle: add → non-erasing flush (clears `tfFresh`) → spend → erasing flush correctly removes entries from both cache and database (no orphaned DB entries).
- [ ] `go test ./node/blockchain/ -run 'TestPeriodicFlushErasesWhenCacheFull'` — verifies `FlushPeriodic` performs an erasing flush when memory exceeds `maxTotalMemoryUsage`.
- [ ] `go test ./node/blockchain/ -run 'TestUtxoCacheFlush'` — existing test updated to assert non-erasing behavior on periodic flush.
- [ ] `go test ./node/database/ffldb/...` — all ffldb driver tests pass with the new optional flush interval argument.