### PR TITLE
fix(ci): use macos-13 runner for darwin-amd64 binary build

### DIFF
--- a/.github/workflows/pearl-desktop-wallet.yml
+++ b/.github/workflows/pearl-desktop-wallet.yml
@@ -127,7 +127,7 @@ jobs:
             bin_ext: ""
             electron_build_cmd: pnpm -F @pearl/pearl-desktop-wallet run build:linux
           - name: macOS Intel
-            os: macos-15
+            os: macos-13
             goos: darwin
             goarch: amd64
             electron_arch: x64


### PR DESCRIPTION
Fixes #127.

The `pearl-desktop-wallet.yml` workflow used `macos-15` for the macOS Intel (amd64) build. GitHub's `macos-15` runner runs on Apple Silicon hardware, so even with `GOARCH=amd64` the resulting binary is arm64 due to CGO and native toolchain.

`macos-13` is the last Intel-based macOS runner available on GitHub Actions and produces correct amd64 binaries.