### PR TITLE
[codex] add miner launcher and LoRA fine-tune entrypoint

### DIFF
--- a/miner/README.md
+++ b/miner/README.md
@@ -129,5 +129,87 @@ docker run --rm -it --gpus all \
   --enforce-eager
 ```
 
+## Single-node launcher
 
+For repeatable single-machine deployments, use `miner/run_pearl_miner.py` from
+the repository root. It keeps the official container entrypoint flow:
+`pearl-gateway start` followed by `vllm serve`, while standardizing GPU
+selection, vLLM tuning flags, and optional LoRA adapter loading.
+
+Preview a two-GPU Docker run:
+
+```bash
+python3 miner/run_pearl_miner.py \
+  --mode docker \
+  --gpus 0,1 \
+  --pearld-rpc-url http://127.0.0.1:44107 \
+  --pearld-rpc-user rpcuser \
+  --pearld-rpc-password rpcpass \
+  --mining-address <your-mining-address> \
+  --model pearl-ai/Llama-3.3-70B-Instruct-pearl \
+  --max-model-len 8192 \
+  --gpu-memory-utilization 0.9 \
+  --dry-run
+```
+
+Run it for real by removing `--dry-run`. The launcher automatically maps
+`--gpus 0,1` to `CUDA_VISIBLE_DEVICES=0,1` and
+`--tensor-parallel-size 2` unless you override `--tensor-parallel-size`.
+
+Load a fine-tuned LoRA adapter into vLLM:
+
+```bash
+python3 miner/run_pearl_miner.py \
+  --mode docker \
+  --gpus 0,1 \
+  --lora-adapter /host/adapters/pearl-lora \
+  --lora-name pearl_ft \
+  --pearld-rpc-url http://127.0.0.1:44107 \
+  --mining-address <your-mining-address>
+```
+
+For a local non-Docker run on a prepared machine:
+
+```bash
+python3 miner/run_pearl_miner.py \
+  --mode local \
+  --gpus 0 \
+  --pearld-rpc-url http://127.0.0.1:44107 \
+  --mining-address <your-mining-address>
+```
+
+Extra vLLM optimization flags can be appended repeatedly:
+
+```bash
+python3 miner/run_pearl_miner.py \
+  --mode docker \
+  --gpus 0,1 \
+  --extra-vllm-arg=--max-num-seqs \
+  --extra-vllm-arg 128
+```
+
+## Fine-tuning
+
+For a minimal LoRA/SFT fine-tune of a Pearl-compatible vLLM model, use
+`miner/fine_tune_lora.py` from the repository root. The script supports local
+JSON/JSONL/CSV files or Hugging Face datasets. Each row can contain one of
+`text`, `prompt` plus `completion`, or `messages` in chat-template format.
+
+```bash
+uv run \
+  --with transformers \
+  --with datasets \
+  --with peft \
+  --with accelerate \
+  --with bitsandbytes \
+  miner/fine_tune_lora.py \
+  --model pearl-ai/Llama-3.3-70B-Instruct-pearl \
+  --dataset ./train.jsonl \
+  --output-dir ./outputs/pearl-lora \
+  --load-in-4bit \
+  --bf16
+```
+
+The output directory contains the LoRA adapter and tokenizer files. Pass
+`--merge` to also write a merged model under `<output-dir>/merged`.
 

--- a/miner/fine_tune_lora.py
+++ b/miner/fine_tune_lora.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_TARGET_MODULES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+
+
+@dataclass(frozen=True)
+class FineTuneConfig:
+    model: str = "pearl-ai/Llama-3.3-70B-Instruct-pearl"
+    dataset: str = ""
+    dataset_split: str = "train"
+    output_dir: str = "outputs/pearl-lora"
+    text_field: str = "text"
+    max_seq_length: int = 2048
+    num_train_epochs: float = 1.0
+    per_device_train_batch_size: int = 1
+    gradient_accumulation_steps: int = 8
+    learning_rate: float = 2e-4
+    logging_steps: int = 10
+    save_steps: int = 200
+    save_total_limit: int = 2
+    warmup_ratio: float = 0.03
+    lora_r: int = 16
+    lora_alpha: int = 32
+    lora_dropout: float = 0.05
+    lora_target_modules: tuple[str, ...] = DEFAULT_TARGET_MODULES
+    load_in_4bit: bool = False
+    bf16: bool = False
+    fp16: bool = False
+    gradient_checkpointing: bool = True
+    merge: bool = False
+    trust_remote_code: bool = True
+
+
+def parse_target_modules(value: str) -> tuple[str, ...]:
+    modules = tuple(item.strip() for item in value.split(",") if item.strip())
+    if not modules:
+        raise ValueError("at least one LoRA target module is required")
+    return modules
+
+
+def extract_text(example: dict[str, object], tokenizer: object, text_field: str) -> str:
+    if text_field in example and example[text_field] is not None:
+        return str(example[text_field])
+    if "prompt" in example and "completion" in example:
+        return f"{example['prompt']}\n{example['completion']}"
+    messages = example.get("messages")
+    if isinstance(messages, list):
+        apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+        if callable(apply_chat_template):
+            return str(
+                apply_chat_template(
+                    messages,
+                    tokenize=False,
+                    add_generation_prompt=False,
+                )
+            )
+        return "\n".join(
+            f"{message.get('role', 'unknown')}: {message.get('content', '')}"
+            for message in messages
+            if isinstance(message, dict)
+        )
+    raise ValueError(f"example must contain '{text_field}', prompt+completion, or messages fields")
+
+
+def load_training_dataset(datasets_module: object, config: FineTuneConfig) -> object:
+    load_dataset = datasets_module.load_dataset
+    suffix = Path(config.dataset).suffix.lower()
+    if suffix in {".json", ".jsonl"}:
+        return load_dataset("json", data_files=config.dataset, split=config.dataset_split)
+    if suffix == ".csv":
+        return load_dataset("csv", data_files=config.dataset, split=config.dataset_split)
+    return load_dataset(config.dataset, split=config.dataset_split)
+
+
+def build_training_arguments(
+    config: FineTuneConfig,
+    training_arguments_cls: Callable[..., object],
+) -> object:
+    return training_arguments_cls(
+        output_dir=config.output_dir,
+        num_train_epochs=config.num_train_epochs,
+        per_device_train_batch_size=config.per_device_train_batch_size,
+        gradient_accumulation_steps=config.gradient_accumulation_steps,
+        learning_rate=config.learning_rate,
+        logging_steps=config.logging_steps,
+        save_steps=config.save_steps,
+        save_total_limit=config.save_total_limit,
+        warmup_ratio=config.warmup_ratio,
+        bf16=config.bf16,
+        fp16=config.fp16,
+        report_to="none",
+        remove_unused_columns=False,
+    )
+
+
+def tokenize_dataset(dataset: object, tokenizer: object, config: FineTuneConfig) -> object:
+    column_names = getattr(dataset, "column_names", None)
+
+    def tokenize(example: dict[str, object]) -> dict[str, object]:
+        text = extract_text(example, tokenizer, config.text_field)
+        return tokenizer(
+            text,
+            max_length=config.max_seq_length,
+            truncation=True,
+            padding=False,
+        )
+
+    kwargs: dict[str, object] = {}
+    if column_names:
+        kwargs["remove_columns"] = column_names
+    return dataset.map(tokenize, **kwargs)
+
+
+def run_fine_tune(config: FineTuneConfig) -> None:
+    import datasets  # noqa: PLC0415 - optional fine-tune dependency.
+    from peft import (  # noqa: PLC0415 - optional fine-tune dependency.
+        LoraConfig,
+        get_peft_model,
+        prepare_model_for_kbit_training,
+    )
+    from transformers import (  # noqa: PLC0415 - optional fine-tune dependency.
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        DataCollatorForLanguageModeling,
+        Trainer,
+        TrainingArguments,
+    )
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        config.model,
+        trust_remote_code=config.trust_remote_code,
+    )
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model_kwargs: dict[str, object] = {
+        "device_map": "auto",
+        "trust_remote_code": config.trust_remote_code,
+    }
+    if config.load_in_4bit:
+        from transformers import BitsAndBytesConfig  # noqa: PLC0415
+
+        model_kwargs["quantization_config"] = BitsAndBytesConfig(
+            load_in_4bit=True,
+            bnb_4bit_quant_type="nf4",
+            bnb_4bit_compute_dtype="bfloat16" if config.bf16 else "float16",
+        )
+
+    model = AutoModelForCausalLM.from_pretrained(config.model, **model_kwargs)
+    if config.gradient_checkpointing:
+        model.gradient_checkpointing_enable()
+    if config.load_in_4bit:
+        model = prepare_model_for_kbit_training(model)
+
+    lora_config = LoraConfig(
+        r=config.lora_r,
+        lora_alpha=config.lora_alpha,
+        lora_dropout=config.lora_dropout,
+        target_modules=list(config.lora_target_modules),
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+    model = get_peft_model(model, lora_config)
+
+    dataset = load_training_dataset(datasets, config)
+    tokenized = tokenize_dataset(dataset, tokenizer, config)
+    training_args = build_training_arguments(config, TrainingArguments)
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized,
+        data_collator=DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False),
+    )
+    trainer.train()
+    trainer.save_model(config.output_dir)
+    tokenizer.save_pretrained(config.output_dir)
+
+    if config.merge:
+        merged_dir = str(Path(config.output_dir) / "merged")
+        merged_model = model.merge_and_unload()
+        merged_model.save_pretrained(merged_dir, safe_serialization=True)
+        tokenizer.save_pretrained(merged_dir)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Minimal LoRA SFT fine-tune entrypoint for Pearl-compatible vLLM models."
+    )
+    parser.add_argument("--model", default=FineTuneConfig.model)
+    parser.add_argument("--dataset", required=True)
+    parser.add_argument("--dataset-split", default="train")
+    parser.add_argument("--output-dir", default=FineTuneConfig.output_dir)
+    parser.add_argument("--text-field", default="text")
+    parser.add_argument("--max-seq-length", type=int, default=2048)
+    parser.add_argument("--num-train-epochs", type=float, default=1.0)
+    parser.add_argument("--per-device-train-batch-size", type=int, default=1)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=8)
+    parser.add_argument("--learning-rate", type=float, default=2e-4)
+    parser.add_argument("--logging-steps", type=int, default=10)
+    parser.add_argument("--save-steps", type=int, default=200)
+    parser.add_argument("--save-total-limit", type=int, default=2)
+    parser.add_argument("--warmup-ratio", type=float, default=0.03)
+    parser.add_argument("--lora-r", type=int, default=16)
+    parser.add_argument("--lora-alpha", type=int, default=32)
+    parser.add_argument("--lora-dropout", type=float, default=0.05)
+    parser.add_argument(
+        "--lora-target-modules",
+        default=",".join(DEFAULT_TARGET_MODULES),
+        help="comma-separated module names, for example q_proj,v_proj,o_proj",
+    )
+    parser.add_argument("--load-in-4bit", action="store_true")
+    parser.add_argument("--bf16", action="store_true")
+    parser.add_argument("--fp16", action="store_true")
+    parser.add_argument("--no-gradient-checkpointing", action="store_true")
+    parser.add_argument("--merge", action="store_true")
+    parser.add_argument("--no-trust-remote-code", action="store_true")
+    return parser.parse_args(argv)
+
+
+def config_from_args(args: argparse.Namespace) -> FineTuneConfig:
+    return FineTuneConfig(
+        model=args.model,
+        dataset=args.dataset,
+        dataset_split=args.dataset_split,
+        output_dir=args.output_dir,
+        text_field=args.text_field,
+        max_seq_length=args.max_seq_length,
+        num_train_epochs=args.num_train_epochs,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        learning_rate=args.learning_rate,
+        logging_steps=args.logging_steps,
+        save_steps=args.save_steps,
+        save_total_limit=args.save_total_limit,
+        warmup_ratio=args.warmup_ratio,
+        lora_r=args.lora_r,
+        lora_alpha=args.lora_alpha,
+        lora_dropout=args.lora_dropout,
+        lora_target_modules=parse_target_modules(args.lora_target_modules),
+        load_in_4bit=args.load_in_4bit,
+        bf16=args.bf16,
+        fp16=args.fp16,
+        gradient_checkpointing=not args.no_gradient_checkpointing,
+        merge=args.merge,
+        trust_remote_code=not args.no_trust_remote_code,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    run_fine_tune(config_from_args(args))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/miner/run_pearl_miner.py
+++ b/miner/run_pearl_miner.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import FrameType
+
+DEFAULT_MODEL = "pearl-ai/Llama-3.3-70B-Instruct-pearl"
+DEFAULT_IMAGE = "vllm_miner:latest"
+DEFAULT_CACHE_MOUNT = str(Path.home() / ".cache" / "huggingface")
+
+
+@dataclass(frozen=True)
+class MinerRunConfig:
+    mode: str = "docker"
+    image: str = DEFAULT_IMAGE
+    model: str = DEFAULT_MODEL
+    gpus: tuple[str, ...] = ("all",)
+    tensor_parallel_size: int = 0
+    pearld_rpc_url: str = "http://127.0.0.1:44107"
+    pearld_rpc_user: str = "user"
+    pearld_rpc_password: str = "pass"
+    mining_address: str = ""
+    hf_token: str = ""
+    api_host: str = "0.0.0.0"
+    api_port: int = 8000
+    max_model_len: int = 8192
+    gpu_memory_utilization: float = 0.9
+    enforce_eager: bool = True
+    shm_size: str = "8g"
+    network_host: bool = True
+    cache_mount: str = DEFAULT_CACHE_MOUNT
+    lora_adapter: str = ""
+    lora_name: str = "pearl_ft"
+    extra_vllm_args: tuple[str, ...] = field(default_factory=tuple)
+    dry_run: bool = False
+
+
+class StopFlag:
+    def __init__(self) -> None:
+        self.requested = False
+
+    def request_stop(self, _signum: int | None = None, _frame: FrameType | None = None) -> None:
+        self.requested = True
+
+
+def build_docker_run_command(config: MinerRunConfig) -> list[str]:
+    command = [
+        "docker",
+        "run",
+        "--rm",
+        "-it",
+        "--gpus",
+        "all",
+    ]
+    if config.network_host:
+        command.extend(["--network", "host"])
+    else:
+        command.extend(
+            ["-p", f"{config.api_port}:{config.api_port}", "-p", "8337:8337", "-p", "8339:8339"]
+        )
+    command.extend(["--shm-size", config.shm_size])
+    for env_name, env_value in docker_env(config).items():
+        if env_value != "":
+            command.extend(["-e", f"{env_name}={env_value}"])
+    if config.cache_mount:
+        command.extend(["-v", f"{config.cache_mount}:/root/.cache/huggingface"])
+    if config.lora_adapter:
+        command.extend(["-v", f"{config.lora_adapter}:{container_lora_path(config)}:ro"])
+    command.append(config.image)
+    command.extend(build_vllm_args(config, docker=True))
+    return command
+
+
+def build_local_commands(config: MinerRunConfig) -> tuple[dict[str, str], list[str], list[str]]:
+    env = local_env(config)
+    return (
+        env,
+        ["pearl-gateway", "start"],
+        ["vllm", "serve", *build_vllm_args(config, docker=False)],
+    )
+
+
+def docker_env(config: MinerRunConfig) -> dict[str, str]:
+    env = base_env(config)
+    env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices(config.gpus)
+    env["MINER_RPC_TRANSPORT"] = "tcp"
+    return env
+
+
+def local_env(config: MinerRunConfig) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(base_env(config))
+    env["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices(config.gpus)
+    return env
+
+
+def base_env(config: MinerRunConfig) -> dict[str, str]:
+    return {
+        "PEARLD_RPC_URL": config.pearld_rpc_url,
+        "PEARLD_RPC_USER": config.pearld_rpc_user,
+        "PEARLD_RPC_PASSWORD": config.pearld_rpc_password,
+        "PEARLD_MINING_ADDRESS": config.mining_address,
+        "HF_TOKEN": config.hf_token,
+    }
+
+
+def build_vllm_args(config: MinerRunConfig, docker: bool) -> list[str]:
+    args = [
+        config.model,
+        "--host",
+        config.api_host,
+        "--port",
+        str(config.api_port),
+        "--max-model-len",
+        str(config.max_model_len),
+        "--gpu-memory-utilization",
+        str(config.gpu_memory_utilization),
+        "--tensor-parallel-size",
+        str(effective_tensor_parallel_size(config)),
+    ]
+    if config.enforce_eager:
+        args.append("--enforce-eager")
+    if config.lora_adapter:
+        args.extend(
+            [
+                "--enable-lora",
+                "--lora-modules",
+                f"{config.lora_name}={container_lora_path(config) if docker else config.lora_adapter}",
+            ]
+        )
+    args.extend(config.extra_vllm_args)
+    return args
+
+
+def container_lora_path(config: MinerRunConfig) -> str:
+    return f"/models/{config.lora_name}"
+
+
+def effective_tensor_parallel_size(config: MinerRunConfig) -> int:
+    if config.tensor_parallel_size > 0:
+        return config.tensor_parallel_size
+    return 1 if config.gpus == ("all",) else len(config.gpus)
+
+
+def cuda_visible_devices(gpus: tuple[str, ...]) -> str:
+    if gpus == ("all",):
+        return ""
+    return ",".join(gpus)
+
+
+def parse_gpus(value: str) -> tuple[str, ...]:
+    normalized = value.strip().lower()
+    if normalized in {"", "all"}:
+        return ("all",)
+    return tuple(item.strip() for item in value.split(",") if item.strip())
+
+
+def print_command(command: list[str]) -> None:
+    print(" ".join(shlex.quote(part) for part in command), flush=True)
+
+
+def run_docker(config: MinerRunConfig) -> int:
+    command = build_docker_run_command(config)
+    if config.dry_run:
+        print_command(command)
+        return 0
+    return subprocess.call(command)
+
+
+def run_local(config: MinerRunConfig) -> int:
+    env, gateway_command, vllm_command = build_local_commands(config)
+    if config.dry_run:
+        print(
+            " ".join(
+                f"{key}={shlex.quote(value)}"
+                for key, value in sorted(base_env(config).items())
+                if value
+            )
+        )
+        print_command(gateway_command)
+        print_command(vllm_command)
+        return 0
+
+    stop = StopFlag()
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(signum, stop.request_stop)
+    gateway = subprocess.Popen(gateway_command, env=env)
+    try:
+        time.sleep(2)
+        vllm = subprocess.Popen(vllm_command, env=env)
+        while not stop.requested:
+            code = vllm.poll()
+            if code is not None:
+                return code
+            time.sleep(1)
+        vllm.terminate()
+        return vllm.wait(timeout=30)
+    finally:
+        gateway.terminate()
+        try:
+            gateway.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            gateway.kill()
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Launch the official Pearl vLLM miner for single-node multi-GPU or Docker runs."
+    )
+    parser.add_argument("--mode", choices=("docker", "local"), default="docker")
+    parser.add_argument("--image", default=DEFAULT_IMAGE)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument(
+        "--gpus", default="all", help="all or a comma-separated list, for example 0,1"
+    )
+    parser.add_argument("--tensor-parallel-size", type=int, default=0)
+    parser.add_argument("--pearld-rpc-url", default="http://127.0.0.1:44107")
+    parser.add_argument("--pearld-rpc-user", default="user")
+    parser.add_argument("--pearld-rpc-password", default="pass")
+    parser.add_argument("--mining-address", default="")
+    parser.add_argument("--hf-token", default=os.environ.get("HF_TOKEN", ""))
+    parser.add_argument("--api-host", default="0.0.0.0")
+    parser.add_argument("--api-port", type=int, default=8000)
+    parser.add_argument("--max-model-len", type=int, default=8192)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.9)
+    parser.add_argument("--no-enforce-eager", action="store_true")
+    parser.add_argument("--shm-size", default="8g")
+    parser.add_argument("--no-network-host", action="store_true")
+    parser.add_argument("--cache-mount", default=DEFAULT_CACHE_MOUNT)
+    parser.add_argument("--lora-adapter", default="")
+    parser.add_argument("--lora-name", default="pearl_ft")
+    parser.add_argument("--extra-vllm-arg", action="append", default=[])
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def config_from_args(args: argparse.Namespace) -> MinerRunConfig:
+    gpus = parse_gpus(args.gpus)
+    tensor_parallel_size = args.tensor_parallel_size
+    if tensor_parallel_size <= 0:
+        tensor_parallel_size = 1 if gpus == ("all",) else len(gpus)
+    return MinerRunConfig(
+        mode=args.mode,
+        image=args.image,
+        model=args.model,
+        gpus=gpus,
+        tensor_parallel_size=tensor_parallel_size,
+        pearld_rpc_url=args.pearld_rpc_url,
+        pearld_rpc_user=args.pearld_rpc_user,
+        pearld_rpc_password=args.pearld_rpc_password,
+        mining_address=args.mining_address,
+        hf_token=args.hf_token,
+        api_host=args.api_host,
+        api_port=args.api_port,
+        max_model_len=args.max_model_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+        enforce_eager=not args.no_enforce_eager,
+        shm_size=args.shm_size,
+        network_host=not args.no_network_host,
+        cache_mount=args.cache_mount,
+        lora_adapter=args.lora_adapter,
+        lora_name=args.lora_name,
+        extra_vllm_args=tuple(args.extra_vllm_arg),
+        dry_run=args.dry_run,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    config = config_from_args(parse_args(sys.argv[1:] if argv is None else argv))
+    if config.mode == "docker":
+        return run_docker(config)
+    return run_local(config)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fine_tune_lora.py
+++ b/tests/test_fine_tune_lora.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+
+fine_tune_lora = importlib.import_module("fine_tune_lora")
+
+
+class FakeTokenizer:
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        tokenize: bool = False,
+        add_generation_prompt: bool = False,
+    ) -> str:
+        assert not tokenize
+        assert not add_generation_prompt
+        return "\n".join(f"{message['role']}: {message['content']}" for message in messages)
+
+
+class FakeDatasetsModule:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def load_dataset(self, name: str, **kwargs: object) -> dict[str, object]:
+        self.calls.append((name, kwargs))
+        return {"name": name, "kwargs": kwargs}
+
+
+class FineTuneLoraTest(unittest.TestCase):
+    def test_parse_target_modules_trims_and_drops_empty_items(self) -> None:
+        result = fine_tune_lora.parse_target_modules("q_proj, v_proj,, o_proj ")
+
+        self.assertEqual(result, ("q_proj", "v_proj", "o_proj"))
+
+    def test_extract_text_supports_common_sft_shapes(self) -> None:
+        tokenizer = FakeTokenizer()
+
+        self.assertEqual(
+            fine_tune_lora.extract_text({"text": "hello"}, tokenizer, text_field="text"),
+            "hello",
+        )
+        self.assertEqual(
+            fine_tune_lora.extract_text(
+                {"prompt": "Q", "completion": "A"},
+                tokenizer,
+                text_field="text",
+            ),
+            "Q\nA",
+        )
+        self.assertEqual(
+            fine_tune_lora.extract_text(
+                {"messages": [{"role": "user", "content": "hi"}]},
+                tokenizer,
+                text_field="text",
+            ),
+            "user: hi",
+        )
+
+    def test_load_training_dataset_uses_json_loader_for_jsonl_file(self) -> None:
+        datasets = FakeDatasetsModule()
+        config = fine_tune_lora.FineTuneConfig(dataset="train.jsonl", dataset_split="train")
+
+        result = fine_tune_lora.load_training_dataset(datasets, config)
+
+        self.assertEqual(result["name"], "json")
+        self.assertEqual(datasets.calls[0][1]["data_files"], "train.jsonl")
+        self.assertEqual(datasets.calls[0][1]["split"], "train")
+
+    def test_build_training_arguments_passes_minimal_lora_defaults(self) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeTrainingArguments:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+        config = fine_tune_lora.FineTuneConfig(
+            output_dir="out",
+            num_train_epochs=2.0,
+            per_device_train_batch_size=2,
+            gradient_accumulation_steps=4,
+            learning_rate=1e-4,
+        )
+
+        fine_tune_lora.build_training_arguments(config, FakeTrainingArguments)
+
+        self.assertEqual(captured["output_dir"], "out")
+        self.assertEqual(captured["num_train_epochs"], 2.0)
+        self.assertEqual(captured["per_device_train_batch_size"], 2)
+        self.assertEqual(captured["gradient_accumulation_steps"], 4)
+        self.assertEqual(captured["learning_rate"], 1e-4)
+        self.assertEqual(captured["report_to"], "none")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_run_pearl_miner.py
+++ b/tests/test_run_pearl_miner.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import importlib
+import unittest
+
+run_pearl_miner = importlib.import_module("run_pearl_miner")
+
+
+class RunPearlMinerTest(unittest.TestCase):
+    def test_docker_command_uses_official_vllm_miner_image_and_multigpu_env(self) -> None:
+        config = run_pearl_miner.MinerRunConfig(
+            mode="docker",
+            gpus=("0", "1"),
+            pearld_rpc_url="http://node:44107",
+            pearld_rpc_user="user",
+            pearld_rpc_password="pass",
+            mining_address="prl1test",
+            model="pearl-ai/Llama-3.3-70B-Instruct-pearl",
+        )
+
+        command = run_pearl_miner.build_docker_run_command(config)
+
+        self.assertEqual(command[:5], ["docker", "run", "--rm", "-it", "--gpus"])
+        self.assertIn("vllm_miner:latest", command)
+        self.assertIn("CUDA_VISIBLE_DEVICES=0,1", command)
+        self.assertIn("--tensor-parallel-size", command)
+        self.assertIn("2", command)
+        self.assertIn("PEARLD_RPC_URL=http://node:44107", command)
+        self.assertIn("PEARLD_MINING_ADDRESS=prl1test", command)
+
+    def test_lora_adapter_adds_vllm_lora_flags_and_mount(self) -> None:
+        config = run_pearl_miner.MinerRunConfig(
+            mode="docker",
+            lora_adapter="/host/adapters/pearl-lora",
+            lora_name="pearl_ft",
+        )
+
+        command = run_pearl_miner.build_docker_run_command(config)
+
+        self.assertIn("/host/adapters/pearl-lora:/models/pearl_ft:ro", command)
+        self.assertIn("--enable-lora", command)
+        self.assertIn("--lora-modules", command)
+        self.assertIn("pearl_ft=/models/pearl_ft", command)
+
+    def test_local_commands_start_gateway_then_vllm_with_same_optimization_flags(self) -> None:
+        config = run_pearl_miner.MinerRunConfig(
+            mode="local",
+            gpus=("0",),
+            max_model_len=4096,
+            gpu_memory_utilization=0.92,
+            enforce_eager=True,
+            extra_vllm_args=("--max-num-seqs", "128"),
+        )
+
+        env, gateway_command, vllm_command = run_pearl_miner.build_local_commands(config)
+
+        self.assertEqual(env["CUDA_VISIBLE_DEVICES"], "0")
+        self.assertEqual(gateway_command, ["pearl-gateway", "start"])
+        self.assertEqual(vllm_command[:3], ["vllm", "serve", config.model])
+        self.assertIn("--max-model-len", vllm_command)
+        self.assertIn("4096", vllm_command)
+        self.assertIn("--gpu-memory-utilization", vllm_command)
+        self.assertIn("0.92", vllm_command)
+        self.assertIn("--enforce-eager", vllm_command)
+        self.assertEqual(vllm_command[-2:], ["--max-num-seqs", "128"])
+
+    def test_parse_args_defaults_tensor_parallel_to_gpu_count(self) -> None:
+        args = run_pearl_miner.parse_args(["--gpus", "0,1,2", "--dry-run"])
+        config = run_pearl_miner.config_from_args(args)
+
+        self.assertEqual(config.gpus, ("0", "1", "2"))
+        self.assertEqual(config.tensor_parallel_size, 3)
+        self.assertTrue(config.dry_run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `miner/run_pearl_miner.py` for official vLLM miner Docker/local launches with single-node multi-GPU tuning.
- Add LoRA adapter loading support through vLLM `--enable-lora --lora-modules`.
- Add `miner/fine_tune_lora.py` for minimal LoRA/SFT adapter training and document the A+C workflow.

## Validation
- `PYTHONPATH=/Users/bytedance/pearl-mining/pearl-src/miner python3 -m unittest tests.test_run_pearl_miner tests.test_fine_tune_lora -v`
- `uv run --with ruff ruff check miner/run_pearl_miner.py miner/fine_tune_lora.py tests/test_run_pearl_miner.py tests/test_fine_tune_lora.py`
- `python3 -m py_compile miner/run_pearl_miner.py miner/fine_tune_lora.py tests/test_run_pearl_miner.py tests/test_fine_tune_lora.py`

## Notes
This intentionally wraps the existing official `pearl-gateway start` plus `vllm serve` flow instead of replacing miner internals.