### PR TITLE
fix(proxy): correct rate limit inconsistencies across docs and test script

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -118,7 +118,7 @@ requests receive HTTP 429 (Too Many Requests). Adjust in the `Caddyfile`:
 rate_limit {
     zone rpc {
         key    {remote_host}
-        events 120
+        events 100
         window 1m
     }
 }

--- a/proxy/proxy_test.sh
+++ b/proxy/proxy_test.sh
@@ -39,7 +39,7 @@ for arg in "$@"; do
             echo "  --rpc-user=USER        RPC username (required)"
             echo "  --rpc-pass=PASS        RPC password (required)"
             echo "  --proxy-port=PORT      Local port for the proxy (default: 44111)"
-            echo "  --rate-limit=N         Expected rate limit events/min (default: 60)"
+            echo "  --rate-limit=N         Expected rate limit events/min (default: 100)"
             exit 0
             ;;
         *) echo "Unknown argument: $arg"; exit 1 ;;


### PR DESCRIPTION
## Summary

Three places in the proxy documentation and test script referenced different rate limit values, making it unclear what the actual default is.

## Changes

**`proxy/README.md`**
- Fix example `Caddyfile` snippet showing `events 120` → `events 100` to match the actual `Caddyfile` default

**`proxy/proxy_test.sh`**
- Fix `--help` text saying `default: 60` → `default: 100` to match the actual `RATE_LIMIT` default in the script

## Before / After

| File | Was | Now |
|---|---|---|
| `proxy/README.md` example | `events 120` | `events 100` |
| `proxy/proxy_test.sh --help` | `default: 60` | `default: 100` |
| `proxy/Caddyfile` (ground truth) | `events 100` | unchanged |