### PR TITLE
docs: fill zk-pow README, add coredns dnsseed README, remove stale pearl website refs

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -4,13 +4,6 @@ This monorepo contains the user-facing applications for the Pearl blockchain net
 
 ## 📦 Applications
 
-### 🌐 Landing Page (`@pearl/pearl-website`)
-
-The official landing page for the Pearl blockchain network, built with React and Vite. It provides
-information about the network, features, and documentation.
-
-**Location:** [apps/pearl-website](./apps/pearl-website)
-
 ### 💼 Pearl Desktop Wallet (`@pearl/pearl-desktop-wallet`)
 
 A modern, secure desktop wallet application for managing Pearl blockchain assets. Built with
@@ -56,14 +49,6 @@ This will install dependencies for all apps and packages in the monorepo workspa
 
 ## 🛠️ Development
 
-### Running the Landing Page
-
-To start the landing page in development mode:
-
-```bash
-pnpm --filter @pearl/pearl-website dev
-```
-
 ### Running the Desktop Wallet
 
 To start the Pearl Desktop Wallet in development mode:
@@ -73,19 +58,6 @@ pnpm --filter @pearl/pearl-desktop-wallet dev
 ```
 
 ## 🏗️ Building
-
-### Building the Landing Page
-
-```bash
-# From the apps root directory
-pnpm --filter @pearl/pearl-website build
-
-# Or from the pearl-website directory
-cd apps/pearl-website
-pnpm build
-```
-
-The production build will be output to `apps/pearl-website/dist`.
 
 ### Building the Desktop Wallet
 
@@ -169,7 +141,6 @@ pnpm lint
 ```
 apps/
 ├── apps/
-│   ├── pearl-website/          # Landing page application
 │   └── pearl-desktop-wallet/ # Desktop wallet application
 ├── packages/
 │   ├── ui/                    # Shared UI components

--- a/coredns-dnsseed/README.md
+++ b/coredns-dnsseed/README.md
@@ -1,0 +1,69 @@
+# Pearl DNS Seeder (CoreDNS Plugin)
+
+A CoreDNS plugin that crawls the Pearl P2P network and serves peer IP addresses
+via DNS A/AAAA records.
+
+## Local Development
+
+### Prerequisites
+
+- A running `pearld` node (regtest mode is simplest)
+- Docker
+
+### Quick Start
+
+1. Start a regtest node:
+
+```bash
+pearld --regtest --listen 127.0.0.1:18444
+```
+
+2. Build the CoreDNS image from the repo root:
+
+```bash
+docker build -f coredns-dnsseed/deploy/Dockerfile -t pearl-seeder .
+```
+
+3. Run with the local dev Corefile:
+
+```bash
+docker run --rm --network host \
+  -v $(pwd)/coredns-dnsseed/deploy/Corefile.local:/etc/coredns/Corefile \
+  pearl-seeder
+```
+
+4. Query:
+
+```bash
+dig @127.0.0.1 -p 1053 localhost A +short
+```
+
+### Configuration
+
+The seeder is configured via a CoreDNS Corefile. The `dnsseed` block supports:
+
+| Directive         | Default | Description                              |
+| ----------------- | ------- | ---------------------------------------- |
+| `network`         | —       | Pearl network: mainnet, testnet, testnet2, regtest, signet, simnet |
+| `bootstrap_peers` | —       | Space-separated `host:port` list         |
+| `crawl_interval`  | `15m`   | How often to re-crawl the network        |
+| `record_ttl`      | `3600`  | DNS record TTL in seconds                |
+| `max_answers`     | `25`    | Max IPs per DNS response                 |
+
+### Production Deployment
+
+For production, create a separate Corefile with real domains and bootstrap peers,
+and mount it into the container at `/etc/coredns/Corefile`. Example:
+
+```
+mainnet.seeder.example.com {
+    dnsseed {
+        network mainnet
+        bootstrap_peers node1.example.com:44108 node2.example.com:44108
+        crawl_interval 15m
+        record_ttl 600
+    }
+    prometheus
+    health
+}
+```

--- a/zk-pow/README.md
+++ b/zk-pow/README.md
@@ -1,1 +1,85 @@
 # zk-pow
+
+[![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+
+Rust crate implementing Pearl's zero-knowledge proof-of-work (ZK-PoW) circuit. It converts a GPU-generated `PlainProof` (matrix solution) into a compact Plonky2 ZK proof that the Pearl node verifies on-chain.
+
+## Architecture
+
+```
+PlainProof (GPU output)
+    └─► zk_prove_plain_proof()  →  ZKProof { public_data, proof_data }
+                                        └─► verify_block()  →  Ok / Err
+```
+
+- **`api/prove.rs`** — `zk_prove_plain_proof()`: converts a `PlainProof` into a `ZKProof`
+- **`api/verify.rs`** — `verify_block()` / `verify_block_cached_circuits_only()`: verifies a `ZKProof`
+- **`api/proof.rs`** — core types: `IncompleteBlockHeader`, `PublicProofParams`, `ZKProof`, `PlainProof`
+- **`circuit/`** — Plonky2 circuit definition (Pearl STARK + recursion)
+- **`ffi/`** — Python bindings (via `pyo3` feature) used by `py-pearl-mining`
+
+## Usage
+
+### Proving
+
+```rust
+use zk_pow::api::prove::zk_prove_plain_proof;
+use zk_pow::circuit::circuit_utils::CircuitCache;
+
+let mut cache = CircuitCache::default();
+let result = zk_prove_plain_proof(block_header, &plain_proof, &mut cache, true)?;
+// result.public_data — 164-byte committed public data
+// result.proof_data  — raw Plonky2 proof bytes
+```
+
+### Verifying
+
+```rust
+use zk_pow::api::verify::verify_block;
+
+verify_block(&public_params, &zk_proof, &mut cache)?;
+```
+
+### Cached verification (production)
+
+```rust
+use zk_pow::api::verify::verify_block_cached_circuits_only;
+
+// Pre-compile circuits once, then reuse cache for all subsequent verifications
+verify_block_cached_circuits_only(&public_params, &zk_proof, &cache, None)?;
+```
+
+## Building
+
+```bash
+# Build (requires Rust toolchain, see rust-toolchain.toml)
+cargo build --release
+
+# Run tests
+cargo test
+
+# Build with Python bindings
+cargo build --release --features pyo3
+
+# Build with embedded verifier cache
+cargo build --release --features embedded_cache
+```
+
+## Features
+
+| Feature | Description |
+|---|---|
+| `pyo3` | Enable Python bindings (used by `py-pearl-mining`) |
+| `embedded_cache` | Embed pre-compiled verifier circuit into the binary |
+
+## Wire Format
+
+After proving, a `ZKCertificate` is assembled from `public_data` and `proof_data`. The full block is serialized as:
+
+```
+ZKCertificate.serialize() | PearlHeader.serialize() | TX_COUNT (varint) | TRANSACTIONS
+```
+
+## License
+
+Licensed under the [copyfree](http://copyfree.org) ISC License.


### PR DESCRIPTION
## Summary

Fixes #146 three documentation gaps across the monorepo.

## Changes

**`zk-pow/README.md`**
- Was empty (title only); filled with architecture overview, API usage examples (prove/verify/cached-verify), build instructions, feature flags table, and wire format description

**`coredns-dnsseed/README.md`**
- Did not exist at repo root; added from the existing `deploy/README.md` which covers local dev setup, configuration directives, and production deployment

**`apps/README.md`**
- Removed 8 references to non-existent `pearl-website` app (landing page section, dev/build commands, file tree entry)