### PR TITLE
fix(spv): correct license badge from MIT to ISC

### DIFF
--- a/spv/README.md
+++ b/spv/README.md
@@ -1,7 +1,7 @@
 # Pearl Light Client
 
 [![Build Status](https://github.com/pearl-research-labs/pearl/workflows/Build%20and%20Test/badge.svg)](https://github.com/pearl-research-labs/pearl/actions)
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/pearl-research-labs/pearl/spv)
 
 A privacy-preserving Pearl light client. It uses compact block filters


### PR DESCRIPTION
## Summary

The license badge in `spv/README.md` incorrectly displayed MIT but the actual license stated in the file footer and the project LICENSE file is ISC.

## Changes

- `spv/README.md`: replace MIT badge with correct ISC badge