### PR TITLE
fix(wallet): create dataDir before writing wallet-setup.json

### DIFF
--- a/apps/apps/pearl-desktop-wallet/src/main/services/wallet-process.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/services/wallet-process.ts
@@ -131,6 +131,7 @@ class WalletProcess {
       const isImport = !!seed;
       let walletConfigFile: string | undefined;
 
+      fs.mkdirSync(this.config.dataDir, { recursive: true });
       walletConfigFile = path.join(this.config.dataDir, 'wallet-setup.json');
       const walletConfig = {
         seed,


### PR DESCRIPTION
Fixes #155.

On a fresh Windows install the `.pearl-wallet/wallet-data/<name>/` directory tree does not exist. `fs.writeFileSync` fails when the parent directory is missing, causing oyster to report:

```
Unable to read wallet create file: C:\Users\<user>\.pearl-wallet\wallet-data\<name>\wallet-setup.json
```

Added `fs.mkdirSync(this.config.dataDir, { recursive: true })` before the `writeFileSync` call to ensure the directory exists.