### PR TITLE
fix(rpc): use chain.IsCurrent for getblocktemplate IBD check

### DIFF
--- a/node/rpcserver.go
+++ b/node/rpcserver.go
@@ -1933,7 +1933,7 @@ func handleGetBlockTemplateRequest(s *rpcServer, request *btcjson.TemplateReques
 
 	// No point in generating or accepting work before the chain is synced.
 	currentHeight := s.cfg.Chain.BestSnapshot().Height
-	if currentHeight != 0 && !s.cfg.SyncMgr.IsCurrent() {
+	if currentHeight != 0 && !s.cfg.Chain.IsCurrent() {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCClientInInitialDownload,
 			Message: "Pearl is downloading blocks...",


### PR DESCRIPTION
getblocktemplate was using `SyncMgr.IsCurrent()` to check if the node is still in IBD. `Chain.IsCurrent()` is more accurate as it reflects the actual chain state directly.

One-line fix in `handleGetBlockTemplateRequest`.