### PR TITLE
chore(wallet,spv): bump wallet to 2.0.0 and derive neutrino UA from monorepo version

### DIFF
--- a/apps/apps/pearl-desktop-wallet/package.json
+++ b/apps/apps/pearl-desktop-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearl/pearl-desktop-wallet",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Pearl Desktop Wallet - A modern cryptocurrency wallet application",
   "author": {
     "name": "Pearl Research Labs",

--- a/node/server.go
+++ b/node/server.go
@@ -68,7 +68,7 @@ var (
 
 	// userAgentVersion is the user agent version and is used to help
 	// identify ourselves to other peers on the network.
-	userAgentVersion = fmt.Sprintf("%d.%d.%d", pearlversion.Major, pearlversion.Minor, pearlversion.Patch)
+	userAgentVersion = pearlversion.UserAgent()
 )
 
 // zeroHash is the zero value hash (all zeros).  It is defined as a convenience.

--- a/spv/neutrino.go
+++ b/spv/neutrino.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pearl-research-labs/pearl/spv/headerfs"
 	"github.com/pearl-research-labs/pearl/spv/pushtx"
 	"github.com/pearl-research-labs/pearl/spv/query"
+	pearlversion "github.com/pearl-research-labs/pearl/version"
 	"github.com/pearl-research-labs/pearl/wallet/walletdb"
 )
 
@@ -48,8 +49,9 @@ var (
 	UserAgentName = "neutrino"
 
 	// UserAgentVersion is the user agent version and is used to help
-	// identify ourselves to other peers.
-	UserAgentVersion = "1.1.0"
+	// identify ourselves to other peers. It is derived from the canonical
+	// monorepo version so it never drifts from version/version.go.
+	UserAgentVersion = pearlversion.UserAgent()
 
 	// Services describes the services that are supported by the server.
 	Services = wire.SFNodeWitness | wire.SFNodeCF

--- a/spv/neutrino.go
+++ b/spv/neutrino.go
@@ -49,7 +49,7 @@ var (
 
 	// UserAgentVersion is the user agent version and is used to help
 	// identify ourselves to other peers.
-	UserAgentVersion = "0.12.0-beta"
+	UserAgentVersion = "1.1.0"
 
 	// Services describes the services that are supported by the server.
 	Services = wire.SFNodeWitness | wire.SFNodeCF

--- a/version/version.go
+++ b/version/version.go
@@ -34,14 +34,25 @@ var Build string
 // Version returns the application version as a properly formed string per the
 // semantic versioning 2.0.0 spec (http://semver.org/).
 func Version() string {
+	v := UserAgent()
+
+	if build := normalizeVerString(Build); build != "" {
+		v = fmt.Sprintf("%s+%s", v, build)
+	}
+
+	return v
+}
+
+// UserAgent returns the version string to advertise in p2p user agents:
+// "major.minor.patch" plus the pre-release tag if one is set (e.g.
+// "1.2.0-beta"). Build metadata is deliberately excluded so the user agent
+// is stable across builds of the same release and does not leak build
+// details to peers.
+func UserAgent() string {
 	v := fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
 
 	if preRelease := normalizeVerString(PreRelease); preRelease != "" {
 		v = fmt.Sprintf("%s-%s", v, preRelease)
-	}
-
-	if build := normalizeVerString(Build); build != "" {
-		v = fmt.Sprintf("%s+%s", v, build)
 	}
 
 	return v


### PR DESCRIPTION
## Summary

Bump the pearl-desktop-wallet app version to 2.0.0 and align the neutrino SPV user-agent version with the MoE-fork (certificate v2) release. Instead of hardcoding the new UA version, derive it from the canonical monorepo version in `version/version.go` so it can never drift again.

## Type

chore

## Scope

wallet, spv, version, node

## Changes

- `apps/apps/pearl-desktop-wallet/package.json`: `version` 1.0.0 → 2.0.0 (drives the wallet release tag `pearl-wallet-v2.0.0` and installer artifacts, e.g. `Pearl-Wallet-Setup-2.0.0.exe`).
- `version/version.go`: add `UserAgent()`, returning `major.minor.patch` plus the pre-release tag if set (e.g. `1.2.0-beta`). Link-time `Build` metadata is deliberately excluded so the p2p UA is stable across builds of the same release and doesn't leak build details to peers. `Version()` is now defined in terms of it.
- `spv/neutrino.go`: `UserAgentVersion` `0.12.0-beta` → `version.UserAgent()` (currently `1.1.0`), so the SPV client always advertises the canonical monorepo version.
- `node/server.go`: pearld's `userAgentVersion` uses the same `version.UserAgent()` instead of an inline `fmt.Sprintf`, removing the duplicated formatting.

The advertised wire strings are byte-identical to the deployed ones: `/pearlwire:0.5.0/pearld:1.1.0/` and `/pearlwire:0.5.0/neutrino:1.1.0/`. Future pre-release tags set in `version/version.go` will propagate to both UAs automatically.

## Test plan

Verified `go build`/`go vet` pass for `version`, `spv`, and `node`, and that `version.UserAgent()` evaluates to exactly `1.1.0` (no behavior change for deployed pearld). Previously verified `oyster` builds cleanly from this branch and, in SPV mode, syncs the full testnet2 chain past the cert-v2 fork height (incl. V2-certificate blocks) against the live `pearld:1.1.0` node without errors.

- [ ] Existing tests pass (`task test`) — `node/wire` UA tests pass; full suite not run
- [ ] New tests added (if applicable)