### PR TITLE
[WIP] feat: MoE hardfork

### DIFF
--- a/node/blockchain/chain.go
+++ b/node/blockchain/chain.go
@@ -2211,6 +2211,11 @@ func New(config *Config) (*BlockChain, error) {
 	if config.TimeSource == nil {
 		return nil, AssertError("blockchain.New timesource is nil")
 	}
+	// A negative MoEForkHeight would make IsMoEForkActive true from genesis,
+	// so reject it; 0 means the fork is not scheduled.
+	if config.ChainParams.MoEForkHeight < 0 {
+		return nil, AssertError("blockchain.New MoEForkHeight must be >= 0")
+	}
 
 	// Generate a checkpoint by height map from the provided checkpoints
 	// and assert the provided checkpoints are sorted by height as required.

--- a/node/blockchain/chain_test.go
+++ b/node/blockchain/chain_test.go
@@ -469,7 +469,7 @@ func addNodes(t *testing.T, chain *BlockChain, tip *blockNode, numNodes int) []*
 		// Create a certificate for the block.
 		// These are synthetic blocks for testing the chain index, not going through
 		// full validation, so they don't need valid PoW certificates.
-		cert := &wire.ZKCertificate{
+		cert := &wire.CertificateV1{
 			Hash:      header.BlockHash(),
 			ProofData: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe},
 		}

--- a/node/blockchain/common_test.go
+++ b/node/blockchain/common_test.go
@@ -348,7 +348,7 @@ func newBlock(chain *BlockChain, prev *btcutil.Block,
 		Bits:       chain.chainParams.PowLimitBits,
 		Timestamp:  ts,
 	}
-	cert, err := SolveBlock(&header, chain.chainParams.Net)
+	cert, err := SolveBlock(&header, chain.chainParams, blockHeight)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/node/blockchain/fullblocktests/generate.go
+++ b/node/blockchain/fullblocktests/generate.go
@@ -1406,10 +1406,10 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 	b46a := g.nextBlock("b46a", outs[14])
 	{
 		origHash := b46a.BlockHash()
-		// Set a ZKCertificate with ProofData exceeding MaxSize
+		// Set a CertificateV1 with ProofData exceeding MaxSize
 		oversizedProof := make([]byte, wire.CertificateMaxSize+1)
 		b46a.MsgHeader.MsgCertificate = wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      b46a.BlockHash(),
 				ProofData: oversizedProof,
 			},

--- a/node/blockchain/fullblocktests/generate.go
+++ b/node/blockchain/fullblocktests/generate.go
@@ -552,7 +552,7 @@ func (g *testGenerator) nextBlock(blockName string, spend *testhelper.SpendableO
 
 	// Attach a certificate unless the munger already set one.
 	if block.BlockCertificate() == nil {
-		cert, err := blockchain.SolveBlock(block.BlockHeader(), g.params.Net)
+		cert, err := blockchain.SolveBlock(block.BlockHeader(), g.params, nextHeight)
 		if err != nil {
 			panic(fmt.Sprintf("failed to solve block %q: %v", blockName, err))
 		}
@@ -721,7 +721,7 @@ func (g *testGenerator) padBlockToVsize(b *wire.MsgBlock, targetVsize int) {
 	updateWitnessCommitment(b)
 
 	b.BlockHeader().MerkleRoot = calcMerkleRoot(b.Transactions)
-	cert, _ := blockchain.SolveBlock(b.BlockHeader(), g.params.Net)
+	cert, _ := blockchain.SolveBlock(b.BlockHeader(), g.params, g.tipHeight+1)
 	b.MsgHeader.MsgCertificate = wire.MsgCertificate{Certificate: cert}
 }
 

--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -1,0 +1,181 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/pearl-research-labs/pearl/node/btcutil"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests exercise the MoE certificate version cutover on SimNet. PoW
+// verification is auto-skipped there (BFNoPoWCheck), but the version policy is
+// not, so it is fully exercised despite the fail-closed placeholder verifier.
+
+const moeForkTestHeight = int32(4)
+
+func moeSimNetParams() chaincfg.Params {
+	params := chaincfg.SimNetParams
+	params.ReduceMinDifficulty = false
+	params.MoEForkHeight = moeForkTestHeight
+	return params
+}
+
+// newBlockForcedCert builds (but does not process) the next block on top of
+// prev and replaces its certificate with the provided one, regardless of the
+// version SolveBlock would have chosen for the height. Used to drive
+// wrong-version rejection cases.
+func newBlockForcedCert(t *testing.T, chain *BlockChain, prev *btcutil.Block,
+	cert wire.BlockCertificate) *btcutil.Block {
+
+	t.Helper()
+	block, _, err := newBlock(chain, prev, nil)
+	require.NoError(t, err)
+	block.MsgBlock().MsgHeader.MsgCertificate = wire.MsgCertificate{Certificate: cert}
+	return block
+}
+
+func requireRuleError(t *testing.T, err error, code ErrorCode) {
+	t.Helper()
+	require.Error(t, err)
+	var ruleErr RuleError
+	require.ErrorAs(t, err, &ruleErr)
+	require.Equalf(t, code, ruleErr.ErrorCode,
+		"expected rule error %v, got %v", code, ruleErr.ErrorCode)
+}
+
+// TestMoEForkActivationAcceptsRequiredVersion builds a chain across the
+// activation boundary and asserts each block is accepted with the version
+// required at its height (ZK before the fork, MoE at and after it). The blocks
+// are produced by the height-aware SolveBlock, so this also covers mining-side
+// version selection on SimNet.
+func TestMoEForkActivationAcceptsRequiredVersion(t *testing.T) {
+	params := moeSimNetParams()
+	chain, teardown, err := chainSetup("moe_fork_accept", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	for h := int32(1); h <= moeForkTestHeight+2; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoErrorf(t, err, "block at height %d should be accepted", h)
+
+		want := wire.CertificateVersionZK
+		if h >= moeForkTestHeight {
+			want = wire.CertificateVersionMoE
+		}
+		require.Equalf(t, want, block.MsgBlock().BlockCertificate().Version(),
+			"unexpected certificate version at height %d", h)
+
+		tip = block
+	}
+
+	require.Equal(t, moeForkTestHeight+2, chain.BestSnapshot().Height)
+}
+
+// TestMoEForkActivationRejectsMoEBeforeFork asserts an MoE certificate is
+// rejected for a block below the activation height.
+func TestMoEForkActivationRejectsMoEBeforeFork(t *testing.T) {
+	params := moeSimNetParams()
+	chain, teardown, err := chainSetup("moe_fork_reject_early", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	// Extend with valid ZK blocks until the next block sits at
+	// moeForkTestHeight-1 (still pre-fork).
+	for h := int32(1); h <= moeForkTestHeight-2; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoError(t, err)
+		tip = block
+	}
+
+	bad := newBlockForcedCert(t, chain, tip,
+		&wire.MoECertificate{ProofData: []byte{0x00}})
+	_, _, err = chain.ProcessBlock(bad, BFNone)
+	requireRuleError(t, err, ErrDisallowedCertVersion)
+
+	// The tip must be unchanged by the rejected block.
+	require.Equal(t, moeForkTestHeight-2, chain.BestSnapshot().Height)
+}
+
+// TestMoEForkActivationRejectsZKAtFork asserts the legacy ZK certificate is
+// rejected at and after the activation height (strict cutover).
+func TestMoEForkActivationRejectsZKAtFork(t *testing.T) {
+	params := moeSimNetParams()
+	chain, teardown, err := chainSetup("moe_fork_reject_late", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	// Extend with valid ZK blocks until the next block sits exactly at the
+	// activation height.
+	for h := int32(1); h <= moeForkTestHeight-1; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoError(t, err)
+		tip = block
+	}
+
+	bad := newBlockForcedCert(t, chain, tip,
+		&wire.ZKCertificate{ProofData: []byte{0x00}})
+	_, _, err = chain.ProcessBlock(bad, BFNone)
+	requireRuleError(t, err, ErrDisallowedCertVersion)
+
+	require.Equal(t, moeForkTestHeight-1, chain.BestSnapshot().Height)
+}
+
+// TestSolveBlockSelectsVersionSimNet asserts the height-aware SolveBlock picks
+// the certificate version required by the MoE cutover on SimNet (where it
+// returns a lightweight dummy certificate of the correct version).
+func TestSolveBlockSelectsVersionSimNet(t *testing.T) {
+	params := moeSimNetParams()
+	header := &wire.BlockHeader{}
+
+	cert, err := SolveBlock(header, &params, moeForkTestHeight-1)
+	require.NoError(t, err)
+	require.Equal(t, wire.CertificateVersionZK, cert.Version(),
+		"pre-fork height must use the ZK certificate")
+
+	cert, err = SolveBlock(header, &params, moeForkTestHeight)
+	require.NoError(t, err)
+	require.Equal(t, wire.CertificateVersionMoE, cert.Version(),
+		"at/after fork height must use the MoE certificate")
+}
+
+// TestCheckCertificateVersion exercises the policy helper directly, including
+// the disabled-fork case and the nil-certificate guard.
+func TestCheckCertificateVersion(t *testing.T) {
+	enabled := &chaincfg.Params{MoEForkHeight: moeForkTestHeight}
+	disabled := &chaincfg.Params{MoEForkHeight: 0}
+
+	zk := &wire.ZKCertificate{}
+	moe := &wire.MoECertificate{}
+
+	// Disabled fork: ZK always valid, MoE never valid.
+	require.NoError(t, CheckCertificateVersion(zk, 1_000_000, disabled))
+	requireRuleError(t, CheckCertificateVersion(moe, 1_000_000, disabled),
+		ErrDisallowedCertVersion)
+
+	// Enabled fork: strict cutover at the activation height.
+	require.NoError(t, CheckCertificateVersion(zk, moeForkTestHeight-1, enabled))
+	require.NoError(t, CheckCertificateVersion(moe, moeForkTestHeight, enabled))
+	requireRuleError(t, CheckCertificateVersion(moe, moeForkTestHeight-1, enabled),
+		ErrDisallowedCertVersion)
+	requireRuleError(t, CheckCertificateVersion(zk, moeForkTestHeight, enabled),
+		ErrDisallowedCertVersion)
+
+	// Missing certificate.
+	requireRuleError(t, CheckCertificateVersion(nil, 1, enabled),
+		ErrCertificateMissing)
+}

--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -67,9 +67,9 @@ func TestMoEForkActivationAcceptsRequiredVersion(t *testing.T) {
 		block, _, err := addBlock(chain, tip, nil)
 		require.NoErrorf(t, err, "block at height %d should be accepted", h)
 
-		want := wire.CertificateVersionZK
+		want := wire.CertificateVersionV1
 		if h >= moeForkTestHeight {
-			want = wire.CertificateVersionMoE
+			want = wire.CertificateVersionV2
 		}
 		require.Equalf(t, want, block.MsgBlock().BlockCertificate().Version(),
 			"unexpected certificate version at height %d", h)
@@ -100,7 +100,7 @@ func TestMoEForkActivationRejectsMoEBeforeFork(t *testing.T) {
 	}
 
 	bad := newBlockForcedCert(t, chain, tip,
-		&wire.MoECertificate{ProofData: []byte{0x00}})
+		&wire.CertificateV2{ProofData: []byte{0x00}})
 	_, _, err = chain.ProcessBlock(bad, BFNone)
 	requireRuleError(t, err, ErrDisallowedCertVersion)
 
@@ -128,7 +128,7 @@ func TestMoEForkActivationRejectsZKAtFork(t *testing.T) {
 	}
 
 	bad := newBlockForcedCert(t, chain, tip,
-		&wire.ZKCertificate{ProofData: []byte{0x00}})
+		&wire.CertificateV1{ProofData: []byte{0x00}})
 	_, _, err = chain.ProcessBlock(bad, BFNone)
 	requireRuleError(t, err, ErrDisallowedCertVersion)
 
@@ -144,12 +144,12 @@ func TestSolveBlockSelectsVersionSimNet(t *testing.T) {
 
 	cert, err := SolveBlock(header, &params, moeForkTestHeight-1)
 	require.NoError(t, err)
-	require.Equal(t, wire.CertificateVersionZK, cert.Version(),
+	require.Equal(t, wire.CertificateVersionV1, cert.Version(),
 		"pre-fork height must use the ZK certificate")
 
 	cert, err = SolveBlock(header, &params, moeForkTestHeight)
 	require.NoError(t, err)
-	require.Equal(t, wire.CertificateVersionMoE, cert.Version(),
+	require.Equal(t, wire.CertificateVersionV2, cert.Version(),
 		"at/after fork height must use the MoE certificate")
 }
 
@@ -159,8 +159,8 @@ func TestCheckCertificateVersion(t *testing.T) {
 	enabled := &chaincfg.Params{MoEForkHeight: moeForkTestHeight}
 	disabled := &chaincfg.Params{MoEForkHeight: 0}
 
-	zk := &wire.ZKCertificate{}
-	moe := &wire.MoECertificate{}
+	zk := &wire.CertificateV1{}
+	moe := &wire.CertificateV2{}
 
 	// Disabled fork: ZK always valid, MoE never valid.
 	require.NoError(t, CheckCertificateVersion(zk, 1_000_000, disabled))

--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -153,6 +153,42 @@ func TestSolveBlockSelectsVersionSimNet(t *testing.T) {
 		"at/after fork height must use the MoE certificate")
 }
 
+// TestMoEForkBlockTemplateVersion verifies CheckConnectBlockTemplate enforces
+// the version cutover for block templates: at the fork height a V2 template is
+// accepted and a V1 template is rejected. This is the contract the height-aware
+// mining template selection (mining.NewBlockTemplate) is built to satisfy.
+func TestMoEForkBlockTemplateVersion(t *testing.T) {
+	params := moeSimNetParams()
+	chain, teardown, err := chainSetup("moe_fork_template", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	// Extend with valid V1 blocks so a template built on the tip lands
+	// exactly at the fork height.
+	for h := int32(1); h <= moeForkTestHeight-1; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoError(t, err)
+		tip = block
+	}
+
+	// A template at the fork height must carry V2 (SolveBlock selects it).
+	v2Template, _, err := newBlock(chain, tip, nil)
+	require.NoError(t, err)
+	require.Equal(t, wire.CertificateVersionV2,
+		v2Template.MsgBlock().BlockCertificate().Version())
+	require.NoError(t, chain.CheckConnectBlockTemplate(v2Template),
+		"V2 template must be accepted at the fork height")
+
+	// The same template carrying a V1 certificate must be rejected.
+	v1Template := newBlockForcedCert(t, chain, tip,
+		&wire.CertificateV1{ProofData: []byte{0x00}})
+	requireRuleError(t, chain.CheckConnectBlockTemplate(v1Template),
+		ErrDisallowedCertVersion)
+}
+
 // TestCheckCertificateVersion exercises the policy helper directly, including
 // the disabled-fork case and the nil-certificate guard.
 func TestCheckCertificateVersion(t *testing.T) {

--- a/node/blockchain/process_test.go
+++ b/node/blockchain/process_test.go
@@ -92,7 +92,7 @@ func TestProcessBlock_CheckpointDifficulty(t *testing.T) {
 		blk := &wire.MsgBlock{
 			MsgHeader: wire.MsgHeader{
 				BlockHeader: header,
-				MsgCertificate: wire.MsgCertificate{Certificate: &wire.ZKCertificate{
+				MsgCertificate: wire.MsgCertificate{Certificate: &wire.CertificateV1{
 					Hash:      header.BlockHash(),
 					ProofData: []byte{0xde, 0xad},
 				}},

--- a/node/blockchain/solve.go
+++ b/node/blockchain/solve.go
@@ -5,17 +5,30 @@
 package blockchain
 
 import (
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
 	"github.com/pearl-research-labs/pearl/node/wire"
 	"github.com/pearl-research-labs/pearl/node/zkpow"
 )
 
-// SolveBlock mines a ZKCertificate for the given block header.
-// On SimNet, it returns a lightweight dummy certificate (no actual mining),
-// matching the auto-skip of PoW verification in checkBlockSanity for SimNet.
-// NOTE: This function modifies header.ProofCommitment to match the mined certificate.
-func SolveBlock(header *wire.BlockHeader, net wire.PearlNet) (wire.BlockCertificate, error) {
-	if net == wire.SimNet {
-		return &wire.ZKCertificate{PublicData: [wire.PublicDataSize]byte{}, ProofData: []byte{0x00}}, nil
+// SolveBlock mines a block certificate for the given header at the given height,
+// selecting the version required by the MoE hardfork cutover
+// (params.RequiredCertVersion).
+//
+// On SimNet it returns a lightweight dummy certificate of the required version
+// (no actual mining), since PoW verification is skipped there. For real mining
+// it modifies header.ProofCommitment to match the mined certificate.
+func SolveBlock(header *wire.BlockHeader, params *chaincfg.Params, height int32) (wire.BlockCertificate, error) {
+	moeActive := params.IsMoEForkActive(height)
+
+	if params.Net == wire.SimNet {
+		if moeActive {
+			return &wire.MoECertificate{ProofData: []byte{0x00}}, nil
+		}
+		return &wire.ZKCertificate{ProofData: []byte{0x00}}, nil
+	}
+
+	if moeActive {
+		return zkpow.MineMoE(header)
 	}
 	return zkpow.Mine(header)
 }

--- a/node/blockchain/solve.go
+++ b/node/blockchain/solve.go
@@ -22,13 +22,13 @@ func SolveBlock(header *wire.BlockHeader, params *chaincfg.Params, height int32)
 
 	if params.Net == wire.SimNet {
 		if moeActive {
-			return &wire.MoECertificate{ProofData: []byte{0x00}}, nil
+			return &wire.CertificateV2{ProofData: []byte{0x00}}, nil
 		}
-		return &wire.ZKCertificate{ProofData: []byte{0x00}}, nil
+		return &wire.CertificateV1{ProofData: []byte{0x00}}, nil
 	}
 
 	if moeActive {
-		return zkpow.MineMoE(header)
+		return zkpow.MineV2(header)
 	}
-	return zkpow.Mine(header)
+	return zkpow.MineV1(header)
 }

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -512,6 +512,26 @@ func CheckBlockSanity(block *btcutil.Block, chainParams *chaincfg.Params, timeSo
 	return checkBlockSanity(block, chainParams, timeSource, BFNone)
 }
 
+// CheckCertificateVersion enforces the strict MoE hardfork cutover: the block at
+// the given height must carry the version returned by params.RequiredCertVersion
+// (MoE at/after the fork height, ZK before it).
+//
+// This is a contextual check (it needs the block height) and, unlike the
+// cryptographic proof check, is not gated by BFNoPoWCheck, so it is enforced
+// even where proof verification is skipped (e.g. SimNet).
+func CheckCertificateVersion(cert wire.BlockCertificate, height int32, params *chaincfg.Params) error {
+	if cert == nil {
+		return ruleError(ErrCertificateMissing, "block has no certificate")
+	}
+	want := params.RequiredCertVersion(height)
+	if cert.Version() != want {
+		str := fmt.Sprintf("certificate version %d is not allowed at height %d "+
+			"(require version %d)", cert.Version(), height, want)
+		return ruleError(ErrDisallowedCertVersion, str)
+	}
+	return nil
+}
+
 // ExtractCoinbaseHeight attempts to extract the height of the block from the
 // scriptSig of a coinbase transaction.  Coinbase heights are only present in
 // blocks of version 2 or later.  This was added as part of BIP0034.
@@ -701,13 +721,17 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		return err
 	}
 
+	// Enforce the MoE certificate version cutover. It is cheap and
+	// consensus-critical, so it runs regardless of BFFastAdd.
+	blockHeight := prevNode.height + 1
+	if err := CheckCertificateVersion(block.MsgBlock().BlockCertificate(),
+		blockHeight, b.chainParams); err != nil {
+		return err
+	}
+
 	fastAdd := flags&BFFastAdd == BFFastAdd
 	if !fastAdd {
 		blockTime := CalcPastMedianTime(prevNode)
-
-		// The height of this block is one more than the referenced
-		// previous block.
-		blockHeight := prevNode.height + 1
 
 		// Ensure all transactions in the block are finalized.
 		for _, tx := range block.Transactions() {

--- a/node/blockchain/validate_test.go
+++ b/node/blockchain/validate_test.go
@@ -153,7 +153,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 // TestCheckBlockSanity tests the CheckBlockSanity function to ensure it works
 // as expected.
 func TestCheckBlockSanity(t *testing.T) {
-	// Create a block with a valid ZKCertificate.
+	// Create a block with a valid CertificateV1.
 	// Use RegTest chainParams so PoW is actually verified (SimNet auto-skips PoW).
 	chainParams := &chaincfg.RegressionNetParams
 	header := wire.BlockHeader{
@@ -164,8 +164,8 @@ func TestCheckBlockSanity(t *testing.T) {
 		Bits:       chainParams.PowLimitBits,
 	}
 
-	// Mine a valid ZKCertificate (only 1 block, so longer ZK proof time is acceptable)
-	cert, err := zkpow.Mine(&header)
+	// Mine a valid CertificateV1 (only 1 block, so longer ZK proof time is acceptable)
+	cert, err := zkpow.MineV1(&header)
 	if err != nil {
 		t.Fatalf("Mine failed: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestCheckTransactionSanityOutputScriptTypes(t *testing.T) {
 var Block100000 = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash: chainhash.Hash([32]byte{ // Block hash placeholder
 					0xb4, 0x66, 0x51, 0x7c, 0x4c, 0xa8, 0x50, 0xc5,
 					0x7c, 0x21, 0x9c, 0x77, 0xbe, 0xe8, 0xdf, 0xcb,

--- a/node/btcutil/block_test.go
+++ b/node/btcutil/block_test.go
@@ -147,7 +147,7 @@ func TestBlock(t *testing.T) {
 	// Certificate(46) + Header(108) + varint(1) = 155 bytes before first tx
 	// Certificate format: Version(4) + BlockHash(32) + ProofLen(4) + ProofData(6) = 46 bytes
 	// Header format: Version(4) + PrevBlock(32) + MerkleRoot(32) + Timestamp(4) + Bits(4) + ProofCommitment(32) = 108 bytes
-	certLength := 212 // ZKCertificate: version(4) + hash(32) + PublicData(164) + proofLen(4) + proofData(8)
+	certLength := 212 // CertificateV1: version(4) + hash(32) + PublicData(164) + proofLen(4) + proofData(8)
 	headerLength := 108
 	varintLength := 1                                      // tx count varint
 	baseOffset := certLength + headerLength + varintLength // 305
@@ -308,11 +308,11 @@ func TestBlockErrors(t *testing.T) {
 }
 
 // Block100000 defines block 100,000 of the block chain.  It is used to
-// test Block operations. Uses ZKCertificate with stub proof (not valid for PoW verification).
+// test Block operations. Uses CertificateV1 with stub proof (not valid for PoW verification).
 var Block100000 = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      chainhash.Hash{},
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe, 0xba, 0xbe},
 			},

--- a/node/btcutil/bloom/merkleblock_test.go
+++ b/node/btcutil/bloom/merkleblock_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestMerkleBlock3(t *testing.T) {
 	blockStr := "" +
-		// ZKCertificate (212 bytes): Version(4) + BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData(8)
+		// CertificateV1 (212 bytes): Version(4) + BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData(8)
 		"01000000" + // Version (1 = ZK)
 		"0000000000000000000000000000000000000000000000000000000000000000" + // BlockHash (32 zeros)
 		// PublicData (164 bytes = 5×32 + 4 bytes, all zeros)

--- a/node/chaincfg/genesis.go
+++ b/node/chaincfg/genesis.go
@@ -90,7 +90,7 @@ var genesisMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{
 var genesisBlock = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      genesisHash,
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef}, // Vanity proof for genesis block
 			},
@@ -125,7 +125,7 @@ var regTestGenesisMerkleRoot = genesisMerkleRoot
 var regTestGenesisBlock = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      regTestGenesisHash,
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef}, // Vanity proof for genesis block
 			},
@@ -205,7 +205,7 @@ var testNetGenesisMerkleRoot = chainhash.Hash([chainhash.HashSize]byte{
 var testNetGenesisBlock = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      testNetGenesisHash,
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef}, // Vanity proof for genesis block
 			},
@@ -240,7 +240,7 @@ var testNet2GenesisMerkleRoot = testNetGenesisMerkleRoot
 var testNet2GenesisBlock = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      testNet2GenesisHash,
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef}, // Vanity proof for genesis block
 			},
@@ -275,7 +275,7 @@ var simNetGenesisMerkleRoot = genesisMerkleRoot
 var simNetGenesisBlock = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      simNetGenesisHash,
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef}, // Vanity proof for genesis block
 			},
@@ -310,7 +310,7 @@ var sigNetGenesisMerkleRoot = genesisMerkleRoot
 var sigNetGenesisBlock = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash:      sigNetGenesisHash,
 				ProofData: []byte{0xde, 0xad, 0xbe, 0xef}, // Vanity proof for genesis block
 			},

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -249,6 +249,13 @@ type Params struct {
 	MinerConfirmationWindow       uint32
 	Deployments                   [DefinedDeployments]ConsensusDeployment
 
+	// MoEForkHeight is the block height at which the MoE hardfork activates.
+	// At and after this height blocks must carry the MoE certificate
+	// (wire.CertificateVersionMoE); before it, the legacy ZK certificate
+	// (wire.CertificateVersionZK). A value of 0 disables the fork (ZK at every
+	// height).
+	MoEForkHeight int32
+
 	// Mempool parameters
 	RelayNonStdTxs bool
 
@@ -266,6 +273,23 @@ type Params struct {
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
 	HDCoinType uint32
+}
+
+// IsMoEForkActive reports whether the MoE hardfork is active at the given block
+// height. The fork is disabled when MoEForkHeight is 0.
+func (p *Params) IsMoEForkActive(height int32) bool {
+	return p.MoEForkHeight != 0 && height >= p.MoEForkHeight
+}
+
+// RequiredCertVersion returns the block certificate version that a block at the
+// given height must use under the strict MoE hardfork cutover: the MoE
+// certificate at and after the activation height, the legacy ZK certificate
+// before it (and always, when the fork is disabled).
+func (p *Params) RequiredCertVersion(height int32) wire.CertificateVersion {
+	if p.IsMoEForkActive(height) {
+		return wire.CertificateVersionMoE
+	}
+	return wire.CertificateVersionZK
 }
 
 // MainNetParams defines the network parameters for the main Pearl network.

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -251,8 +251,8 @@ type Params struct {
 
 	// MoEForkHeight is the block height at which the MoE hardfork activates.
 	// At and after this height blocks must carry the MoE certificate
-	// (wire.CertificateVersionMoE); before it, the legacy ZK certificate
-	// (wire.CertificateVersionZK). A value of 0 disables the fork (ZK at every
+	// (wire.CertificateVersionV2); before it, the legacy ZK certificate
+	// (wire.CertificateVersionV1). A value of 0 disables the fork (ZK at every
 	// height).
 	MoEForkHeight int32
 
@@ -287,9 +287,9 @@ func (p *Params) IsMoEForkActive(height int32) bool {
 // before it (and always, when the fork is disabled).
 func (p *Params) RequiredCertVersion(height int32) wire.CertificateVersion {
 	if p.IsMoEForkActive(height) {
-		return wire.CertificateVersionMoE
+		return wire.CertificateVersionV2
 	}
-	return wire.CertificateVersionZK
+	return wire.CertificateVersionV1
 }
 
 // MainNetParams defines the network parameters for the main Pearl network.

--- a/node/chaincfg/params_test.go
+++ b/node/chaincfg/params_test.go
@@ -100,6 +100,58 @@ func TestSigNetMagic(t *testing.T) {
 	require.Equal(t, wire.SigNet, SigNetParams.Net)
 }
 
+// TestMoEForkActivation verifies the strict cutover at the MoE hardfork
+// activation height: ZK before the fork, MoE at and after it.
+func TestMoEForkActivation(t *testing.T) {
+	const forkHeight = int32(100)
+	p := Params{MoEForkHeight: forkHeight}
+
+	tests := []struct {
+		name        string
+		height      int32
+		wantActive  bool
+		wantVersion wire.CertificateVersion
+	}{
+		{"genesis", 0, false, wire.CertificateVersionZK},
+		{"just before fork", forkHeight - 1, false, wire.CertificateVersionZK},
+		{"at fork height", forkHeight, true, wire.CertificateVersionMoE},
+		{"after fork height", forkHeight + 1, true, wire.CertificateVersionMoE},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantActive, p.IsMoEForkActive(tt.height))
+			require.Equal(t, tt.wantVersion, p.RequiredCertVersion(tt.height))
+		})
+	}
+}
+
+// TestMoEForkDisabled verifies that a zero MoEForkHeight disables the fork at
+// every height (the legacy ZK certificate is always required).
+func TestMoEForkDisabled(t *testing.T) {
+	p := Params{MoEForkHeight: 0}
+	for _, height := range []int32{0, 1, 100, 1_000_000} {
+		require.False(t, p.IsMoEForkActive(height))
+		require.Equal(t, wire.CertificateVersionZK, p.RequiredCertVersion(height))
+	}
+}
+
+// TestShippedNetworksMoEForkDisabled enforces that every shipped network ships
+// with the MoE hardfork disabled until the verifier is finalized and an
+// activation height is chosen.
+func TestShippedNetworksMoEForkDisabled(t *testing.T) {
+	networks := map[string]*Params{
+		"mainnet":  &MainNetParams,
+		"testnet":  &TestNetParams,
+		"testnet2": &TestNet2Params,
+		"regtest":  &RegressionNetParams,
+		"simnet":   &SimNetParams,
+	}
+	for name, p := range networks {
+		require.Zerof(t, p.MoEForkHeight,
+			"%s must ship with the MoE fork disabled", name)
+	}
+}
+
 // compactToBig is a copy of the blockchain.CompactToBig function. We copy it
 // here so we don't run into a circular dependency just because of a test.
 func compactToBig(compact uint32) *big.Int {

--- a/node/chaincfg/params_test.go
+++ b/node/chaincfg/params_test.go
@@ -112,10 +112,10 @@ func TestMoEForkActivation(t *testing.T) {
 		wantActive  bool
 		wantVersion wire.CertificateVersion
 	}{
-		{"genesis", 0, false, wire.CertificateVersionZK},
-		{"just before fork", forkHeight - 1, false, wire.CertificateVersionZK},
-		{"at fork height", forkHeight, true, wire.CertificateVersionMoE},
-		{"after fork height", forkHeight + 1, true, wire.CertificateVersionMoE},
+		{"genesis", 0, false, wire.CertificateVersionV1},
+		{"just before fork", forkHeight - 1, false, wire.CertificateVersionV1},
+		{"at fork height", forkHeight, true, wire.CertificateVersionV2},
+		{"after fork height", forkHeight + 1, true, wire.CertificateVersionV2},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -131,7 +131,7 @@ func TestMoEForkDisabled(t *testing.T) {
 	p := Params{MoEForkHeight: 0}
 	for _, height := range []int32{0, 1, 100, 1_000_000} {
 		require.False(t, p.IsMoEForkActive(height))
-		require.Equal(t, wire.CertificateVersionZK, p.RequiredCertVersion(height))
+		require.Equal(t, wire.CertificateVersionV1, p.RequiredCertVersion(height))
 	}
 }
 

--- a/node/integration/rpctest/blockgen.go
+++ b/node/integration/rpctest/blockgen.go
@@ -18,9 +18,11 @@ import (
 )
 
 // solveBlock generates a certificate for the given block header using the
-// network-aware SolveBlock: real mining on RegTest/MainNet, dummy cert on SimNet.
-func solveBlock(header *wire.BlockHeader, net wire.PearlNet) (wire.BlockCertificate, error) {
-	return blockchain.SolveBlock(header, net)
+// network- and height-aware SolveBlock: real mining on RegTest/MainNet, dummy
+// cert on SimNet. The height selects the certificate version under the MoE
+// hardfork cutover.
+func solveBlock(header *wire.BlockHeader, params *chaincfg.Params, height int32) (wire.BlockCertificate, error) {
+	return blockchain.SolveBlock(header, params, height)
 }
 
 // standardCoinbaseScript returns a standard script suitable for use as the
@@ -149,7 +151,7 @@ func CreateBlock(prevBlock *btcutil.Block, inclusionTxs []*btcutil.Tx,
 		}
 	}
 
-	cert, solveErr := solveBlock(block.BlockHeader(), net.Net)
+	cert, solveErr := solveBlock(block.BlockHeader(), net, blockHeight)
 	if solveErr != nil {
 		return nil, fmt.Errorf("unable to solve block: %w", solveErr)
 	}

--- a/node/mining/cpuminer/cpuminer.go
+++ b/node/mining/cpuminer/cpuminer.go
@@ -144,7 +144,7 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, blockHeight int32) bool {
 	}
 
 	// Generate certificate using solve method
-	cert, err := blockchain.SolveBlock(msgBlock.BlockHeader(), m.cfg.ChainParams.Net)
+	cert, err := blockchain.SolveBlock(msgBlock.BlockHeader(), m.cfg.ChainParams, blockHeight)
 	if err != nil {
 		log.Errorf("Failed to solve block: %v", err)
 		return false

--- a/node/mining/mining.go
+++ b/node/mining/mining.go
@@ -654,7 +654,7 @@ mempoolLoop:
 		Bits:       reqDifficulty,
 	}}
 	msgBlock.MsgHeader.MsgCertificate = wire.MsgCertificate{
-		Certificate: &wire.ZKCertificate{
+		Certificate: &wire.CertificateV1{
 			Hash: msgBlock.BlockHash(),
 		},
 	}

--- a/node/mining/mining.go
+++ b/node/mining/mining.go
@@ -653,11 +653,16 @@ mempoolLoop:
 		Timestamp:  ts,
 		Bits:       reqDifficulty,
 	}}
-	msgBlock.MsgHeader.MsgCertificate = wire.MsgCertificate{
-		Certificate: &wire.CertificateV1{
-			Hash: msgBlock.BlockHash(),
-		},
+	// Use a certificate placeholder whose version matches what consensus
+	// requires at this height, so CheckConnectBlockTemplate (which enforces
+	// the version cutover) accepts the template at and after the fork height.
+	var certificate wire.BlockCertificate
+	if g.chainParams.IsMoEForkActive(nextBlockHeight) {
+		certificate = &wire.CertificateV2{Hash: msgBlock.BlockHash()}
+	} else {
+		certificate = &wire.CertificateV1{Hash: msgBlock.BlockHash()}
 	}
+	msgBlock.MsgHeader.MsgCertificate = wire.MsgCertificate{Certificate: certificate}
 	for _, tx := range blockTxns {
 		if err := msgBlock.AddTransaction(tx.MsgTx()); err != nil {
 			return nil, err

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -1083,6 +1083,21 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		prevNode := prevNodeEl.Value.(*headerNode)
 		if prevNode.hash.IsEqual(&blockHeader.PrevBlock) {
 			node.height = prevNode.height + 1
+
+			// Enforce the MoE certificate version cutover now that
+			// the header's height is known (CheckHeaderSanity above
+			// is context-free).
+			if err := blockchain.CheckCertificateVersion(
+				msgHeader.BlockCertificate(), node.height,
+				sm.chainParams,
+			); err != nil {
+				log.Warnf("Header from peer %s has a disallowed "+
+					"certificate version: %v -- disconnecting",
+					peer.Addr(), err)
+				peer.Disconnect()
+				return
+			}
+
 			e := sm.headerList.PushBack(&node)
 			if sm.startHeader == nil {
 				sm.startHeader = e

--- a/node/peer/peer_test.go
+++ b/node/peer/peer_test.go
@@ -336,9 +336,9 @@ func TestPeerListeners(t *testing.T) {
 			MsgHeader: wire.MsgHeader{
 				BlockHeader: *wire.NewBlockHeader(1, &chainhash.Hash{}, &chainhash.Hash{}, 1),
 				MsgCertificate: wire.MsgCertificate{
-					Certificate: &wire.ZKCertificate{
+					Certificate: &wire.CertificateV1{
 						Hash:       chainhash.Hash{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20},
-						PublicData: [wire.PublicDataSize]byte{},
+						PublicData: [wire.PublicDataSizeV1]byte{},
 						ProofData:  make([]byte, 51200),
 					},
 				},

--- a/node/wire/bench_test.go
+++ b/node/wire/bench_test.go
@@ -842,7 +842,7 @@ func BenchmarkDecodeGetHeaders(b *testing.B) {
 
 // BenchmarkDecodeHeaders performs a benchmark on how long it takes to
 // decode a headers message with the maximum number of headers.
-// Uses ZKCertificate with realistic 50KB+ proof data to simulate production workloads.
+// Uses CertificateV1 with realistic 50KB+ proof data to simulate production workloads.
 func BenchmarkDecodeHeaders(b *testing.B) {
 	b.ReportAllocs()
 
@@ -861,9 +861,9 @@ func BenchmarkDecodeHeaders(b *testing.B) {
 			b.Fatalf("NewHashFromStr: unexpected error: %v", err)
 		}
 		bh := NewBlockHeader(1, hash, hash, 0)
-		cert := &ZKCertificate{
+		cert := &CertificateV1{
 			Hash:       bh.BlockHash(),
-			PublicData: [PublicDataSize]byte{},
+			PublicData: [PublicDataSizeV1]byte{},
 			ProofData:  proofData,
 		}
 		m.AddBlockHeader(*bh, cert)

--- a/node/wire/certificate.go
+++ b/node/wire/certificate.go
@@ -13,7 +13,7 @@ logic through three layers:
 
 1. MsgCertificate: Wrapper handling version-based polymorphic encoding/decoding
 2. BlockCertificate: Interface defining symmetric Serialize/Deserialize methods
-3. Certificate types: Concrete implementations (currently only ZKCertificate)
+3. Certificate types: Concrete implementations (CertificateV1; CertificateV2 not yet finalized)
 
 # WIRE FORMAT
 
@@ -21,7 +21,7 @@ Version-first design enables polymorphic decoding:
 
 	MsgCertificate: Version(4) + certificate-specific fields
 
-	ZKCertificate: BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData
+	CertificateV1: BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData
 	  Size: 238 + len(ProofData) bytes
 	  PublicData: committed public fields
 	  ProofData: Plonky2 proof bytes
@@ -42,7 +42,7 @@ blockchain.CheckCertificateVersion.
 
 # GENESIS BLOCKS
 
-All genesis blocks use empty ZKCertificate (all fields zero except hash).
+All genesis blocks use empty CertificateV1 (all fields zero except hash).
 Genesis blocks are never verified (hardcoded and trusted), only serialized.
 
 # IMPLEMENTATION NOTES
@@ -61,10 +61,10 @@ import (
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 )
 
-// MaxZKProofSize is the maximum size of a serialized ZK proof blob.
-const MaxZKProofSize = 60000
+// MaxProofSizeV1 is the maximum size of a serialized ZK proof blob.
+const MaxProofSizeV1 = 60000
 
-// CertificateMaxSize is the maximum allowed certificate size. Has headroom on top of MaxZKProofSize.
+// CertificateMaxSize is the maximum allowed certificate size. Has headroom on top of MaxProofSizeV1.
 const CertificateMaxSize = 65000
 
 // CertificateVersion identifies the certificate format version.
@@ -72,11 +72,11 @@ type CertificateVersion uint32
 
 const (
 	CertificateVersionNull CertificateVersion = 0
-	CertificateVersionZK   CertificateVersion = 1
-	// CertificateVersionMoE is the certificate version introduced by the
+	CertificateVersionV1   CertificateVersion = 1
+	// CertificateVersionV2 is the certificate version introduced by the
 	// MoE hardfork. Its concrete format and verifier are not yet finalized
-	// (see the TODOs on MoECertificate and verifyMoECertificate).
-	CertificateVersionMoE CertificateVersion = 2
+	// (see the TODOs on CertificateV2 and verifyV2Certificate).
+	CertificateVersionV2 CertificateVersion = 2
 )
 
 // BlockCertificate is the interface that all certificate types must implement.
@@ -106,7 +106,7 @@ type BlockCertificate interface {
 // whether a version is valid at a given height (the MoE hardfork cutover) is
 // enforced separately in blockchain.CheckCertificateVersion.
 func IsCertVersionAllowed(v CertificateVersion) bool {
-	return v == CertificateVersionZK || v == CertificateVersionMoE
+	return v == CertificateVersionV1 || v == CertificateVersionV2
 }
 
 // MsgCertificate wraps a BlockCertificate and handles polymorphic
@@ -149,11 +149,11 @@ func (m *MsgCertificate) PrlDecode(r io.Reader, pver uint32) error {
 		m.Certificate = nil
 		return nil
 
-	case CertificateVersionZK:
-		m.Certificate = &ZKCertificate{}
+	case CertificateVersionV1:
+		m.Certificate = &CertificateV1{}
 
-	case CertificateVersionMoE:
-		m.Certificate = &MoECertificate{}
+	case CertificateVersionV2:
+		m.Certificate = &CertificateV2{}
 
 	default:
 		return fmt.Errorf("unsupported certificate version: %d", version)

--- a/node/wire/certificate.go
+++ b/node/wire/certificate.go
@@ -33,11 +33,12 @@ Certificate types implement perfectly mirrored Serialize/Deserialize methods:
 - Version handling delegated to MsgCertificate wrapper
 - Eliminates encoding/decoding asymmetry
 
-# NETWORK RESTRICTIONS
+# VERSION POLICY
 
-Only CertificateVersionZK is allowed. IsCertVersionAllowed(net, v) returns true
-only for CertificateVersionZK. blockchain.checkBlockSanity also validates via
-IsCertVersionAllowed.
+IsCertVersionAllowed is context-free: it reports whether a version is known and
+decodable here. Whether a version is valid at a given height (the MoE hardfork
+cutover) is a consensus rule enforced separately by
+blockchain.CheckCertificateVersion.
 
 # GENESIS BLOCKS
 
@@ -72,6 +73,10 @@ type CertificateVersion uint32
 const (
 	CertificateVersionNull CertificateVersion = 0
 	CertificateVersionZK   CertificateVersion = 1
+	// CertificateVersionMoE is the certificate version introduced by the
+	// MoE hardfork. Its concrete format and verifier are not yet finalized
+	// (see the TODOs on MoECertificate and verifyMoECertificate).
+	CertificateVersionMoE CertificateVersion = 2
 )
 
 // BlockCertificate is the interface that all certificate types must implement.
@@ -96,9 +101,12 @@ type BlockCertificate interface {
 	SerializedSize() int
 }
 
-// IsCertVersionAllowed reports whether certificate version v is permitted.
+// IsCertVersionAllowed reports whether certificate version v is structurally
+// known and can be decoded and dispatched by this node. It is context-free:
+// whether a version is valid at a given height (the MoE hardfork cutover) is
+// enforced separately in blockchain.CheckCertificateVersion.
 func IsCertVersionAllowed(v CertificateVersion) bool {
-	return v == CertificateVersionZK
+	return v == CertificateVersionZK || v == CertificateVersionMoE
 }
 
 // MsgCertificate wraps a BlockCertificate and handles polymorphic
@@ -143,6 +151,9 @@ func (m *MsgCertificate) PrlDecode(r io.Reader, pver uint32) error {
 
 	case CertificateVersionZK:
 		m.Certificate = &ZKCertificate{}
+
+	case CertificateVersionMoE:
+		m.Certificate = &MoECertificate{}
 
 	default:
 		return fmt.Errorf("unsupported certificate version: %d", version)

--- a/node/wire/certificate_moe.go
+++ b/node/wire/certificate_moe.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+)
+
+// MoEPublicDataSize is the size of the committed PublicData prefix for an MoE
+// certificate. It mirrors ZKCertificate as a placeholder.
+//
+// TODO Or: update when the MoE certificate format is finalized.
+const MoEPublicDataSize = 164
+
+// MaxMoEProofSize is the maximum size of a serialized MoE proof blob.
+//
+// TODO Or: update when the MoE proof format is finalized.
+const MaxMoEProofSize = 60000
+
+// MoECertificate is the Block Certificate introduced by the MoE hardfork. It is
+// a distinct type from ZKCertificate so the finalized format can diverge; the
+// current fields are placeholders.
+//
+// TODO Or: update when the MoE certificate format and verifier are finalized.
+type MoECertificate struct {
+	// Hash is the block hash this certificate is bound to.
+	Hash chainhash.Hash
+
+	// PublicData contains the committed public fields. Placeholder layout.
+	PublicData [MoEPublicDataSize]byte
+
+	// ProofData contains the MoE proof. Placeholder format.
+	ProofData []byte
+}
+
+func (c *MoECertificate) Version() CertificateVersion {
+	return CertificateVersionMoE
+}
+
+func (c *MoECertificate) BlockHash() chainhash.Hash {
+	return c.Hash
+}
+
+// ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData). The
+// version is included so the commitment binds to the certificate version.
+func (c *MoECertificate) ProofCommitment() chainhash.Hash {
+	var buf [4 + MoEPublicDataSize]byte
+	binary.LittleEndian.PutUint32(buf[:4], uint32(c.Version()))
+	copy(buf[4:], c.PublicData[:])
+	return chainhash.DoubleHashH(buf[:])
+}
+
+// Serialize: BlockHash(32) + PublicData(MoEPublicDataSize) + ProofLen(4) + ProofData
+// Version excluded - handled by MsgCertificate.
+func (c *MoECertificate) Serialize(w io.Writer) error {
+	if _, err := w.Write(c.Hash[:]); err != nil {
+		return err
+	}
+	if _, err := w.Write(c.PublicData[:]); err != nil {
+		return err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, uint32(len(c.ProofData))); err != nil {
+		return err
+	}
+	if _, err := w.Write(c.ProofData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Deserialize: BlockHash(32) + PublicData(MoEPublicDataSize) + ProofLen(4) + ProofData
+// Version excluded - handled by MsgCertificate.
+func (c *MoECertificate) Deserialize(r io.Reader) error {
+	if _, err := io.ReadFull(r, c.Hash[:]); err != nil {
+		return err
+	}
+	if _, err := io.ReadFull(r, c.PublicData[:]); err != nil {
+		return err
+	}
+
+	var proofLen uint32
+	if err := binary.Read(r, binary.LittleEndian, &proofLen); err != nil {
+		return err
+	}
+	if proofLen > MaxMoEProofSize {
+		return fmt.Errorf("proof data too large: %d bytes (max %d)", proofLen, MaxMoEProofSize)
+	}
+
+	c.ProofData = make([]byte, proofLen)
+	if _, err := io.ReadFull(r, c.ProofData); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SerializedSize returns the number of bytes needed to serialize the certificate
+// fields. Format: BlockHash(32) + PublicData(MoEPublicDataSize) + ProofLen(4) + ProofData
+// Note: Does NOT include version (4 bytes) - that's handled by MsgCertificate.
+func (c *MoECertificate) SerializedSize() int {
+	return 32 + MoEPublicDataSize + 4 + len(c.ProofData)
+}

--- a/node/wire/certificate_test.go
+++ b/node/wire/certificate_test.go
@@ -6,6 +6,7 @@ package wire_test
 
 import (
 	"bytes"
+	"encoding/binary"
 	"testing"
 	"time"
 
@@ -169,4 +170,147 @@ func TestMsgCertificate_ZK_RoundTrip(t *testing.T) {
 	decodedZK, ok := decoded.Certificate.(*wire.ZKCertificate)
 	require.True(t, ok, "decoded certificate should be ZKCertificate")
 	require.Equal(t, cert.Hash, decodedZK.Hash)
+}
+
+// ============================================================================
+// MoECertificate Tests
+// ============================================================================
+
+// newTestMoECert builds an MoECertificate with deterministic placeholder
+// contents. It does not call the (fail-closed) MoE miner, so these tests
+// exercise the wire layer independently of the verifier implementation.
+func newTestMoECert() *wire.MoECertificate {
+	cert := &wire.MoECertificate{
+		Hash:      chainhash.Hash{0x11, 0x22, 0x33, 0x44},
+		ProofData: []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02},
+	}
+	for i := range cert.PublicData {
+		cert.PublicData[i] = byte(i)
+	}
+	return cert
+}
+
+func TestMoECertificate_Version(t *testing.T) {
+	cert := &wire.MoECertificate{}
+	require.Equal(t, wire.CertificateVersionMoE, cert.Version())
+}
+
+func TestMoECertificate_BlockHash(t *testing.T) {
+	expectedHash := chainhash.Hash{1, 2, 3, 4}
+	cert := &wire.MoECertificate{Hash: expectedHash}
+	require.Equal(t, expectedHash, cert.BlockHash())
+}
+
+func TestMoECertificate_SerializeDeserialize(t *testing.T) {
+	cert := newTestMoECert()
+
+	var buf bytes.Buffer
+	require.NoError(t, cert.Serialize(&buf), "serialization should succeed")
+
+	wantSize := 32 + wire.MoEPublicDataSize + 4 + len(cert.ProofData)
+	require.Equal(t, wantSize, buf.Len())
+	require.Equal(t, wantSize, cert.SerializedSize())
+
+	deserialized := &wire.MoECertificate{}
+	require.NoError(t, deserialized.Deserialize(bytes.NewReader(buf.Bytes())),
+		"deserialization should succeed")
+
+	require.Equal(t, cert.Hash, deserialized.Hash)
+	require.Equal(t, cert.PublicData, deserialized.PublicData)
+	require.Equal(t, cert.ProofData, deserialized.ProofData)
+}
+
+func TestMoECertificate_ProofCommitmentDeterministic(t *testing.T) {
+	cert := newTestMoECert()
+	require.Equal(t, cert.ProofCommitment(), cert.ProofCommitment(),
+		"commitment must be deterministic")
+}
+
+// TestMoECertificate_ProofCommitmentVersioned ensures the commitment binds to
+// the certificate version: an MoE certificate and a ZK certificate with
+// identical PublicData must produce different commitments.
+func TestMoECertificate_ProofCommitmentVersioned(t *testing.T) {
+	moe := newTestMoECert()
+
+	var zk wire.ZKCertificate
+	zk.Hash = moe.Hash
+	copy(zk.PublicData[:], moe.PublicData[:])
+
+	require.NotEqual(t, zk.ProofCommitment(), moe.ProofCommitment(),
+		"ZK and MoE commitments over identical PublicData must differ by version")
+}
+
+func TestMoECertificate_DeserializeProofTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	var hash chainhash.Hash
+	_, _ = buf.Write(hash[:])
+	var pub [wire.MoEPublicDataSize]byte
+	_, _ = buf.Write(pub[:])
+	// Claim a proof length above the maximum without writing the bytes.
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(wire.MaxMoEProofSize+1)))
+
+	cert := &wire.MoECertificate{}
+	require.Error(t, cert.Deserialize(bytes.NewReader(buf.Bytes())),
+		"oversized proof must be rejected")
+}
+
+func TestMsgCertificate_MoE_RoundTrip(t *testing.T) {
+	cert := newTestMoECert()
+
+	msg := &wire.MsgCertificate{Certificate: cert}
+	require.Equal(t, wire.CertificateVersionMoE, msg.Certificate.Version())
+
+	var buf bytes.Buffer
+	require.NoError(t, msg.PrlEncode(&buf, wire.ProtocolVersion), "encoding should succeed")
+
+	// MsgCertificate adds a 4-byte version prefix.
+	require.Equal(t, 4+cert.SerializedSize(), msg.SerializeSize())
+
+	decoded := &wire.MsgCertificate{}
+	require.NoError(t, decoded.PrlDecode(bytes.NewReader(buf.Bytes()), wire.ProtocolVersion),
+		"decoding should succeed")
+
+	require.Equal(t, wire.CertificateVersionMoE, decoded.Certificate.Version())
+	decodedMoE, ok := decoded.Certificate.(*wire.MoECertificate)
+	require.True(t, ok, "decoded certificate should be *MoECertificate")
+	require.Equal(t, cert.Hash, decodedMoE.Hash)
+	require.Equal(t, cert.PublicData, decodedMoE.PublicData)
+	require.Equal(t, cert.ProofData, decodedMoE.ProofData)
+}
+
+func TestMsgCertificate_UnknownVersion(t *testing.T) {
+	// A version that is neither Null, ZK, nor MoE must fail to decode.
+	var buf bytes.Buffer
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(wire.CertificateVersionMoE+1)))
+
+	decoded := &wire.MsgCertificate{}
+	require.Error(t, decoded.PrlDecode(bytes.NewReader(buf.Bytes()), wire.ProtocolVersion),
+		"unknown certificate version must be rejected")
+}
+
+func TestMsgCertificate_MoE_TooLargeEncode(t *testing.T) {
+	cert := newTestMoECert()
+	// Make the serialized MsgCertificate exceed CertificateMaxSize.
+	cert.ProofData = make([]byte, wire.CertificateMaxSize)
+
+	msg := &wire.MsgCertificate{Certificate: cert}
+	var buf bytes.Buffer
+	require.Error(t, msg.PrlEncode(&buf, wire.ProtocolVersion),
+		"encoding an oversized certificate must be rejected")
+}
+
+func TestIsCertVersionAllowed(t *testing.T) {
+	tests := []struct {
+		version wire.CertificateVersion
+		allowed bool
+	}{
+		{wire.CertificateVersionNull, false},
+		{wire.CertificateVersionZK, true},
+		{wire.CertificateVersionMoE, true},
+		{wire.CertificateVersionMoE + 1, false},
+	}
+	for _, tt := range tests {
+		require.Equalf(t, tt.allowed, wire.IsCertVersionAllowed(tt.version),
+			"IsCertVersionAllowed(%d)", tt.version)
+	}
 }

--- a/node/wire/certificate_test.go
+++ b/node/wire/certificate_test.go
@@ -44,13 +44,13 @@ func testBlockHeader(nbits ...uint32) wire.BlockHeader {
 }
 
 // ============================================================================
-// ZKCertificate Tests
+// CertificateV1 Tests
 // ============================================================================
 
-func TestZKCertificate_SerializeDeserialize(t *testing.T) {
+func TestCertificateV1_SerializeDeserialize(t *testing.T) {
 	header := testBlockHeader()
 
-	cert, err := zkpow.Mine(&header)
+	cert, err := zkpow.MineV1(&header)
 	require.NoError(t, err, "mining should succeed")
 
 	var buf bytes.Buffer
@@ -61,7 +61,7 @@ func TestZKCertificate_SerializeDeserialize(t *testing.T) {
 	require.NotEmpty(t, serialized, "serialized data should not be empty")
 	t.Logf("Serialized size: %d bytes", len(serialized))
 
-	deserialized := &wire.ZKCertificate{}
+	deserialized := &wire.CertificateV1{}
 	err = deserialized.Deserialize(bytes.NewReader(serialized))
 	require.NoError(t, err, "deserialization should succeed")
 
@@ -70,26 +70,26 @@ func TestZKCertificate_SerializeDeserialize(t *testing.T) {
 	require.Equal(t, cert.ProofData, deserialized.ProofData)
 }
 
-func TestZKCertificate_Verify(t *testing.T) {
+func TestCertificateV1_Verify(t *testing.T) {
 	header := testBlockHeader()
 
-	cert, err := zkpow.Mine(&header)
+	cert, err := zkpow.MineV1(&header)
 	require.NoError(t, err, "mining should succeed")
 
 	err = zkpow.VerifyCertificate(&header, cert)
-	require.NoError(t, err, "valid ZKCertificate should verify")
+	require.NoError(t, err, "valid CertificateV1 should verify")
 }
 
-func TestZKCertificate_VerifyErrors(t *testing.T) {
+func TestCertificateV1_VerifyErrors(t *testing.T) {
 	header := testBlockHeader()
 
-	origCert, err := zkpow.Mine(&header)
+	origCert, err := zkpow.MineV1(&header)
 	require.NoError(t, err, "mining should succeed")
 
-	createCert := func() *wire.ZKCertificate {
+	createCert := func() *wire.CertificateV1 {
 		proofDataCopy := make([]byte, len(origCert.ProofData))
 		copy(proofDataCopy, origCert.ProofData)
-		return &wire.ZKCertificate{
+		return &wire.CertificateV1{
 			Hash:       origCert.Hash,
 			PublicData: origCert.PublicData,
 			ProofData:  proofDataCopy,
@@ -99,24 +99,24 @@ func TestZKCertificate_VerifyErrors(t *testing.T) {
 	// Test certificate-level validation only (not underlying verifier logic)
 	tests := []struct {
 		name   string
-		modify func(*wire.ZKCertificate)
+		modify func(*wire.CertificateV1)
 	}{
 		{
 			name: "empty proof data",
-			modify: func(c *wire.ZKCertificate) {
+			modify: func(c *wire.CertificateV1) {
 				c.ProofData = nil
 			},
 		},
 		{
 			name: "corrupted config",
-			modify: func(c *wire.ZKCertificate) {
+			modify: func(c *wire.CertificateV1) {
 				// Flip a random byte to corrupt it
-				c.PublicData[wire.PublicDataSize/2] ^= 0xFF
+				c.PublicData[wire.PublicDataSizeV1/2] ^= 0xFF
 			},
 		},
 		{
 			name: "block hash mismatch",
-			modify: func(c *wire.ZKCertificate) {
+			modify: func(c *wire.CertificateV1) {
 				c.Hash[0] ^= 0xFF
 			},
 		},
@@ -133,14 +133,14 @@ func TestZKCertificate_VerifyErrors(t *testing.T) {
 	}
 }
 
-func TestZKCertificate_Version(t *testing.T) {
-	cert := &wire.ZKCertificate{}
-	require.Equal(t, wire.CertificateVersionZK, cert.Version())
+func TestCertificateV1_Version(t *testing.T) {
+	cert := &wire.CertificateV1{}
+	require.Equal(t, wire.CertificateVersionV1, cert.Version())
 }
 
-func TestZKCertificate_BlockHash(t *testing.T) {
+func TestCertificateV1_BlockHash(t *testing.T) {
 	expectedHash := chainhash.Hash{1, 2, 3, 4}
-	cert := &wire.ZKCertificate{Hash: expectedHash}
+	cert := &wire.CertificateV1{Hash: expectedHash}
 	require.Equal(t, expectedHash, cert.BlockHash())
 }
 
@@ -151,12 +151,12 @@ func TestZKCertificate_BlockHash(t *testing.T) {
 func TestMsgCertificate_ZK_RoundTrip(t *testing.T) {
 	header := testBlockHeader()
 
-	cert, err := zkpow.Mine(&header)
+	cert, err := zkpow.MineV1(&header)
 	require.NoError(t, err, "mining should succeed")
 
 	msg := &wire.MsgCertificate{Certificate: cert}
 	require.NotNil(t, msg)
-	require.Equal(t, wire.CertificateVersionZK, msg.Certificate.Version())
+	require.Equal(t, wire.CertificateVersionV1, msg.Certificate.Version())
 
 	var buf bytes.Buffer
 	err = msg.PrlEncode(&buf, wire.ProtocolVersion)
@@ -166,21 +166,21 @@ func TestMsgCertificate_ZK_RoundTrip(t *testing.T) {
 	err = decoded.PrlDecode(bytes.NewReader(buf.Bytes()), wire.ProtocolVersion)
 	require.NoError(t, err, "decoding should succeed")
 
-	require.Equal(t, wire.CertificateVersionZK, decoded.Certificate.Version())
-	decodedZK, ok := decoded.Certificate.(*wire.ZKCertificate)
-	require.True(t, ok, "decoded certificate should be ZKCertificate")
+	require.Equal(t, wire.CertificateVersionV1, decoded.Certificate.Version())
+	decodedZK, ok := decoded.Certificate.(*wire.CertificateV1)
+	require.True(t, ok, "decoded certificate should be CertificateV1")
 	require.Equal(t, cert.Hash, decodedZK.Hash)
 }
 
 // ============================================================================
-// MoECertificate Tests
+// CertificateV2 Tests
 // ============================================================================
 
-// newTestMoECert builds an MoECertificate with deterministic placeholder
+// newTestMoECert builds an CertificateV2 with deterministic placeholder
 // contents. It does not call the (fail-closed) MoE miner, so these tests
 // exercise the wire layer independently of the verifier implementation.
-func newTestMoECert() *wire.MoECertificate {
-	cert := &wire.MoECertificate{
+func newTestMoECert() *wire.CertificateV2 {
+	cert := &wire.CertificateV2{
 		Hash:      chainhash.Hash{0x11, 0x22, 0x33, 0x44},
 		ProofData: []byte{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01, 0x02},
 	}
@@ -190,28 +190,28 @@ func newTestMoECert() *wire.MoECertificate {
 	return cert
 }
 
-func TestMoECertificate_Version(t *testing.T) {
-	cert := &wire.MoECertificate{}
-	require.Equal(t, wire.CertificateVersionMoE, cert.Version())
+func TestCertificateV2_Version(t *testing.T) {
+	cert := &wire.CertificateV2{}
+	require.Equal(t, wire.CertificateVersionV2, cert.Version())
 }
 
-func TestMoECertificate_BlockHash(t *testing.T) {
+func TestCertificateV2_BlockHash(t *testing.T) {
 	expectedHash := chainhash.Hash{1, 2, 3, 4}
-	cert := &wire.MoECertificate{Hash: expectedHash}
+	cert := &wire.CertificateV2{Hash: expectedHash}
 	require.Equal(t, expectedHash, cert.BlockHash())
 }
 
-func TestMoECertificate_SerializeDeserialize(t *testing.T) {
+func TestCertificateV2_SerializeDeserialize(t *testing.T) {
 	cert := newTestMoECert()
 
 	var buf bytes.Buffer
 	require.NoError(t, cert.Serialize(&buf), "serialization should succeed")
 
-	wantSize := 32 + wire.MoEPublicDataSize + 4 + len(cert.ProofData)
+	wantSize := 32 + wire.PublicDataSizeV2 + 4 + len(cert.ProofData)
 	require.Equal(t, wantSize, buf.Len())
 	require.Equal(t, wantSize, cert.SerializedSize())
 
-	deserialized := &wire.MoECertificate{}
+	deserialized := &wire.CertificateV2{}
 	require.NoError(t, deserialized.Deserialize(bytes.NewReader(buf.Bytes())),
 		"deserialization should succeed")
 
@@ -220,19 +220,19 @@ func TestMoECertificate_SerializeDeserialize(t *testing.T) {
 	require.Equal(t, cert.ProofData, deserialized.ProofData)
 }
 
-func TestMoECertificate_ProofCommitmentDeterministic(t *testing.T) {
+func TestCertificateV2_ProofCommitmentDeterministic(t *testing.T) {
 	cert := newTestMoECert()
 	require.Equal(t, cert.ProofCommitment(), cert.ProofCommitment(),
 		"commitment must be deterministic")
 }
 
-// TestMoECertificate_ProofCommitmentVersioned ensures the commitment binds to
+// TestCertificateV2_ProofCommitmentVersioned ensures the commitment binds to
 // the certificate version: an MoE certificate and a ZK certificate with
 // identical PublicData must produce different commitments.
-func TestMoECertificate_ProofCommitmentVersioned(t *testing.T) {
+func TestCertificateV2_ProofCommitmentVersioned(t *testing.T) {
 	moe := newTestMoECert()
 
-	var zk wire.ZKCertificate
+	var zk wire.CertificateV1
 	zk.Hash = moe.Hash
 	copy(zk.PublicData[:], moe.PublicData[:])
 
@@ -240,16 +240,16 @@ func TestMoECertificate_ProofCommitmentVersioned(t *testing.T) {
 		"ZK and MoE commitments over identical PublicData must differ by version")
 }
 
-func TestMoECertificate_DeserializeProofTooLarge(t *testing.T) {
+func TestCertificateV2_DeserializeProofTooLarge(t *testing.T) {
 	var buf bytes.Buffer
 	var hash chainhash.Hash
 	_, _ = buf.Write(hash[:])
-	var pub [wire.MoEPublicDataSize]byte
+	var pub [wire.PublicDataSizeV2]byte
 	_, _ = buf.Write(pub[:])
 	// Claim a proof length above the maximum without writing the bytes.
-	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(wire.MaxMoEProofSize+1)))
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(wire.MaxProofSizeV2+1)))
 
-	cert := &wire.MoECertificate{}
+	cert := &wire.CertificateV2{}
 	require.Error(t, cert.Deserialize(bytes.NewReader(buf.Bytes())),
 		"oversized proof must be rejected")
 }
@@ -258,7 +258,7 @@ func TestMsgCertificate_MoE_RoundTrip(t *testing.T) {
 	cert := newTestMoECert()
 
 	msg := &wire.MsgCertificate{Certificate: cert}
-	require.Equal(t, wire.CertificateVersionMoE, msg.Certificate.Version())
+	require.Equal(t, wire.CertificateVersionV2, msg.Certificate.Version())
 
 	var buf bytes.Buffer
 	require.NoError(t, msg.PrlEncode(&buf, wire.ProtocolVersion), "encoding should succeed")
@@ -270,9 +270,9 @@ func TestMsgCertificate_MoE_RoundTrip(t *testing.T) {
 	require.NoError(t, decoded.PrlDecode(bytes.NewReader(buf.Bytes()), wire.ProtocolVersion),
 		"decoding should succeed")
 
-	require.Equal(t, wire.CertificateVersionMoE, decoded.Certificate.Version())
-	decodedMoE, ok := decoded.Certificate.(*wire.MoECertificate)
-	require.True(t, ok, "decoded certificate should be *MoECertificate")
+	require.Equal(t, wire.CertificateVersionV2, decoded.Certificate.Version())
+	decodedMoE, ok := decoded.Certificate.(*wire.CertificateV2)
+	require.True(t, ok, "decoded certificate should be *CertificateV2")
 	require.Equal(t, cert.Hash, decodedMoE.Hash)
 	require.Equal(t, cert.PublicData, decodedMoE.PublicData)
 	require.Equal(t, cert.ProofData, decodedMoE.ProofData)
@@ -281,7 +281,7 @@ func TestMsgCertificate_MoE_RoundTrip(t *testing.T) {
 func TestMsgCertificate_UnknownVersion(t *testing.T) {
 	// A version that is neither Null, ZK, nor MoE must fail to decode.
 	var buf bytes.Buffer
-	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(wire.CertificateVersionMoE+1)))
+	require.NoError(t, binary.Write(&buf, binary.LittleEndian, uint32(wire.CertificateVersionV2+1)))
 
 	decoded := &wire.MsgCertificate{}
 	require.Error(t, decoded.PrlDecode(bytes.NewReader(buf.Bytes()), wire.ProtocolVersion),
@@ -305,9 +305,9 @@ func TestIsCertVersionAllowed(t *testing.T) {
 		allowed bool
 	}{
 		{wire.CertificateVersionNull, false},
-		{wire.CertificateVersionZK, true},
-		{wire.CertificateVersionMoE, true},
-		{wire.CertificateVersionMoE + 1, false},
+		{wire.CertificateVersionV1, true},
+		{wire.CertificateVersionV2, true},
+		{wire.CertificateVersionV2 + 1, false},
 	}
 	for _, tt := range tests {
 		require.Equalf(t, tt.allowed, wire.IsCertVersionAllowed(tt.version),

--- a/node/wire/certificate_v1.go
+++ b/node/wire/certificate_v1.go
@@ -12,34 +12,34 @@ import (
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 )
 
-// PublicDataSize is the size of the committed PublicData prefix.
+// PublicDataSizeV1 is the size of the committed PublicData prefix.
 // config(52) + hash_a(32) + hash_b(32) + hash_jackpot(32) + m(4) + n(4) + t_rows(4) + t_cols(4)
 // Must match PublicProofParams::PUBLICDATA_SIZE in zk-pow/src/api/proof_utils.rs.
-const PublicDataSize = 164
+const PublicDataSizeV1 = 164
 
-// ZKCertificate contains a ZK proof for production networks.
-type ZKCertificate struct {
+// CertificateV1 contains a ZK proof for production networks.
+type CertificateV1 struct {
 	// Block Hash
 	Hash chainhash.Hash
 
 	// PublicData contains the committed public fields.
-	PublicData [PublicDataSize]byte
+	PublicData [PublicDataSizeV1]byte
 
 	// ProofData contains the plonky2 proof.
 	ProofData []byte
 }
 
-func (c *ZKCertificate) Version() CertificateVersion {
-	return CertificateVersionZK
+func (c *CertificateV1) Version() CertificateVersion {
+	return CertificateVersionV1
 }
 
-func (c *ZKCertificate) BlockHash() chainhash.Hash {
+func (c *CertificateV1) BlockHash() chainhash.Hash {
 	return c.Hash
 }
 
 // ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData(164)).
-func (c *ZKCertificate) ProofCommitment() chainhash.Hash {
-	var buf [4 + PublicDataSize]byte
+func (c *CertificateV1) ProofCommitment() chainhash.Hash {
+	var buf [4 + PublicDataSizeV1]byte
 	binary.LittleEndian.PutUint32(buf[:4], uint32(c.Version()))
 	copy(buf[4:], c.PublicData[:])
 	return chainhash.DoubleHashH(buf[:])
@@ -47,7 +47,7 @@ func (c *ZKCertificate) ProofCommitment() chainhash.Hash {
 
 // Serialize: BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData
 // Version excluded - handled by MsgCertificate.
-func (c *ZKCertificate) Serialize(w io.Writer) error {
+func (c *CertificateV1) Serialize(w io.Writer) error {
 	if _, err := w.Write(c.Hash[:]); err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (c *ZKCertificate) Serialize(w io.Writer) error {
 
 // Deserialize: BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData
 // Version excluded - handled by MsgCertificate.
-func (c *ZKCertificate) Deserialize(r io.Reader) error {
+func (c *CertificateV1) Deserialize(r io.Reader) error {
 	if _, err := io.ReadFull(r, c.Hash[:]); err != nil {
 		return err
 	}
@@ -79,8 +79,8 @@ func (c *ZKCertificate) Deserialize(r io.Reader) error {
 	if err := binary.Read(r, binary.LittleEndian, &proofLen); err != nil {
 		return err
 	}
-	if proofLen > MaxZKProofSize {
-		return fmt.Errorf("proof data too large: %d bytes (max %d)", proofLen, MaxZKProofSize)
+	if proofLen > MaxProofSizeV1 {
+		return fmt.Errorf("proof data too large: %d bytes (max %d)", proofLen, MaxProofSizeV1)
 	}
 
 	c.ProofData = make([]byte, proofLen)
@@ -94,6 +94,6 @@ func (c *ZKCertificate) Deserialize(r io.Reader) error {
 // SerializedSize returns the number of bytes needed to serialize the certificate fields.
 // Format: BlockHash(32) + PublicData(164) + ProofLen(4) + ProofData
 // Note: Does NOT include version (4 bytes) - that's handled by MsgCertificate.
-func (c *ZKCertificate) SerializedSize() int {
-	return 32 + PublicDataSize + 4 + len(c.ProofData)
+func (c *CertificateV1) SerializedSize() int {
+	return 32 + PublicDataSizeV1 + 4 + len(c.ProofData)
 }

--- a/node/wire/certificate_v2.go
+++ b/node/wire/certificate_v2.go
@@ -12,53 +12,53 @@ import (
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 )
 
-// MoEPublicDataSize is the size of the committed PublicData prefix for an MoE
-// certificate. It mirrors ZKCertificate as a placeholder.
+// PublicDataSizeV2 is the size of the committed PublicData prefix for a V2
+// certificate. It mirrors CertificateV1 as a placeholder.
 //
-// TODO Or: update when the MoE certificate format is finalized.
-const MoEPublicDataSize = 164
+// TODO Or: update when the V2 certificate format is finalized.
+const PublicDataSizeV2 = 164
 
-// MaxMoEProofSize is the maximum size of a serialized MoE proof blob.
+// MaxProofSizeV2 is the maximum size of a serialized MoE proof blob.
 //
 // TODO Or: update when the MoE proof format is finalized.
-const MaxMoEProofSize = 60000
+const MaxProofSizeV2 = 60000
 
-// MoECertificate is the Block Certificate introduced by the MoE hardfork. It is
-// a distinct type from ZKCertificate so the finalized format can diverge; the
+// CertificateV2 is the Block Certificate introduced by the MoE hardfork. It is
+// a distinct type from CertificateV1 so the finalized format can diverge; the
 // current fields are placeholders.
 //
-// TODO Or: update when the MoE certificate format and verifier are finalized.
-type MoECertificate struct {
+// TODO Or: update when the V2 certificate format and verifier are finalized.
+type CertificateV2 struct {
 	// Hash is the block hash this certificate is bound to.
 	Hash chainhash.Hash
 
 	// PublicData contains the committed public fields. Placeholder layout.
-	PublicData [MoEPublicDataSize]byte
+	PublicData [PublicDataSizeV2]byte
 
 	// ProofData contains the MoE proof. Placeholder format.
 	ProofData []byte
 }
 
-func (c *MoECertificate) Version() CertificateVersion {
-	return CertificateVersionMoE
+func (c *CertificateV2) Version() CertificateVersion {
+	return CertificateVersionV2
 }
 
-func (c *MoECertificate) BlockHash() chainhash.Hash {
+func (c *CertificateV2) BlockHash() chainhash.Hash {
 	return c.Hash
 }
 
 // ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData). The
 // version is included so the commitment binds to the certificate version.
-func (c *MoECertificate) ProofCommitment() chainhash.Hash {
-	var buf [4 + MoEPublicDataSize]byte
+func (c *CertificateV2) ProofCommitment() chainhash.Hash {
+	var buf [4 + PublicDataSizeV2]byte
 	binary.LittleEndian.PutUint32(buf[:4], uint32(c.Version()))
 	copy(buf[4:], c.PublicData[:])
 	return chainhash.DoubleHashH(buf[:])
 }
 
-// Serialize: BlockHash(32) + PublicData(MoEPublicDataSize) + ProofLen(4) + ProofData
+// Serialize: BlockHash(32) + PublicData(PublicDataSizeV2) + ProofLen(4) + ProofData
 // Version excluded - handled by MsgCertificate.
-func (c *MoECertificate) Serialize(w io.Writer) error {
+func (c *CertificateV2) Serialize(w io.Writer) error {
 	if _, err := w.Write(c.Hash[:]); err != nil {
 		return err
 	}
@@ -76,9 +76,9 @@ func (c *MoECertificate) Serialize(w io.Writer) error {
 	return nil
 }
 
-// Deserialize: BlockHash(32) + PublicData(MoEPublicDataSize) + ProofLen(4) + ProofData
+// Deserialize: BlockHash(32) + PublicData(PublicDataSizeV2) + ProofLen(4) + ProofData
 // Version excluded - handled by MsgCertificate.
-func (c *MoECertificate) Deserialize(r io.Reader) error {
+func (c *CertificateV2) Deserialize(r io.Reader) error {
 	if _, err := io.ReadFull(r, c.Hash[:]); err != nil {
 		return err
 	}
@@ -90,8 +90,8 @@ func (c *MoECertificate) Deserialize(r io.Reader) error {
 	if err := binary.Read(r, binary.LittleEndian, &proofLen); err != nil {
 		return err
 	}
-	if proofLen > MaxMoEProofSize {
-		return fmt.Errorf("proof data too large: %d bytes (max %d)", proofLen, MaxMoEProofSize)
+	if proofLen > MaxProofSizeV2 {
+		return fmt.Errorf("proof data too large: %d bytes (max %d)", proofLen, MaxProofSizeV2)
 	}
 
 	c.ProofData = make([]byte, proofLen)
@@ -103,8 +103,8 @@ func (c *MoECertificate) Deserialize(r io.Reader) error {
 }
 
 // SerializedSize returns the number of bytes needed to serialize the certificate
-// fields. Format: BlockHash(32) + PublicData(MoEPublicDataSize) + ProofLen(4) + ProofData
+// fields. Format: BlockHash(32) + PublicData(PublicDataSizeV2) + ProofLen(4) + ProofData
 // Note: Does NOT include version (4 bytes) - that's handled by MsgCertificate.
-func (c *MoECertificate) SerializedSize() int {
-	return 32 + MoEPublicDataSize + 4 + len(c.ProofData)
+func (c *CertificateV2) SerializedSize() int {
+	return 32 + PublicDataSizeV2 + 4 + len(c.ProofData)
 }

--- a/node/wire/message_test.go
+++ b/node/wire/message_test.go
@@ -88,7 +88,7 @@ func TestMessage(t *testing.T) {
 		{msgGetAddr, msgGetAddr, pver, MainNet, 24},
 		{msgAddr, msgAddr, pver, MainNet, 25},
 		{msgGetBlocks, msgGetBlocks, pver, MainNet, 61},
-		{msgBlock, msgBlock, pver, MainNet, 479}, // 24 msg header + 212 cert (ZKCertificate with 8-byte proof) + 108 header + 1 varint + 134 tx
+		{msgBlock, msgBlock, pver, MainNet, 479}, // 24 msg header + 212 cert (CertificateV1 with 8-byte proof) + 108 header + 1 varint + 134 tx
 		{msgInv, msgInv, pver, MainNet, 25},
 		{msgGetData, msgGetData, pver, MainNet, 25},
 		{msgNotFound, msgNotFound, pver, MainNet, 25},

--- a/node/wire/msgblock_test.go
+++ b/node/wire/msgblock_test.go
@@ -222,7 +222,7 @@ func TestBlockWireErrors(t *testing.T) {
 	}{
 		// Force error in certificate version (first 4 bytes).
 		{&blockOne, blockOneBytes, pver, BaseEncoding, 0, io.ErrShortWrite, io.EOF},
-		// Force error in header version (after 212-byte ZKCertificate, at offset 212).
+		// Force error in header version (after 212-byte CertificateV1, at offset 212).
 		{&blockOne, blockOneBytes, pver, BaseEncoding, 212, io.ErrShortWrite, io.EOF},
 		// Force error in prev block hash (partial read).
 		{&blockOne, blockOneBytes, pver, BaseEncoding, 220, io.ErrShortWrite, io.ErrUnexpectedEOF},
@@ -342,7 +342,7 @@ func TestBlockSerializeErrors(t *testing.T) {
 	}{
 		// Force error in certificate version.
 		{&blockOne, blockOneBytes, 0, io.ErrShortWrite, io.EOF},
-		// Force error in header version (after 212-byte ZKCertificate).
+		// Force error in header version (after 212-byte CertificateV1).
 		{&blockOne, blockOneBytes, 212, io.ErrShortWrite, io.EOF},
 		// Force error in prev block hash (partial read).
 		{&blockOne, blockOneBytes, 220, io.ErrShortWrite, io.ErrUnexpectedEOF},
@@ -492,7 +492,7 @@ func TestBlockSerializeSize(t *testing.T) {
 		in   *MsgBlock // Block to encode
 		size int       // Expected serialized size
 	}{
-		// Block with no transactions: 212 (ZKCertificate with 8-byte proof) + 108 (header) + 1 (varint tx count)
+		// Block with no transactions: 212 (CertificateV1 with 8-byte proof) + 108 (header) + 1 (varint tx count)
 		{noTxBlock, 321},
 
 		// First block in the mainnet block chain: 212 (cert) + 108 (header) + 1 (varint) + 134 (tx)
@@ -511,7 +511,7 @@ func TestBlockSerializeSize(t *testing.T) {
 }
 
 // blockOne is the first block in the mainnet block chain.
-// Uses ZKCertificate with sample data for wire encoding tests (mainnet format).
+// Uses CertificateV1 with sample data for wire encoding tests (mainnet format).
 var blockOne = MsgBlock{
 	MsgHeader: MsgHeader{
 		BlockHeader: BlockHeader{
@@ -533,7 +533,7 @@ var blockOne = MsgBlock{
 			Bits:      0x1d00ffff,               // 486604799
 		},
 		MsgCertificate: MsgCertificate{
-			Certificate: &ZKCertificate{
+			Certificate: &CertificateV1{
 				Hash: chainhash.Hash([chainhash.HashSize]byte{
 					0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 					0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,

--- a/node/zkpow/miner.go
+++ b/node/zkpow/miner.go
@@ -86,3 +86,13 @@ func Mine(header *wire.BlockHeader) (*wire.ZKCertificate, error) {
 
 	return cert, nil
 }
+
+// MineMoE mines a block under the MoE hardfork rules. Real proving is not yet
+// implemented, so this is fail-closed (always returns an error).
+//
+// TODO Or: implement when the MoE prover is finalized. The intended shape
+// mirrors Mine: call a Rust FFI entry point (e.g. C.mine_moe) to produce
+// PublicData and ProofData, then set header.ProofCommitment and cert.Hash.
+func MineMoE(header *wire.BlockHeader) (*wire.MoECertificate, error) {
+	return nil, fmt.Errorf("MoE mining not yet implemented")
+}

--- a/node/zkpow/miner.go
+++ b/node/zkpow/miner.go
@@ -49,13 +49,13 @@ var defaultMiningConfig = [miningConfigSize]byte{
 	// reserved (32 bytes) are zero
 }
 
-// Mine mines a block using the Rust implementation and returns a ZKCertificate.
+// MineV1 mines a block using the Rust implementation and returns a CertificateV1.
 // This function modifies header.ProofCommitment to match the mined certificate.
-func Mine(header *wire.BlockHeader) (*wire.ZKCertificate, error) {
+func MineV1(header *wire.BlockHeader) (*wire.CertificateV1, error) {
 	cHeader := blockHeaderToC(header)
 	cMiningConfig := (*[miningConfigSize]C.uint8_t)(unsafe.Pointer(&defaultMiningConfig))
 
-	proofData := make([]byte, wire.MaxZKProofSize)
+	proofData := make([]byte, wire.MaxProofSizeV1)
 	var pinner runtime.Pinner
 	pinner.Pin(&proofData[0])
 	defer pinner.Unpin()
@@ -76,10 +76,10 @@ func Mine(header *wire.BlockHeader) (*wire.ZKCertificate, error) {
 		return nil, fmt.Errorf("mining failed (code %d): %s", result, msg)
 	}
 
-	cert := &wire.ZKCertificate{
+	cert := &wire.CertificateV1{
 		ProofData: proofData[:int(cZKProof.proof_blob_len)],
 	}
-	C.memcpy(unsafe.Pointer(&cert.PublicData[0]), unsafe.Pointer(&cZKProof.public_data[0]), C.size_t(wire.PublicDataSize))
+	C.memcpy(unsafe.Pointer(&cert.PublicData[0]), unsafe.Pointer(&cZKProof.public_data[0]), C.size_t(wire.PublicDataSizeV1))
 
 	header.ProofCommitment = cert.ProofCommitment()
 	cert.Hash = header.BlockHash()
@@ -87,12 +87,12 @@ func Mine(header *wire.BlockHeader) (*wire.ZKCertificate, error) {
 	return cert, nil
 }
 
-// MineMoE mines a block under the MoE hardfork rules. Real proving is not yet
+// MineV2 mines a block under the MoE hardfork rules. Real proving is not yet
 // implemented, so this is fail-closed (always returns an error).
 //
 // TODO Or: implement when the MoE prover is finalized. The intended shape
-// mirrors Mine: call a Rust FFI entry point (e.g. C.mine_moe) to produce
+// mirrors MineV1: call a Rust FFI entry point (e.g. C.mine_moe) to produce
 // PublicData and ProofData, then set header.ProofCommitment and cert.Hash.
-func MineMoE(header *wire.BlockHeader) (*wire.MoECertificate, error) {
+func MineV2(header *wire.BlockHeader) (*wire.CertificateV2, error) {
 	return nil, fmt.Errorf("MoE mining not yet implemented")
 }

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -32,32 +32,32 @@ import (
 // It returns an error if the certificate is invalid or does not match the header.
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
 	switch c := cert.(type) {
-	case *wire.ZKCertificate:
-		return verifyZKCertificate(header, c)
-	case *wire.MoECertificate:
-		return verifyMoECertificate(header, c)
+	case *wire.CertificateV1:
+		return verifyV1Certificate(header, c)
+	case *wire.CertificateV2:
+		return verifyV2Certificate(header, c)
 	default:
 		return fmt.Errorf("unknown certificate type: %T", cert)
 	}
 }
 
 // ================================================================================
-// ZK CERTIFICATE VERIFICATION
+// V1 CERTIFICATE VERIFICATION
 // ================================================================================
 
-func verifyZKCertificate(header *wire.BlockHeader, c *wire.ZKCertificate) error {
-	return verifyZKCertificateInner(header, c, nil)
+func verifyV1Certificate(header *wire.BlockHeader, c *wire.CertificateV1) error {
+	return verifyV1CertificateInner(header, c, nil)
 }
 
-// VerifyZKCertificateWithNbits verifies a ZK certificate using nbitsOverride
+// VerifyCertificateV1WithNbits verifies a V1 certificate using nbitsOverride
 // as the difficulty target instead of the block header's nbits field.
 //
 // WARNING: This bypasses the header's embedded difficulty, Do not use it in block acceptance or relay paths.
-func VerifyZKCertificateWithNbits(header *wire.BlockHeader, c *wire.ZKCertificate, nbitsOverride uint32) error {
-	return verifyZKCertificateInner(header, c, &nbitsOverride)
+func VerifyCertificateV1WithNbits(header *wire.BlockHeader, c *wire.CertificateV1, nbitsOverride uint32) error {
+	return verifyV1CertificateInner(header, c, &nbitsOverride)
 }
 
-func verifyZKCertificateInner(header *wire.BlockHeader, c *wire.ZKCertificate, nbitsOverride *uint32) error {
+func verifyV1CertificateInner(header *wire.BlockHeader, c *wire.CertificateV1, nbitsOverride *uint32) error {
 	blockHash := header.BlockHash()
 	if !c.Hash.IsEqual(&blockHash) {
 		return fmt.Errorf("block hash mismatch: certificate has %s, header has %s",
@@ -77,7 +77,7 @@ func verifyZKCertificateInner(header *wire.BlockHeader, c *wire.ZKCertificate, n
 	cBlockHeader := blockHeaderToC(header)
 
 	var cZKProof C.CZKProof
-	C.memcpy(unsafe.Pointer(&cZKProof.public_data[0]), unsafe.Pointer(&c.PublicData[0]), C.size_t(wire.PublicDataSize))
+	C.memcpy(unsafe.Pointer(&cZKProof.public_data[0]), unsafe.Pointer(&c.PublicData[0]), C.size_t(wire.PublicDataSizeV1))
 
 	// Pin the ProofData memory to prevent GC from moving it during the C call
 	var pinner runtime.Pinner
@@ -111,18 +111,18 @@ func verifyZKCertificateInner(header *wire.BlockHeader, c *wire.ZKCertificate, n
 }
 
 // ================================================================================
-// MOE CERTIFICATE VERIFICATION
+// V2 CERTIFICATE VERIFICATION
 // ================================================================================
 
-// verifyMoECertificate verifies an MoE certificate against the header. The
+// verifyV2Certificate verifies a V2 certificate against the header. The
 // header-binding checks are format-independent, but the cryptographic proof
 // verification is not yet implemented, so this is fail-closed (always rejects).
 //
-// TODO Or: implement when the MoE verifier is finalized. The intended shape
-// mirrors verifyZKCertificateInner: convert the header to C form, copy the
+// TODO Or: implement when the V2 verifier is finalized. The intended shape
+// mirrors verifyV1CertificateInner: convert the header to C form, copy the
 // PublicData, pin the ProofData, then call a Rust FFI entry point (e.g.
 // C.verify_moe_proof) and translate its result code.
-func verifyMoECertificate(header *wire.BlockHeader, c *wire.MoECertificate) error {
+func verifyV2Certificate(header *wire.BlockHeader, c *wire.CertificateV2) error {
 	blockHash := header.BlockHash()
 	if !c.Hash.IsEqual(&blockHash) {
 		return fmt.Errorf("block hash mismatch: certificate has %s, header has %s",
@@ -139,8 +139,8 @@ func verifyMoECertificate(header *wire.BlockHeader, c *wire.MoECertificate) erro
 		return fmt.Errorf("empty proof data")
 	}
 
-	// TODO Or: call the real MoE proof verifier (Rust FFI) when finalized.
-	return fmt.Errorf("MoE certificate verifier not yet implemented")
+	// TODO Or: call the real V2 proof verifier (Rust FFI) when finalized.
+	return fmt.Errorf("V2 certificate verifier not yet implemented")
 }
 
 // ================================================================================

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -34,6 +34,8 @@ func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) err
 	switch c := cert.(type) {
 	case *wire.ZKCertificate:
 		return verifyZKCertificate(header, c)
+	case *wire.MoECertificate:
+		return verifyMoECertificate(header, c)
 	default:
 		return fmt.Errorf("unknown certificate type: %T", cert)
 	}
@@ -106,6 +108,39 @@ func verifyZKCertificateInner(header *wire.BlockHeader, c *wire.ZKCertificate, n
 	default:
 		return fmt.Errorf("unknown verification result %d: %s", result, msg)
 	}
+}
+
+// ================================================================================
+// MOE CERTIFICATE VERIFICATION
+// ================================================================================
+
+// verifyMoECertificate verifies an MoE certificate against the header. The
+// header-binding checks are format-independent, but the cryptographic proof
+// verification is not yet implemented, so this is fail-closed (always rejects).
+//
+// TODO Or: implement when the MoE verifier is finalized. The intended shape
+// mirrors verifyZKCertificateInner: convert the header to C form, copy the
+// PublicData, pin the ProofData, then call a Rust FFI entry point (e.g.
+// C.verify_moe_proof) and translate its result code.
+func verifyMoECertificate(header *wire.BlockHeader, c *wire.MoECertificate) error {
+	blockHash := header.BlockHash()
+	if !c.Hash.IsEqual(&blockHash) {
+		return fmt.Errorf("block hash mismatch: certificate has %s, header has %s",
+			c.Hash, blockHash)
+	}
+
+	certCommitment := c.ProofCommitment()
+	if header.ProofCommitment != certCommitment {
+		return fmt.Errorf("proof commitment mismatch: header has %s, certificate has %s",
+			header.ProofCommitment, certCommitment)
+	}
+
+	if len(c.ProofData) == 0 {
+		return fmt.Errorf("empty proof data")
+	}
+
+	// TODO Or: call the real MoE proof verifier (Rust FFI) when finalized.
+	return fmt.Errorf("MoE certificate verifier not yet implemented")
 }
 
 // ================================================================================

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -20,16 +20,16 @@ func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) err
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
 }
 
-func VerifyZKCertificateWithNbits(header *wire.BlockHeader, c *wire.ZKCertificate, nbitsOverride uint32) error {
+func VerifyCertificateV1WithNbits(header *wire.BlockHeader, c *wire.CertificateV1, nbitsOverride uint32) error {
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification with nbits override")
 }
 
-func Mine(header *wire.BlockHeader) (*wire.ZKCertificate, error) {
+func MineV1(header *wire.BlockHeader) (*wire.CertificateV1, error) {
 	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable mining")
 }
 
-// MineMoE is the no-zkpow stub for MoE mining; the real implementation lives in
+// MineV2 is the no-zkpow stub for MoE mining; the real implementation lives in
 // miner.go under the zkpow build tag.
-func MineMoE(header *wire.BlockHeader) (*wire.MoECertificate, error) {
+func MineV2(header *wire.BlockHeader) (*wire.CertificateV2, error) {
 	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable mining")
 }

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -27,3 +27,9 @@ func VerifyZKCertificateWithNbits(header *wire.BlockHeader, c *wire.ZKCertificat
 func Mine(header *wire.BlockHeader) (*wire.ZKCertificate, error) {
 	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable mining")
 }
+
+// MineMoE is the no-zkpow stub for MoE mining; the real implementation lives in
+// miner.go under the zkpow build tag.
+func MineMoE(header *wire.BlockHeader) (*wire.MoECertificate, error) {
+	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable mining")
+}

--- a/node/zkpow/zkpow_test.go
+++ b/node/zkpow/zkpow_test.go
@@ -186,6 +186,52 @@ func TestVerifyProof_InvalidInput(t *testing.T) {
 }
 
 // ================================================================================
+// MOE CERTIFICATE VERIFICATION
+// ================================================================================
+
+// TestVerifyMoECertificateFailClosed asserts the MoE verifier is fail-closed:
+// a well-formed MoE certificate (header bindings satisfied) is still rejected
+// because the cryptographic verifier is not yet implemented.
+func TestVerifyMoECertificateFailClosed(t *testing.T) {
+	header := testBlockHeader()
+	cert := &wire.MoECertificate{ProofData: []byte{0x01, 0x02, 0x03}}
+
+	// Satisfy the header-binding checks so verification reaches the
+	// not-implemented (fail-closed) path rather than a binding mismatch.
+	header.ProofCommitment = cert.ProofCommitment()
+	cert.Hash = header.BlockHash()
+
+	err := VerifyCertificate(header, cert)
+	require.Error(t, err, "MoE certificate must be rejected (fail-closed)")
+	require.Contains(t, err.Error(), "not yet implemented")
+}
+
+// TestVerifyMoECertificateBindingChecks asserts the binding checks reject a
+// certificate whose hash/commitment do not match the header, and one with an
+// empty proof.
+func TestVerifyMoECertificateBindingChecks(t *testing.T) {
+	header := testBlockHeader()
+
+	// Mismatched block hash (Hash left zero, header has a real hash).
+	err := VerifyCertificate(header, &wire.MoECertificate{ProofData: []byte{0x01}})
+	require.Error(t, err)
+
+	// Matching bindings but empty proof data is also rejected.
+	matching := &wire.MoECertificate{}
+	header.ProofCommitment = matching.ProofCommitment()
+	matching.Hash = header.BlockHash()
+	require.Error(t, VerifyCertificate(header, matching),
+		"empty proof data must be rejected")
+}
+
+// TestMineMoEFailClosed asserts the MoE miner is fail-closed.
+func TestMineMoEFailClosed(t *testing.T) {
+	_, err := MineMoE(testBlockHeader())
+	require.Error(t, err, "MoE mining must be fail-closed")
+	require.Contains(t, err.Error(), "not yet implemented")
+}
+
+// ================================================================================
 // BENCHMARKS
 // ================================================================================
 

--- a/node/zkpow/zkpow_test.go
+++ b/node/zkpow/zkpow_test.go
@@ -42,12 +42,12 @@ func testBlockHeader(nbits ...uint32) *wire.BlockHeader {
 	}
 }
 
-// mineZKCertificate mines a block and returns the header and ZKCertificate.
-func mineZKCertificate(t *testing.T) (*wire.BlockHeader, *wire.ZKCertificate) {
+// mineCertificateV1 mines a block and returns the header and CertificateV1.
+func mineCertificateV1(t *testing.T) (*wire.BlockHeader, *wire.CertificateV1) {
 	t.Helper()
 	header := testBlockHeader()
 
-	cert, err := Mine(header)
+	cert, err := MineV1(header)
 	require.NoError(t, err, "mining should succeed")
 
 	return header, cert
@@ -65,9 +65,9 @@ func copyBlockHeader(h *wire.BlockHeader) *wire.BlockHeader {
 	}
 }
 
-// copyZKCertificate creates a deep copy of ZKCertificate for tampering tests
-func copyZKCertificate(c *wire.ZKCertificate) *wire.ZKCertificate {
-	cp := &wire.ZKCertificate{
+// copyCertificateV1 creates a deep copy of CertificateV1 for tampering tests
+func copyCertificateV1(c *wire.CertificateV1) *wire.CertificateV1 {
+	cp := &wire.CertificateV1{
 		Hash:       c.Hash,
 		PublicData: c.PublicData,
 		ProofData:  make([]byte, len(c.ProofData)),
@@ -84,7 +84,7 @@ func TestMineAndVerifyProof(t *testing.T) {
 		DefaultM, DefaultN, header.Bits)
 
 	startMine := time.Now()
-	header, cert := mineZKCertificate(t)
+	header, cert := mineCertificateV1(t)
 	t.Logf("Mining completed in %v, proof size: %d bytes", time.Since(startMine), len(cert.ProofData))
 
 	startVerify := time.Now()
@@ -97,7 +97,7 @@ func TestMineAndVerifyProof(t *testing.T) {
 // PublicData layout: config(0..52) | hash_a(52..84) | hash_b(84..116) | hash_jackpot(116..148) |
 // m,n,t_rows,t_cols(148..164)
 func TestTamperedParams(t *testing.T) {
-	header, cert := mineZKCertificate(t)
+	header, cert := mineCertificateV1(t)
 
 	// Block header field tampering.
 	headerTampers := []struct {
@@ -121,10 +121,10 @@ func TestTamperedParams(t *testing.T) {
 	}
 
 	// Every byte of PublicData must individually cause rejection when flipped.
-	for i := 0; i < wire.PublicDataSize; i++ {
+	for i := 0; i < wire.PublicDataSizeV1; i++ {
 		i := i
 		t.Run(fmt.Sprintf("PublicData[%d]", i), func(t *testing.T) {
-			tamperedCert := copyZKCertificate(cert)
+			tamperedCert := copyCertificateV1(cert)
 			tamperedCert.PublicData[i] ^= 0xFF
 			err := VerifyCertificate(header, tamperedCert)
 			require.Error(t, err, "proof should be rejected when PublicData[%d] is tampered", i)
@@ -134,7 +134,7 @@ func TestTamperedParams(t *testing.T) {
 
 	// ProofData tampering.
 	t.Run("ProofData", func(t *testing.T) {
-		tamperedCert := copyZKCertificate(cert)
+		tamperedCert := copyCertificateV1(cert)
 		tamperedCert.ProofData[20] ^= 0xFF
 		err := VerifyCertificate(header, tamperedCert)
 		require.Error(t, err, "proof should be rejected when ProofData is tampered")
@@ -144,9 +144,9 @@ func TestTamperedParams(t *testing.T) {
 
 // TestTamperedProof verifies that overwriting the metadata fields in proof_data is rejected.
 func TestTamperedProof(t *testing.T) {
-	header, cert := mineZKCertificate(t)
+	header, cert := mineCertificateV1(t)
 
-	tamperedCert := copyZKCertificate(cert)
+	tamperedCert := copyCertificateV1(cert)
 	for i := 0; i < 50; i++ {
 		tamperedCert.ProofData[i] ^= 0xFF
 	}
@@ -160,7 +160,7 @@ func TestTamperedProof(t *testing.T) {
 func TestVerifyProof_InvalidInput(t *testing.T) {
 	header := testBlockHeader()
 
-	// Generate a random 70400-byte proof (the native size of a valid ZKCertificate)
+	// Generate a random 70400-byte proof (the native size of a valid CertificateV1)
 	randomProof := make([]byte, 70400)
 	for i := range randomProof {
 		randomProof[i] = byte(i % 256)
@@ -169,11 +169,11 @@ func TestVerifyProof_InvalidInput(t *testing.T) {
 	testCases := []struct {
 		name   string
 		header *wire.BlockHeader
-		cert   *wire.ZKCertificate
+		cert   *wire.CertificateV1
 	}{
-		{"EmptyProofData", header, &wire.ZKCertificate{ProofData: nil}},
-		{"ZeroLengthProofData", header, &wire.ZKCertificate{ProofData: []byte{}}},
-		{"Random70400ByteProof", header, &wire.ZKCertificate{ProofData: randomProof}},
+		{"EmptyProofData", header, &wire.CertificateV1{ProofData: nil}},
+		{"ZeroLengthProofData", header, &wire.CertificateV1{ProofData: []byte{}}},
+		{"Random70400ByteProof", header, &wire.CertificateV1{ProofData: randomProof}},
 	}
 
 	for _, tc := range testCases {
@@ -189,12 +189,12 @@ func TestVerifyProof_InvalidInput(t *testing.T) {
 // MOE CERTIFICATE VERIFICATION
 // ================================================================================
 
-// TestVerifyMoECertificateFailClosed asserts the MoE verifier is fail-closed:
+// TestVerifyV2CertificateFailClosed asserts the MoE verifier is fail-closed:
 // a well-formed MoE certificate (header bindings satisfied) is still rejected
 // because the cryptographic verifier is not yet implemented.
-func TestVerifyMoECertificateFailClosed(t *testing.T) {
+func TestVerifyV2CertificateFailClosed(t *testing.T) {
 	header := testBlockHeader()
-	cert := &wire.MoECertificate{ProofData: []byte{0x01, 0x02, 0x03}}
+	cert := &wire.CertificateV2{ProofData: []byte{0x01, 0x02, 0x03}}
 
 	// Satisfy the header-binding checks so verification reaches the
 	// not-implemented (fail-closed) path rather than a binding mismatch.
@@ -206,27 +206,27 @@ func TestVerifyMoECertificateFailClosed(t *testing.T) {
 	require.Contains(t, err.Error(), "not yet implemented")
 }
 
-// TestVerifyMoECertificateBindingChecks asserts the binding checks reject a
+// TestVerifyV2CertificateBindingChecks asserts the binding checks reject a
 // certificate whose hash/commitment do not match the header, and one with an
 // empty proof.
-func TestVerifyMoECertificateBindingChecks(t *testing.T) {
+func TestVerifyV2CertificateBindingChecks(t *testing.T) {
 	header := testBlockHeader()
 
 	// Mismatched block hash (Hash left zero, header has a real hash).
-	err := VerifyCertificate(header, &wire.MoECertificate{ProofData: []byte{0x01}})
+	err := VerifyCertificate(header, &wire.CertificateV2{ProofData: []byte{0x01}})
 	require.Error(t, err)
 
 	// Matching bindings but empty proof data is also rejected.
-	matching := &wire.MoECertificate{}
+	matching := &wire.CertificateV2{}
 	header.ProofCommitment = matching.ProofCommitment()
 	matching.Hash = header.BlockHash()
 	require.Error(t, VerifyCertificate(header, matching),
 		"empty proof data must be rejected")
 }
 
-// TestMineMoEFailClosed asserts the MoE miner is fail-closed.
-func TestMineMoEFailClosed(t *testing.T) {
-	_, err := MineMoE(testBlockHeader())
+// TestMineV2FailClosed asserts the MoE miner is fail-closed.
+func TestMineV2FailClosed(t *testing.T) {
+	_, err := MineV2(testBlockHeader())
 	require.Error(t, err, "MoE mining must be fail-closed")
 	require.Contains(t, err.Error(), "not yet implemented")
 }
@@ -255,7 +255,7 @@ func BenchmarkMine(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				cert, err := Mine(header)
+				cert, err := MineV1(header)
 				if err != nil {
 					b.Fatalf("mining failed: %v", err)
 				}
@@ -274,7 +274,7 @@ func BenchmarkMine(b *testing.B) {
 func BenchmarkVerifyProof(b *testing.B) {
 	header := testBlockHeader()
 
-	cert, err := Mine(header)
+	cert, err := MineV1(header)
 	if err != nil {
 		b.Fatalf("mining failed during setup: %v", err)
 	}

--- a/spv/blockmanager.go
+++ b/spv/blockmanager.go
@@ -2855,6 +2855,14 @@ func (b *blockManager) checkHeaderSanity(blockHeader *wire.BlockHeader,
 		return err
 	}
 
+	// Enforce the MoE certificate version cutover (contextual; the
+	// context-free sanity check below does not cover it).
+	if err := blockchain.CheckCertificateVersion(
+		cert, prevNodeHeight+1, &b.cfg.ChainParams,
+	); err != nil {
+		return err
+	}
+
 	return blockchain.CheckBlockHeaderSanity(
 		blockHeader, cert, b.cfg.ChainParams.PowLimit, b.cfg.TimeSource,
 		b.cfg.ChainParams.MaxTimeOffsetMinutes, flags,

--- a/version/version.go
+++ b/version/version.go
@@ -19,8 +19,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	Major uint = 1
-	Minor uint = 0
-	Patch uint = 6
+	Minor uint = 1
+	Patch uint = 0
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/wallet/chain/block_filterer_test.go
+++ b/wallet/chain/block_filterer_test.go
@@ -13,11 +13,11 @@ import (
 	"github.com/pearl-research-labs/pearl/wallet/chain"
 )
 
-// Block100000 uses ZKCertificate with stub proof (not valid for PoW verification).
+// Block100000 uses CertificateV1 with stub proof (not valid for PoW verification).
 var Block100000 = wire.MsgBlock{
 	MsgHeader: wire.MsgHeader{
 		MsgCertificate: wire.MsgCertificate{
-			Certificate: &wire.ZKCertificate{
+			Certificate: &wire.CertificateV1{
 				Hash: chainhash.Hash([32]byte{
 					0x06, 0xe5, 0x33, 0xfd, 0x1a, 0xda, 0x86, 0x39,
 					0x1f, 0x3f, 0x6c, 0x34, 0x32, 0x04, 0xb0, 0xd2,

--- a/wallet/chain/utils_test.go
+++ b/wallet/chain/utils_test.go
@@ -140,7 +140,7 @@ func genBlockChain(numBlocks uint32) ([]*chainhash.Hash, map[chainhash.Hash]*wir
 			Timestamp:  prevHeader.Timestamp.Add(chainParams.TargetTimePerBlock),
 			Bits:       chainParams.PowLimitBits,
 		}
-		cert, err := blockchain.SolveBlock(header, chainParams.Net)
+		cert, err := blockchain.SolveBlock(header, &chainParams, int32(i+1))
 		if err != nil {
 			panic(fmt.Sprintf("could not solve block at idx %v: %v", i, err))
 		}


### PR DESCRIPTION
## Summary

> **Draft / WIP.** This is a draft implementation of the MoE hardfork. It adds the hardfork's activation mechanics and deployment logic (new certificate version, height-based activation, strict version cutover, version-aware mining). The actual V2 certificate format and verifier/prover are **not finalized** — they are fail-closed and marked with `// TODO Or:` in the code, to be implemented and deployed on this branch.

Introduces a new block-certificate version (`CertificateVersionV2`) and the machinery to activate it via a height-based flag-day — the standard mechanism PoW chains use for hard forks. The pre-existing ZK certificate is renamed to `CertificateV1` (`CertificateVersionV1`).

### Activation & cutover
- New `chaincfg.Params.MoEForkHeight`. `0` = not scheduled (disabled); shipped as `0` on every network until the verifier is finalized and a height is chosen. `blockchain.New()` rejects a negative value.
- Strict cutover: exactly one version is valid at any height — V1 before the fork height, V2 at and after it.

### Where the rule is enforced
The cryptographic proof check stays context-free; the height-based version policy is a separate contextual consensus rule (`CheckCertificateVersion`), enforced on every accept/receive path: full-block acceptance (`checkBlockContext` — the single choke point for P2P relay, RPC `submitblock`, the miner, `addblock`), headers-first P2P sync, SPV header sync (main + reorg), and block-template validation. It is not gated by `BFNoPoWCheck`, so it holds even on SimNet.

### Changes
- wire: `CertificateVersionV2` + `CertificateV2` type, polymorphic decode, structural `IsCertVersionAllowed` (existing ZK cert renamed to `CertificateV1`).
- chaincfg: `Params.MoEForkHeight` + `IsMoEForkActive` / `RequiredCertVersion`.
- blockchain: `CheckCertificateVersion` policy; height-aware `SolveBlock`; `MoEForkHeight` startup validation in `New()`.
- mining: `NewBlockTemplate` selects the certificate version by height so templates pass `CheckConnectBlockTemplate` at and after the fork.
- zkpow: fail-closed `verifyV2Certificate` / `MineV2` with Rust FFI TODOs (`!zkpow` stub updated too).
- netsync / spv: enforce the cutover on header-sync paths.
- tests: wire round-trip/dispatch/limits, chaincfg boundaries, activation-boundary suite, block-template version cutover, fail-closed verifier/miner.

### Deployment safety
The V2 verifier and miner are fail-closed and mainnet ships with the fork disabled, so a V2 block can never be accepted until both the activation height is set and the real verifier lands. Un-upgraded nodes keep requiring V1 and reject V2 blocks — the intended hard-fork behavior.

### Remaining (tracked by TODOs on this branch)
- Implement the finalized V2 certificate format and the Rust FFI verifier/prover behind `verifyV2Certificate` / `MineV2`.
- Choose and set `MoEForkHeight` per network once the verifier is ready.

## Test plan
- [x] `wire`, `chaincfg`, `zkpow`, `blockchain` suites pass with `-tags xmss,zkpow`
- [x] `task build` builds pearld/prlctl/oyster
- [ ] Real V2 verifier integration tests (once the verifier lands)