### PR TITLE
feat(miner): add GB10 reference backend support

### DIFF
--- a/miner/README.md
+++ b/miner/README.md
@@ -39,11 +39,23 @@ uv sync --package vllm-miner
 
 The `pearl-gemm` CUDA kernels are compiled automatically during sync. Set the `PEARL_GEMM_FORCE_BUILD` environment variable to `TRUE` to force a rebuild, or set `PEARL_GEMM_SKIP_CUDA_BUILD=TRUE` to skip the CUDA build entirely.
 
+### CUDA architecture selection
+
+`pearl-gemm` defaults to the existing Hopper `sm_90a` target. To override the build target, set `PEARL_GEMM_CUDA_ARCHS` to a comma, semicolon, or space separated list of CUDA architectures:
+
+```bash
+PEARL_GEMM_CUDA_ARCHS=90a uv sync --package vllm-miner
+PEARL_GEMM_CUDA_ARCHS=121 uv sync --package vllm-miner
+PEARL_GEMM_CUDA_ARCHS=native uv sync --package vllm-miner
+```
+
+When a Blackwell consumer GPU such as GB10 / `sm_121` is detected, the build target is selected explicitly and `setup.py` emits a warning. Hopper remains the optimized kernel path. GB10 uses a functional reference backend for GEMM/noising/hash operations plus a bounded CPU proof scan for local/easy mining jobs; a production-performance Blackwell kernel backend is still required for competitive mining.
+
 ## Tests
 
 All commands run from the **repository root**. Use `-n auto` to run tests in parallel (requires `pytest-xdist`).
 
-> **GPU requirement:** `pearl-gemm` and `vllm-miner` tests require an NVIDIA GPU. Currently only **sm90** (H100 / H200) GPUs are supported.
+> **GPU requirement:** `pearl-gemm` and `vllm-miner` tests require an NVIDIA GPU. Optimized kernels target **sm90** (H100 / H200); GB10 / `sm_121` is supported through the reference backend described above.
 
 ### Basic tests
 

--- a/miner/pearl-gemm/csrc/gemm/pearl_gemm_api.cpp
+++ b/miner/pearl-gemm/csrc/gemm/pearl_gemm_api.cpp
@@ -2,6 +2,7 @@
 // of the torch headers.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/ops/_int_mm_ops.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/nn/functional.h>
 #include <torch/python.h>
@@ -111,6 +112,164 @@ void check_tensor(
   CHECK_SHAPE(tensor, x, y);
 }
 
+namespace {
+
+constexpr int64_t kReferenceBackendPadMultiple = 128;
+
+bool use_reference_backend() {
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+  return dprops != nullptr && dprops->major >= 10;
+}
+
+int64_t round_up_to_multiple(int64_t value, int64_t multiple) {
+  return ((value + multiple - 1) / multiple) * multiple;
+}
+
+at::Tensor safe_int_mm(const at::Tensor& lhs, const at::Tensor& rhs) {
+  TORCH_CHECK(lhs.dim() == 2 && rhs.dim() == 2,
+              "safe_int_mm expects 2D tensors");
+  TORCH_CHECK(lhs.size(1) == rhs.size(0), "safe_int_mm shape mismatch");
+  TORCH_CHECK(lhs.scalar_type() == torch::kInt8 &&
+                  rhs.scalar_type() == torch::kInt8,
+              "safe_int_mm expects int8 inputs");
+
+  const int64_t m = lhs.size(0);
+  const int64_t k = lhs.size(1);
+  const int64_t n = rhs.size(1);
+  const int64_t padded_m = round_up_to_multiple(m, kReferenceBackendPadMultiple);
+  const int64_t padded_n = round_up_to_multiple(n, kReferenceBackendPadMultiple);
+
+  at::Tensor lhs_work = lhs.contiguous();
+  at::Tensor rhs_work = rhs.contiguous();
+
+  if (padded_m != m) {
+    lhs_work = at::zeros({padded_m, k}, lhs.options());
+    lhs_work.narrow(0, 0, m).copy_(lhs);
+  }
+
+  if (padded_n != n) {
+    rhs_work = at::zeros({k, padded_n}, rhs.options());
+    rhs_work.narrow(1, 0, n).copy_(rhs);
+  }
+
+  at::Tensor result = at::_ops::_int_mm::call(lhs_work, rhs_work);
+  if (padded_m != m || padded_n != n) {
+    result = result.narrow(0, 0, m).narrow(1, 0, n).contiguous();
+  }
+  return result;
+}
+
+void copy_scaled_int32_to_dtype(const at::Tensor& src, at::Tensor& dst,
+                                double scale) {
+  at::Tensor tmp = src.to(torch::kFloat32);
+  tmp.mul_(scale);
+  dst.copy_(tmp.to(dst.scalar_type()));
+}
+
+void reference_denoise_converter_impl(
+    const std::optional<at::Tensor>& EARxBpEB_in_,
+    const std::optional<at::Tensor>& AxEBL_in_,
+    const std::optional<at::Tensor>& EARxBpEB_out_,
+    const std::optional<at::Tensor>& AxEBL_out_) {
+  if (AxEBL_in_.has_value() && AxEBL_out_.has_value()) {
+    copy_scaled_int32_to_dtype(AxEBL_in_.value(),
+                               const_cast<at::Tensor&>(AxEBL_out_.value()),
+                               1.0 / static_cast<double>(pearl::kAxEBLScaleFactor));
+  }
+  if (EARxBpEB_in_.has_value() && EARxBpEB_out_.has_value()) {
+    copy_scaled_int32_to_dtype(
+        EARxBpEB_in_.value(), const_cast<at::Tensor&>(EARxBpEB_out_.value()),
+        1.0 / static_cast<double>(pearl::kEARxBpEBScaleFactor));
+  }
+}
+
+void reference_noise_A_impl(at::Tensor& A, at::Tensor& EAL, at::Tensor& AxEBL,
+                            at::Tensor& ApEA, at::Tensor& EAR,
+                            at::Tensor& EBL) {
+  at::Tensor EA = safe_int_mm(EAL, EAR.transpose(0, 1).contiguous());
+  at::Tensor ApEA_int32 = A.to(torch::kInt32).add(EA);
+  ApEA.copy_(ApEA_int32.to(torch::kInt8));
+
+  at::Tensor AxEBL_int32 = safe_int_mm(A, EBL.transpose(0, 1).contiguous());
+  if (AxEBL.scalar_type() == torch::kFloat16) {
+    copy_scaled_int32_to_dtype(
+        AxEBL_int32, AxEBL,
+        1.0 / static_cast<double>(pearl::kAxEBLScaleFactor));
+  } else {
+    AxEBL.copy_(AxEBL_int32);
+  }
+}
+
+void reference_noise_B_impl(at::Tensor& B, at::Tensor& EBR,
+                            at::Tensor& EARxBpEB, at::Tensor& BpEB,
+                            at::Tensor& EAR, at::Tensor& EBL) {
+  at::Tensor EB = safe_int_mm(EBR, EBL.transpose(0, 1).contiguous());
+  at::Tensor BpEB_int32 = B.to(torch::kInt32).add(EB);
+  BpEB.copy_(BpEB_int32.to(torch::kInt8));
+
+  at::Tensor EARxBpEB_int32 =
+      safe_int_mm(BpEB, EAR.transpose(0, 1).contiguous());
+  if (EARxBpEB.scalar_type() == torch::kFloat16) {
+    copy_scaled_int32_to_dtype(
+        EARxBpEB_int32, EARxBpEB,
+        1.0 / static_cast<double>(pearl::kEARxBpEBScaleFactor));
+  } else {
+    EARxBpEB.copy_(EARxBpEB_int32);
+  }
+}
+
+void reference_gemm_impl(at::Tensor& A, at::Tensor& B, at::Tensor& A_scales,
+                         at::Tensor& B_scales, at::Tensor& C) {
+  at::Tensor acc = safe_int_mm(A, B.transpose(0, 1).contiguous());
+  at::Tensor scaled = acc.to(torch::kFloat32);
+  scaled.mul_(A_scales.view({A.size(0), 1}));
+  scaled.mul_(B_scales.view({1, B.size(0)}));
+  C.copy_(scaled.to(C.scalar_type()));
+}
+
+void reference_noisy_gemm_impl(
+    at::Tensor& A, at::Tensor& B, at::Tensor& EAL, at::Tensor& EBR,
+    at::Tensor& EAR_R_major, at::Tensor& EBL_R_major, at::Tensor& EAR_K_major,
+    at::Tensor& EBL_K_major, at::Tensor& AxEBL_fp16,
+    at::Tensor& EARxBpEB_fp16, at::Tensor& ApEA, at::Tensor& BpEB,
+    at::Tensor& A_scales, at::Tensor& B_scales, at::Tensor& C,
+    at::Tensor& host_signal_header_pinned,
+    const std::optional<at::Tensor>& AxEBL_int32_,
+    const std::optional<at::Tensor>& EARxBpEB_int32_, bool run_noising_a,
+    bool run_noising_b, bool skip_denoising) {
+  at::Tensor AxEBL_target = AxEBL_int32_.has_value() ? AxEBL_int32_.value()
+                                                     : AxEBL_fp16;
+  at::Tensor EARxBpEB_target = EARxBpEB_int32_.has_value()
+                                   ? EARxBpEB_int32_.value()
+                                   : EARxBpEB_fp16;
+
+  if (run_noising_a) {
+    reference_noise_A_impl(A, EAL, AxEBL_target, ApEA, EAR_R_major,
+                           EBL_K_major);
+  }
+  if (run_noising_b) {
+    reference_noise_B_impl(B, EBR, EARxBpEB_target, BpEB, EAR_K_major,
+                           EBL_R_major);
+  }
+  if (!skip_denoising) {
+    reference_denoise_converter_impl(EARxBpEB_int32_, AxEBL_int32_,
+                                     EARxBpEB_fp16, AxEBL_fp16);
+  }
+
+  // The denoised result is mathematically identical to the original GEMM.
+  reference_gemm_impl(A, B, A_scales, B_scales, C);
+
+  // This reference path leaves PoW transcript extraction to the Python
+  // GB10 scan path, so leave the host signal idle.
+  if (!host_signal_header_pinned.is_cuda()) {
+    auto* header = reinterpret_cast<HostSignalHeader*>(
+        host_signal_header_pinned.data_ptr());
+    header->status = HostSignalStatus::kSignalIdle;
+  }
+}
+
+}  // namespace
+
 void denoise_converter(
     const std::optional<at::Tensor>& EARxBpEB_in_,   //n x r, int32
     const std::optional<at::Tensor>& AxEBL_in_,      //m x r, int32
@@ -142,6 +301,12 @@ void denoise_converter(
     check_tensor(EARxBpEB_in, n, r, torch::kInt32);
     check_tensor(EARxBpEB_out, n, r, torch::kFloat16);
   }
+  if (use_reference_backend()) {
+    reference_denoise_converter_impl(EARxBpEB_in_, AxEBL_in_, EARxBpEB_out_,
+                                     AxEBL_out_);
+    return;
+  }
+
   PearlAPIParams params;
 
   params.ptr_AxEBL_int32 = convert_AxEBL ? AxEBL_in.data_ptr() : nullptr;
@@ -352,6 +517,11 @@ void noise_A(at::Tensor& A,                          // m x k
         get_num_k_blocks(m, tile_size_m, k, tile_size_k, dprops);
   }
 
+  if (use_reference_backend()) {
+    reference_noise_A_impl(A, EAL, AxEBL, ApEA, EAR, EBL);
+    return;
+  }
+
   PearlAPIParams params;
   params.m = m;
   params.n = n;
@@ -452,6 +622,11 @@ void noise_B(at::Tensor& B,                          // n x k
         get_num_k_blocks(n, tile_size_n, k, tile_size_k, dprops);
   }
 
+  if (use_reference_backend()) {
+    reference_noise_B_impl(B, EBR, EARxBpEB, BpEB, EAR, EBL);
+    return;
+  }
+
   PearlAPIParams params;
 
   params.m = m;
@@ -531,7 +706,11 @@ void gemm(at::Tensor& A,         // m x k
   check_tensor(B, n, k, torch::kInt8);
   check_tensor(A_scales, m, torch::kFloat32);
   check_tensor(B_scales, n, torch::kFloat32);
-  check_tensor(C, m, n, at::kBFloat16);
+  if (use_reference_backend()) {
+    check_tensor(C, m, n, at::kBFloat16, torch::kFloat16);
+  } else {
+    check_tensor(C, m, n, at::kBFloat16);
+  }
 
   TORCH_CHECK(k % bK == 0, "K must be divisible by bK");
 
@@ -541,6 +720,11 @@ void gemm(at::Tensor& A,         // m x k
   static constexpr int align_n = 128 / (sizeof(ElementOut) * 8);
   TORCH_CHECK(n % align_n == 0,
               "N must be divisible by " + std::to_string(align_n));
+
+  if (use_reference_backend()) {
+    reference_gemm_impl(A, B, A_scales, B_scales, C);
+    return;
+  }
 
   params.m = m;
   params.n = n;
@@ -740,7 +924,11 @@ void noisy_gemm(
   check_tensor(EARxBpEB_fp16, n, r, torch::kFloat16);
   check_tensor(A_scales, m, torch::kFloat32);
   check_tensor(B_scales, n, torch::kFloat32);
-  check_tensor(C, m, n, at::kBFloat16);
+  if (use_reference_backend()) {
+    check_tensor(C, m, n, at::kBFloat16, torch::kFloat16);
+  } else {
+    check_tensor(C, m, n, at::kBFloat16);
+  }
 
   CHECK_SHAPE(host_signal_header_pinned, get_host_signal_header_size());
   CHECK_SHAPE(host_signal_sync, get_host_signal_sync_size());
@@ -792,6 +980,26 @@ void noisy_gemm(
 
   int const pipeline_stages = pipeline_stages_.value_or(
       get_pipeline_stages(bM, bN, bK, r, skip_denoising, dprops));
+
+  if (use_reference_backend()) {
+    reference_noisy_gemm_impl(
+        A, B, EAL, EBR, EAR_R_major, EBL_R_major, EAR_K_major, EBL_K_major,
+        AxEBL_fp16, EARxBpEB_fp16, ApEA, BpEB, A_scales, B_scales, C,
+        host_signal_header_pinned, AxEBL_int32_, EARxBpEB_int32_,
+        run_noising_a, run_noising_b, skip_denoising);
+
+    if (enable_debug && inner_hash_counter.has_value()) {
+      constexpr int64_t kReferenceHashTileH = 2;
+      constexpr int64_t kReferenceHashTileW = 64;
+      const int64_t num_tiles = ((m + bM - 1) / bM) * ((n + bN - 1) / bN);
+      const int64_t reductions_per_tile = k / r;
+      const int64_t num_threads_per_cta =
+          (bM / kReferenceHashTileH) * (bN / kReferenceHashTileW);
+      inner_hash_counter.value().add_(num_tiles * reductions_per_tile *
+                                      num_threads_per_cta);
+    }
+    return;
+  }
 
   PearlAPIParams params;
   using ElementOut = cutlass::bfloat16_t;

--- a/miner/pearl-gemm/setup.py
+++ b/miner/pearl-gemm/setup.py
@@ -86,7 +86,9 @@ CORES_PER_JOB = 1
 FALLBACK_MAX_JOBS = 4
 KB_PER_GB = 1024 * 1024
 NVCC_THREAD_COUNT = "4"
-COMPUTE_CAPABILITY = "arch=compute_90a,code=sm_90a"
+DEFAULT_CUDA_ARCHS = "90a"
+CUDA_ARCHS_ENV = "PEARL_GEMM_CUDA_ARCHS"
+BLACKWELL_CONSUMER_ARCHS = {"120", "121"}
 
 
 def linux_total_ram_kb() -> int:
@@ -141,7 +143,16 @@ NOISING_B_KERNELS = [k for k in kernel_configs.noising_b_kernels if k.R in ENABL
 def get_platform() -> str:
     """Returns the platform name as used in wheel filenames."""
     if sys.platform.startswith("linux"):
-        return "linux_x86_64"
+        machine = platform.machine().lower()
+        platform_tags = {
+            "amd64": "linux_x86_64",
+            "x86_64": "linux_x86_64",
+            "aarch64": "linux_aarch64",
+            "arm64": "linux_aarch64",
+        }
+        if machine in platform_tags:
+            return platform_tags[machine]
+        raise ValueError(f"Unsupported Linux machine architecture: {machine}")
     raise ValueError(f"Unsupported platform: {sys.platform}")
 
 
@@ -151,6 +162,99 @@ def get_cuda_bare_metal_version(cuda_dir: str) -> tuple[str, Version]:
     release_idx = output.index("release") + 1
     bare_metal_version = parse(output[release_idx].split(",")[0])
     return raw_output, bare_metal_version
+
+
+def _split_cuda_archs(raw_archs: str) -> list[str]:
+    return [part for part in re.split(r"[,;\s]+", raw_archs.strip()) if part]
+
+
+def normalize_cuda_arch(raw_arch: str) -> str:
+    arch = raw_arch.strip().lower()
+    if not arch:
+        raise ValueError("empty CUDA architecture")
+
+    arch = arch.removeprefix("compute_")
+    arch = arch.removeprefix("compute")
+    arch = arch.removeprefix("sm_")
+    arch = arch.removeprefix("sm")
+    arch = arch.replace(".", "")
+
+    if not re.fullmatch(r"[0-9]+a?", arch):
+        raise ValueError(
+            f"Invalid CUDA architecture {raw_arch!r}. Expected values like 90a, sm_90a, 121, or native."
+        )
+    return arch
+
+
+def detect_native_cuda_arch() -> str | None:
+    try:
+        if not torch.cuda.is_available():
+            return None
+        major, minor = torch.cuda.get_device_capability()
+    except Exception as exc:
+        warnings.warn(
+            f"Could not query CUDA device capability: {exc!r}",
+            category=RuntimeWarning,
+            stacklevel=2,
+        )
+        return None
+
+    arch = f"{major}{minor}"
+    # Pearl's current kernels use Hopper architecture-accelerated instructions,
+    # so Hopper native builds should keep the existing sm_90a target.
+    return "90a" if arch == "90" else arch
+
+
+def warn_if_experimental_blackwell_arch(archs: list[str], source: str) -> None:
+    blackwell_archs = sorted(set(archs) & BLACKWELL_CONSUMER_ARCHS)
+    if not blackwell_archs:
+        return
+
+    warnings.warn(
+        f"{source} selected Blackwell consumer CUDA architecture(s) "
+        f"{', '.join('sm_' + arch for arch in blackwell_archs)}. "
+        "pearl-gemm's main NoisyGEMM/vLLM kernels are still Hopper sm_90a-specific; "
+        "this build target is experimental and does not imply production-performance Blackwell kernel support.",
+        category=RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+def resolve_cuda_archs() -> list[str]:
+    raw_archs = os.getenv(CUDA_ARCHS_ENV)
+    source = CUDA_ARCHS_ENV
+
+    if raw_archs:
+        archs = []
+        for raw_arch in _split_cuda_archs(raw_archs):
+            if raw_arch.strip().lower() == "native":
+                native_arch = detect_native_cuda_arch()
+                if native_arch is None:
+                    raise RuntimeError(
+                        f"{CUDA_ARCHS_ENV}=native was requested, but no CUDA device is visible"
+                    )
+                archs.append(native_arch)
+            else:
+                archs.append(normalize_cuda_arch(raw_arch))
+    else:
+        native_arch = detect_native_cuda_arch()
+        if native_arch in BLACKWELL_CONSUMER_ARCHS:
+            source = "detected CUDA device"
+            archs = [native_arch]
+        else:
+            source = "default"
+            archs = [normalize_cuda_arch(DEFAULT_CUDA_ARCHS)]
+
+    deduped_archs = list(dict.fromkeys(archs))
+    warn_if_experimental_blackwell_arch(deduped_archs, source)
+    return deduped_archs
+
+
+def cuda_gencode_flags(archs: list[str]) -> list[str]:
+    flags = []
+    for arch in archs:
+        flags.extend(["-gencode", f"arch=compute_{arch},code=sm_{arch}"])
+    return flags
 
 
 def warn_if_cuda_home_missing(global_option: str) -> None:
@@ -349,7 +453,9 @@ if not SKIP_CUDA_BUILD:
     warn_if_cuda_home_missing("pearl_gemm")
     _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
     print(f"cuda version = {bare_metal_version}\n\n")
-    arch_flags = ["-gencode", COMPUTE_CAPABILITY]
+    cuda_archs = resolve_cuda_archs()
+    print(f"cuda archs = {', '.join('sm_' + arch for arch in cuda_archs)}\n\n")
+    arch_flags = cuda_gencode_flags(cuda_archs)
 
     if not SKIP_CPP_GENERATION:
         # Generate template instantiations for all possible kernels
@@ -425,11 +531,11 @@ if not SKIP_CUDA_BUILD:
         cutlass_dir / "tools" / "util" / "include",
     ]
     if sys.platform.startswith("linux"):
-        cuda_cccl_include_dir = (
-            Path(CUDA_HOME) / "targets" / f"{platform.machine()}-linux" / "include" / "cccl"
-        )
-        if cuda_cccl_include_dir.exists():
-            include_dirs.append(cuda_cccl_include_dir)
+        cuda_cccl_include_dirs = [
+            Path(CUDA_HOME) / "targets" / f"{platform.machine()}-linux" / "include" / "cccl",
+            Path(CUDA_HOME) / "include" / "cccl",
+        ]
+        include_dirs.extend(path for path in cuda_cccl_include_dirs if path.exists())
 
     # Get PyTorch library path for rpath
     torch_lib_path = os.path.join(os.path.dirname(torch.__file__), "lib")

--- a/miner/pearl-gemm/src/pearl_gemm/__init__.py
+++ b/miner/pearl-gemm/src/pearl_gemm/__init__.py
@@ -4,6 +4,8 @@ pearl_gemm package
 This package provides CUDA kernels for Pearl GEMM with noising/denoising and PoW extraction.
 """
 
+import torch  # noqa: F401 - load PyTorch shared libraries before pearl_gemm_cuda
+
 # Re-export pearl_gemm_cuda utilities for cleaner API
 from pearl_gemm_cuda import (
     HostSignalStatus,

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -1,7 +1,31 @@
-import pearl_gemm_cuda
+# ruff: noqa: I001
+from blake3 import blake3
+
 import torch
+import pearl_gemm_cuda
 
 BLAKE3_DIGEST_SIZE_U32 = 8
+BLAKE3_CHUNK_LEN = 1024
+
+
+def _use_reference_cuda_backend(device=None) -> bool:
+    if not torch.cuda.is_available():
+        return False
+    try:
+        major, _minor = torch.cuda.get_device_capability(device)
+    except Exception:
+        return False
+    return major >= 10
+
+
+def _pad_to_blake3_chunk_boundary(raw: bytes) -> bytes:
+    pad_len = (-len(raw)) % BLAKE3_CHUNK_LEN
+    return raw if pad_len == 0 else raw + (b"\x00" * pad_len)
+
+
+def _copy_digest_to_cuda_out(digest: bytes, out: torch.Tensor) -> None:
+    digest_tensor = torch.frombuffer(bytearray(digest), dtype=torch.uint8).to(out.device)
+    out.copy_(digest_tensor)
 
 
 def make_pow_target_tensor(value: int, device="cuda") -> torch.Tensor:
@@ -573,6 +597,13 @@ def tensor_hash(
     Returns:
         Tensor: Hash output tensor
     """
+    if _use_reference_cuda_backend(data.device):
+        key_bytes = key.detach().cpu().numpy().tobytes()
+        raw = data.flatten().detach().cpu().numpy().tobytes()
+        digest = blake3(_pad_to_blake3_chunk_boundary(raw), key=key_bytes).digest()
+        _copy_digest_to_cuda_out(digest, out)
+        return None
+
     return pearl_gemm_cuda.tensor_hash(
         data, key, out, roots, threads_per_block, num_stages, leaves_per_mt_block
     )
@@ -584,6 +615,16 @@ def commitment_hash_from_merkle_roots(
     """
     Compute the commitment hash from merkle roots of a 2D tensor.
     """
+    if _use_reference_cuda_backend(A_merkle_root.device):
+        key_bytes = key.detach().cpu().numpy().tobytes()
+        a_root = A_merkle_root.detach().cpu().numpy().tobytes()
+        b_root = B_merkle_root.detach().cpu().numpy().tobytes()
+        b_digest = blake3(key_bytes + b_root).digest()
+        a_digest = blake3(b_digest + a_root).digest()
+        _copy_digest_to_cuda_out(a_digest, A_commitment_hash)
+        _copy_digest_to_cuda_out(b_digest, B_commitment_hash)
+        return None
+
     return pearl_gemm_cuda.commitment_hash_from_merkle_roots(
         A_merkle_root, B_merkle_root, key, A_commitment_hash, B_commitment_hash
     )

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -1,7 +1,12 @@
+import os
+
+import numpy as np
 import torch
+from blake3 import blake3
 from miner_base.commitment_hash import CommitmentHasher
 from miner_base.gpu_matmul_config import GPUMatmulConfigFactory
 from miner_utils import get_logger
+from pearl_gateway.comm.dataclasses import CommitmentHash, OpenedBlockInfo
 from pearl_gemm import (
     commitment_hash_from_merkle_roots,
     gemm,
@@ -23,6 +28,156 @@ from .mining_state import (
 )
 
 _LOGGER = get_logger("vllm.pearl_miner")
+
+HASH_ACCUMULATE_ROTATION = 13
+JACKPOT_SIZE_U32 = 16
+REFERENCE_BACKEND_MIN_EXPECTED_HITS = float(
+    os.environ.get("PEARL_GB10_REFERENCE_MIN_EXPECTED_HITS", "0.25")
+)
+
+
+def _use_reference_cuda_backend(device: torch.device | str | None = None) -> bool:
+    if not torch.cuda.is_available():
+        return False
+
+    cuda_device = torch.device("cuda" if device is None else device)
+    if cuda_device.type != "cuda":
+        return False
+
+    major, _minor = torch.cuda.get_device_capability(cuda_device)
+    return major >= 10
+
+
+def _rotl32(values: np.ndarray, shift: int) -> np.ndarray:
+    return ((values << np.uint32(shift)) | (values >> np.uint32(32 - shift))).astype(
+        np.uint32,
+        copy=False,
+    )
+
+
+def _pattern_partitions(pattern, total_dimension: int) -> np.ndarray:
+    base = np.asarray(pattern.to_list(), dtype=np.int64)
+    if base.size == 0:
+        return np.empty((0, 0), dtype=np.int64)
+
+    max_base = int(base.max())
+    if total_dimension <= max_base:
+        return np.empty((0, base.size), dtype=np.int64)
+
+    offsets = [
+        offset for offset in range(total_dimension - max_base) if pattern.offset_is_valid(offset)
+    ]
+    if not offsets:
+        return np.empty((0, base.size), dtype=np.int64)
+
+    return np.asarray(offsets, dtype=np.int64)[:, None] + base[None, :]
+
+
+def _find_reference_backend_opened_indices(
+    ApEA: torch.Tensor,
+    BpEB: torch.Tensor,
+    pow_key: bytes,
+    pow_target: int,
+    mining_config,
+) -> tuple[list[int], list[int]] | None:
+    m, k = ApEA.shape
+    n, b_k = BpEB.shape
+    if b_k != k:
+        raise ValueError(f"A/B common dimension mismatch: {k} != {b_k}")
+
+    rank = int(mining_config.rank)
+    rounded_k = (k // rank) * rank
+    if rounded_k == 0:
+        return None
+
+    row_partitions = _pattern_partitions(mining_config.rows_pattern, m)
+    col_partitions = _pattern_partitions(mining_config.cols_pattern, n)
+    if row_partitions.size == 0 or col_partitions.size == 0:
+        return None
+
+    num_rows = row_partitions.shape[0]
+    target = int(pow_target)
+    candidate_count = num_rows * col_partitions.shape[0]
+    expected_hits = candidate_count * target / float(1 << 256)
+    if expected_hits < REFERENCE_BACKEND_MIN_EXPECTED_HITS:
+        _LOGGER.debug(
+            "Skipping GB10 reference proof scan; expected_hits={:.3e}, candidates={}, target={}",
+            expected_hits,
+            candidate_count,
+            target,
+        )
+        return None
+
+    A_noised = ApEA.detach().cpu().numpy().astype(np.int32, copy=False)
+    B_noised_t = BpEB.detach().cpu().numpy().astype(np.int32, copy=False)
+
+    for col_indices in col_partitions:
+        B_cols = B_noised_t[col_indices]
+        jackpot_tile = np.zeros(
+            (num_rows, row_partitions.shape[1], col_indices.size), dtype=np.int32
+        )
+        jackpot = np.zeros((num_rows, JACKPOT_SIZE_U32), dtype=np.uint32)
+
+        for reduction_idx, start in enumerate(range(0, rounded_k, rank)):
+            end = start + rank
+            A_rows = A_noised[row_partitions, start:end]
+            partial = np.matmul(A_rows, B_cols[:, start:end].T)
+            jackpot_tile += partial
+
+            xored_tile = np.bitwise_xor.reduce(
+                jackpot_tile.view(np.uint32).reshape(num_rows, -1),
+                axis=1,
+            )
+            tid = reduction_idx % JACKPOT_SIZE_U32
+            jackpot[:, tid] = _rotl32(jackpot[:, tid], HASH_ACCUMULATE_ROTATION) ^ xored_tile
+
+        for row_idx, jackpot_words in enumerate(jackpot):
+            msg = jackpot_words.astype("<u4", copy=False).tobytes()
+            digest = blake3(msg, key=pow_key).digest()
+            if int.from_bytes(digest, "little") <= target:
+                return row_partitions[row_idx].astype(int).tolist(), col_indices.astype(
+                    int
+                ).tolist()
+
+    return None
+
+
+def _submit_reference_backend_block(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    ApEA: torch.Tensor,
+    BpEB: torch.Tensor,
+    commitment_hash_A_tensor: torch.Tensor,
+    commitment_hash_B_tensor: torch.Tensor,
+    mining_job,
+    matmul_config,
+    adjusted_target: int,
+) -> None:
+    commitment_hash = CommitmentHash(
+        noise_seed_A=commitment_hash_A_tensor.cpu().numpy().tobytes(),
+        noise_seed_B=commitment_hash_B_tensor.cpu().numpy().tobytes(),
+    )
+
+    opened_indices = _find_reference_backend_opened_indices(
+        ApEA=ApEA,
+        BpEB=BpEB,
+        pow_key=commitment_hash.noise_seed_A,
+        pow_target=adjusted_target,
+        mining_config=matmul_config.mining_config,
+    )
+    if opened_indices is None:
+        return
+
+    A_row_indices, B_column_indices = opened_indices
+    opened_block_info = OpenedBlockInfo(
+        A_row_indices=A_row_indices,
+        B_column_indices=B_column_indices,
+        A=A.cpu().detach(),
+        B_t=B.cpu().detach(),
+        commitment_hash=commitment_hash,
+        noise_rank=config.settings.noise_rank,
+    )
+    get_async_manager().handle_submit_block(opened_block_info, mining_job)
 
 
 def pearl_gemm_vanilla(
@@ -216,26 +371,46 @@ def pearl_gemm_noisy(
     )
 
     if submit_block:
-        # Record a CUDA event after the kernel launch - will complete when kernel finishes
-        cuda_event = torch.cuda.Event()
-        cuda_event.record()
+        if _use_reference_cuda_backend(a.device):
+            try:
+                torch.cuda.synchronize()
+                _submit_reference_backend_block(
+                    A=A,
+                    B=B,
+                    ApEA=ApEA,
+                    BpEB=BpEB,
+                    commitment_hash_A_tensor=commitment_hash_A_tensor,
+                    commitment_hash_B_tensor=commitment_hash_B_tensor,
+                    mining_job=mining_job,
+                    matmul_config=matmul_config,
+                    adjusted_target=adjusted_target,
+                )
+            finally:
+                get_pinned_pool().release(host_signal_header_pinned)
+                host_signal_header_pinned = None
+                commitment_hash_A_tensor = None
+                commitment_hash_B_tensor = None
+        else:
+            # Record a CUDA event after the kernel launch - will complete when kernel finishes
+            cuda_event = torch.cuda.Event()
+            cuda_event.record()
 
-        # Create callback for processing the status check
-        callback = StatusCheckCallback(
-            host_signal_header_pinned=host_signal_header_pinned,
-            commitment_hash_A_tensor=commitment_hash_A_tensor,
-            commitment_hash_B_tensor=commitment_hash_B_tensor,
-            A=A,
-            B=B,
-            mining_job=mining_job,
-        )
+            # Create callback for processing the status check
+            callback = StatusCheckCallback(
+                host_signal_header_pinned=host_signal_header_pinned,
+                commitment_hash_A_tensor=commitment_hash_A_tensor,
+                commitment_hash_B_tensor=commitment_hash_B_tensor,
+                A=A,
+                B=B,
+                mining_job=mining_job,
+            )
 
-        get_async_manager().schedule_status_check(cuda_event, callback)
+            get_async_manager().schedule_status_check(cuda_event, callback)
 
-        # Callback owns these tensors
-        host_signal_header_pinned = None
-        commitment_hash_A_tensor = None
-        commitment_hash_B_tensor = None
+            # Callback owns these tensors
+            host_signal_header_pinned = None
+            commitment_hash_A_tensor = None
+            commitment_hash_B_tensor = None
     else:
         get_pinned_pool().release(host_signal_header_pinned)
         del host_signal_header_pinned

--- a/miner/vllm-miner/tests/test_vanilla_gemm.py
+++ b/miner/vllm-miner/tests/test_vanilla_gemm.py
@@ -4,6 +4,28 @@ from vllm import _custom_ops as vllm_ops
 from vllm_miner.gemm_operators import pearl_gemm_vanilla
 
 
+def _torch_scaled_mm_reference(a, b, scale_a, scale_b, out_dtype, bias):
+    acc = torch._int_mm(a, b.T.contiguous()).to(torch.float32)
+    acc *= scale_a.view(-1, 1)
+    acc *= scale_b.view(1, -1)
+    if bias is not None:
+        acc += bias.view(1, -1)
+    return acc.to(out_dtype)
+
+
+def _scaled_mm_reference(a, b, scale_a, scale_b, out_dtype, bias):
+    try:
+        return vllm_ops.cutlass_scaled_mm(
+            a, b.T, scale_a=scale_a, scale_b=scale_b, out_dtype=out_dtype, bias=bias
+        )
+    except RuntimeError as exc:
+        if torch.cuda.get_device_capability(a.device)[0] < 10:
+            raise
+        if "Int8 not supported" not in str(exc):
+            raise
+        return _torch_scaled_mm_reference(a, b, scale_a, scale_b, out_dtype, bias)
+
+
 @pytest.mark.parametrize("m, n, k", [(1024, 1024, 1024), (8192, 8192, 8192)])
 def test_pearl_gemm_vanilla_correctness(make_random_test_matrices, m, n, k):
     """
@@ -17,9 +39,7 @@ def test_pearl_gemm_vanilla_correctness(make_random_test_matrices, m, n, k):
 
     output = pearl_gemm_vanilla(a, b, scale_a.squeeze(), scale_b.squeeze(), out_dtype)
 
-    ref_output = vllm_ops.cutlass_scaled_mm(
-        a, b.T, scale_a=scale_a, scale_b=scale_b, out_dtype=out_dtype, bias=bias
-    )
+    ref_output = _scaled_mm_reference(a, b, scale_a, scale_b, out_dtype, bias)
     torch.cuda.synchronize()
 
     assert output.shape == (m, n)


### PR DESCRIPTION
## Summary
- add native CUDA architecture selection for GB10/Blackwell consumer devices, including Linux aarch64 wheel tagging and CUDA 13 CCCL include handling
- route GB10/SM 12.x pearl-gemm API calls through a correctness-first Torch `_int_mm` reference backend instead of the Hopper-specific custom kernel path
- add vLLM miner integration support for the GB10 reference path, including CPU proof scanning when the custom kernel host-signal path is bypassed
- update miner docs and vanilla GEMM coverage for the GB10 path

## Why this approach
The custom Blackwell kernel approach in #118 builds on GB10, but it fails a runtime-like NoisyGEMM correctness case for the default 128x256x128, R=128 configuration. This PR intentionally avoids treating SM 12.x as a compatible Hopper target. It provides a functional GB10 path first, while leaving production-performance native Blackwell kernels as a separate follow-up.

## Validation
Ran locally on NVIDIA GB10, driver 580.142, CUDA 13.0, PyTorch 2.11.0+cu130, device capability `(12, 1)`:

- `PEARL_GEMM_CUDA_ARCHS=native PEARL_GEMM_FORCE_BUILD=TRUE uv sync --package pearl-gemm --dev --reinstall-package pearl-gemm`
- `uv run python -c 'import torch; import pearl_gemm; import pearl_gemm_cuda; print(torch.__version__, torch.version.cuda, torch.cuda.get_device_name(), torch.cuda.get_device_capability()); print("import ok")'`
- `cuobjdump --list-elf miner/pearl-gemm/src/pearl_gemm_cuda.cpython-312-aarch64-linux-gnu.so` confirmed `sm_121` cubins
- `uv run pytest -q 'miner/pearl-gemm/tests/test_pearl_gemm.py::TestSwizzleNoisyGEMM::test_int7_swizzle_noisy_gemm[True-None-matmul_config1-8192-8192-512]'`
- `uv run pytest -q -x miner/pearl-gemm/tests/test_pearl_gemm.py` -> `2862 passed, 144 skipped, 16 warnings in 1128.58s`
- `PYTHONPATH=miner/vllm-miner/src uv run pytest -q miner/vllm-miner/tests/test_vanilla_gemm.py` -> `2 passed, 18 warnings in 2.69s`
