### PR TITLE
docs(coredns-dnsseed): add missing README

### DIFF
--- a/coredns-dnsseed/README.md
+++ b/coredns-dnsseed/README.md
@@ -1,0 +1,16 @@
+# coredns-dnsseed
+
+A CoreDNS plugin that serves Pearl network peer addresses via DNS.
+
+## Components
+
+- **crawler** — crawls the Pearl P2P network and maintains an address book of reachable peers
+- **dnsseed** — CoreDNS plugin that answers DNS queries with addresses from the crawler
+
+## Building
+
+
+
+go build ./...
+go test ./...
+


### PR DESCRIPTION
Partial fix for #146.

Adds a minimal README to `coredns-dnsseed/` describing the two sub-packages (crawler and dnsseed plugin) and build instructions.