### PR TITLE
several bugfixes to make MoE mining consistent

### DIFF
--- a/miner/miner-base/pyproject.toml
+++ b/miner/miner-base/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.18,<0.10.0"]
+requires = ["uv_build>=0.9.18,<0.12.0"]
 build-backend = "uv_build"
 
 [dependency-groups]

--- a/miner/miner-utils/pyproject.toml
+++ b/miner/miner-utils/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.18,<0.10.0"]
+requires = ["uv_build>=0.9.18,<0.12.0"]
 build-backend = "uv_build"
 
 [project]

--- a/miner/pearl-gateway/pyproject.toml
+++ b/miner/pearl-gateway/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.18,<0.10.0"]
+requires = ["uv_build>=0.9.18,<0.12.0"]
 build-backend = "uv_build"
 
 [dependency-groups]

--- a/miner/pearl-gemm-build-utils/pyproject.toml
+++ b/miner/pearl-gemm-build-utils/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.18,<0.10.0"]
+requires = ["uv_build>=0.9.18,<0.12.0"]
 build-backend = "uv_build"
 
 [project]

--- a/miner/pearl-gemm/csrc/tensor_hash/merkle_tree_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/merkle_tree_roots_kernel.hpp
@@ -259,7 +259,7 @@ class MerkleTreeRootsKernel {
     const u32 num_full_chunks = compute_num_full_chunks(args.data_len);
     // cuTensorMapEncodeTiled requires extents >= 1. When there is no full chunk
     // the producer issues no TMA loads, so the descriptor is never dereferenced.
-    const size_t tma_chunk_rows = num_full_chunks > 0 ? num_full_chunks : 1;
+    const size_t tma_chunk_rows = max(num_full_chunks, 1);
 
     Tensor mA = make_tensor(
         make_gmem_ptr(reinterpret_cast<uint32_t const*>(args.ptr_data)),
@@ -312,10 +312,10 @@ class MerkleTreeRootsKernel {
     // Calculate number of blocks for output tensor
     // Use ceiling division to include partial chunks
     const u32 num_chunks = compute_num_chunks(params.data_len);
+    const u32 num_full_chunks = compute_num_full_chunks(params.data_len);
     const size_t num_grid_blocks =
         (num_chunks + kNumConsumerThreads - 1) / kNumConsumerThreads;
 
-    const u32 num_full_chunks = compute_num_full_chunks(params.data_len);
     const u32 tma_transaction_bytes =
         num_full_chunks > 0 ? TmaTransactionBytesA : 0;
 

--- a/miner/pearl-gemm/csrc/tensor_hash/merkle_tree_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/merkle_tree_roots_kernel.hpp
@@ -235,19 +235,35 @@ class MerkleTreeRootsKernel {
     TMA_A tma_load_A;
   };
 
+  // Total chunks spanned by the input, including a trailing partial chunk
+  // (ceiling). This is the logical chunk domain used for grid shape, leaf
+  // counts, and the last-chunk predicate.
+  CUTLASS_HOST_DEVICE
+  static u32 compute_num_chunks(u32 data_len) {
+    return (data_len + kChunkSize - 1) / kChunkSize;
+  }
+
+  // Chunks fully backed by input bytes (floor). The TMA descriptor covers
+  // exactly these rows; any trailing partial chunk is loaded from gmem instead.
+  CUTLASS_HOST_DEVICE
+  static u32 compute_num_full_chunks(u32 data_len) {
+    return data_len / kChunkSize;
+  }
+
   static Params to_underlying_arguments(Arguments const& args) {
     Params params;
     params.ptr_data = args.ptr_data;
     params.data_len = args.data_len;
     params.ptr_roots = args.ptr_roots;
 
-    // Use ceiling division to include partial chunks in TMA descriptor
-    // TMA will read the full chunk size, and we'll zero-pad OOB data in the kernel
-    const size_t num_chunks = (args.data_len + kChunkSize - 1) / kChunkSize;
+    const u32 num_full_chunks = compute_num_full_chunks(args.data_len);
+    // cuTensorMapEncodeTiled requires extents >= 1. When there is no full chunk
+    // the producer issues no TMA loads, so the descriptor is never dereferenced.
+    const size_t tma_chunk_rows = num_full_chunks > 0 ? num_full_chunks : 1;
 
     Tensor mA = make_tensor(
         make_gmem_ptr(reinterpret_cast<uint32_t const*>(args.ptr_data)),
-        make_shape(num_chunks, Int<kChunkSize / kWordSize>{}),
+        make_shape(tma_chunk_rows, Int<kChunkSize / kWordSize>{}),
         make_stride(Int<kChunkSize / kWordSize>{}, Int<1>{}));
     params.tma_load_A = make_tma_copy(
         cute::SM90_TMA_LOAD{}, mA, SmemLayoutA_PerGroup{}(_, _, _0{}),
@@ -257,10 +273,7 @@ class MerkleTreeRootsKernel {
   }
 
   static dim3 get_grid_shape(Params const& params) {
-    // Each block processes kNumConsumerThreads chunks
-    // Use ceiling division to include partial chunks
-    const size_t num_chunks =
-        (params.data_len + blake3::CHUNK_SIZE - 1) / blake3::CHUNK_SIZE;
+    const u32 num_chunks = compute_num_chunks(params.data_len);
 
     return dim3((num_chunks + kNumConsumerThreads - 1) / kNumConsumerThreads);
   }
@@ -298,10 +311,13 @@ class MerkleTreeRootsKernel {
 
     // Calculate number of blocks for output tensor
     // Use ceiling division to include partial chunks
-    const size_t num_chunks =
-        (params.data_len + blake3::CHUNK_SIZE - 1) / blake3::CHUNK_SIZE;
+    const u32 num_chunks = compute_num_chunks(params.data_len);
     const size_t num_grid_blocks =
         (num_chunks + kNumConsumerThreads - 1) / kNumConsumerThreads;
+
+    const u32 num_full_chunks = compute_num_full_chunks(params.data_len);
+    const u32 tma_transaction_bytes =
+        num_full_chunks > 0 ? TmaTransactionBytesA : 0;
 
     // kApplyRoot (compile-time) is set by the host only when this is the single
     // CTA of the whole input, so the kernel must apply BLAKE3's ROOT
@@ -340,7 +356,7 @@ class MerkleTreeRootsKernel {
       // For producers: participate in both pipelines
       // For consumers: participate only in their group's pipeline
       typename Pipeline::Params pipeline_params_0;
-      pipeline_params_0.transaction_bytes = TmaTransactionBytesA;
+      pipeline_params_0.transaction_bytes = tma_transaction_bytes;
       pipeline_params_0.role =
           is_producer_warpgroup
               ? Pipeline::ThreadCategory::Producer
@@ -355,7 +371,7 @@ class MerkleTreeRootsKernel {
       pipeline_params_0.num_consumers = kConsumersPerGroup;
 
       typename Pipeline::Params pipeline_params_1;
-      pipeline_params_1.transaction_bytes = TmaTransactionBytesA;
+      pipeline_params_1.transaction_bytes = tma_transaction_bytes;
       pipeline_params_1.role =
           is_producer_warpgroup
               ? Pipeline::ThreadCategory::Producer
@@ -418,7 +434,7 @@ class MerkleTreeRootsKernel {
       // Initialize pipeline with warpgroup-specialized roles
       // ONE leader per warpgroup (thread 0 of each warpgroup)
       typename Pipeline::Params pipeline_params;
-      pipeline_params.transaction_bytes = TmaTransactionBytesA;
+      pipeline_params.transaction_bytes = tma_transaction_bytes;
       pipeline_params.role = is_producer_warpgroup
                                  ? Pipeline::ThreadCategory::Producer
                                  : Pipeline::ThreadCategory::Consumer;
@@ -514,9 +530,8 @@ class MerkleTreeRootsKernel {
                                     SharedStorage& shared_storage,
                                     PipelineState& smem_pipe_write) {
     const int bid = blockIdx.x;
-    // Use ceiling division to match TMA descriptor (includes partial chunks)
-    const int num_chunks =
-        (params.data_len + blake3::CHUNK_SIZE - 1) / blake3::CHUNK_SIZE;
+    const u32 num_chunks = compute_num_chunks(params.data_len);
+    const u32 num_full_chunks = compute_num_full_chunks(params.data_len);
 
     // View of our CTA's tile of A
     Tensor mA = params.tma_load_A.get_tma_tensor(
@@ -540,15 +555,20 @@ class MerkleTreeRootsKernel {
       for (int load_idx = 0; load_idx < kNumLoads; ++load_idx) {
         pipeline.producer_acquire(smem_pipe_write);
 
-        PipelineBarrierType* tma_barrier =
-            pipeline.producer_get_barrier(smem_pipe_write);
-        auto stage = smem_pipe_write.index();
+        // With no full chunk the descriptor covers no backed memory; skip the
+        // copy entirely (the barrier expects 0 transaction bytes in that case
+        // and completes on the producer's arrival alone).
+        if (num_full_chunks > 0) {
+          PipelineBarrierType* tma_barrier =
+              pipeline.producer_get_barrier(smem_pipe_write);
+          auto stage = smem_pipe_write.index();
 
-        // Issue TMA copy with barrier
-        copy(params.tma_load_A.with(*tma_barrier, 0 /*mcast_mask*/),
-             tAgA(_, load_idx), tAsA(_, stage));
+          // Issue TMA copy with barrier
+          copy(params.tma_load_A.with(*tma_barrier, 0 /*mcast_mask*/),
+               tAgA(_, load_idx), tAsA(_, stage));
 
-        pipeline.producer_commit(smem_pipe_write, TmaTransactionBytesA);
+          pipeline.producer_commit(smem_pipe_write, TmaTransactionBytesA);
+        }
         ++smem_pipe_write;
       }
     }
@@ -567,50 +587,38 @@ class MerkleTreeRootsKernel {
     }
   }
 
-  // ==================== ZERO-PADDING HELPER ====================
+  // ==================== PARTIAL-CHUNK LOAD HELPER ====================
 
-  /// Zero-pad partial chunks in shared memory (per-load iteration)
-  /// Each TMA load brings in kThreadLoadSize bytes into one stage
-  /// We need to zero the out-of-bounds parts within that loaded data
+  /// Load one slice of the trailing partial chunk straight from global memory
+  /// into shared memory, zero-filling past the end of the data. At most one
+  /// chunk (1 KiB) per hash is read this way.
   template <class SmemTensorA>
-  CUTLASS_DEVICE void zero_pad_partial_chunk_load(SmemTensorA& sA,
-                                                  int consumer_tid, int stage,
-                                                  int load_idx,
-                                                  u32 last_chunk_len) {
-    // This load brought in bytes [load_start_byte, load_start_byte + kThreadLoadSize)
-    // from the chunk into sA(consumer_tid, 0..kNumWordsPerLoad-1, stage)
+  CUTLASS_DEVICE void load_partial_chunk(Params const& params, SmemTensorA& sA,
+                                         int smem_row, int stage, int load_idx,
+                                         u32 last_chunk_len) {
+    // The partial chunk starts right after the last full chunk.
+    const u32 chunk_start_byte = (params.data_len / kChunkSize) * kChunkSize;
+    // This load covers bytes [load_start_byte, load_start_byte + kThreadLoadSize)
+    // of the chunk, i.e. sA(smem_row, 0..kNumWordsPerLoad-1, stage).
     const u32 load_start_byte = load_idx * kThreadLoadSize;
+    const Element* chunk_ptr = params.ptr_data + chunk_start_byte;
 
-    // If this entire load is beyond valid data, zero everything
-    if (load_start_byte >= last_chunk_len) {
-      CUTLASS_PRAGMA_UNROLL
-      for (int w = 0; w < kNumWordsPerLoad; ++w) {
-        sA(consumer_tid, w, stage) = 0;
-      }
-      return;
-    }
-
-    // Some or all of this load contains valid data
-    // Process each word in the load
     CUTLASS_PRAGMA_UNROLL
     for (int w = 0; w < kNumWordsPerLoad; ++w) {
       const u32 word_start_byte = load_start_byte + w * sizeof(uint32_t);
-      const u32 word_end_byte = word_start_byte + sizeof(uint32_t);
-
-      if (word_start_byte >= last_chunk_len) {
-        // Entire word is OOB - zero it
-        sA(consumer_tid, w, stage) = 0;
-      } else if (word_end_byte > last_chunk_len) {
-        // Partial word - some bytes valid, some OOB
-        const u32 valid_bytes = last_chunk_len - word_start_byte;
-        // Mask: valid_bytes=1 -> 0xFF, =2 -> 0xFFFF, =3 -> 0xFFFFFF
-        const u32 mask = (1u << (valid_bytes * 8)) - 1;
-
-        // Read, mask, write back
-        uint32_t val = sA(consumer_tid, w, stage);
-        sA(consumer_tid, w, stage) = val & mask;
+      u32 word = 0;
+      if (word_start_byte < last_chunk_len) {
+        const u32 remaining = last_chunk_len - word_start_byte;
+        const Element* src = chunk_ptr + word_start_byte;
+        if (remaining >= sizeof(uint32_t)) {
+          word = *reinterpret_cast<const uint32_t*>(src);
+        } else {
+          for (u32 b = 0; b < remaining; ++b) {
+            word |= u32(src[b]) << (8 * b);
+          }
+        }
       }
-      // else: word is fully valid, no action needed
+      sA(smem_row, w, stage) = word;
     }
   }
 
@@ -622,9 +630,8 @@ class MerkleTreeRootsKernel {
       SmemTensorA_0& sA_0, SmemTensorA_1& sA_1, SharedStorage& shared_storage,
       PipelineState& smem_pipe_write_0, PipelineState& smem_pipe_write_1) {
     const int bid = blockIdx.x;
-    // Use ceiling division to match TMA descriptor (includes partial chunks)
-    const int num_chunks =
-        (params.data_len + blake3::CHUNK_SIZE - 1) / blake3::CHUNK_SIZE;
+    const u32 num_chunks = compute_num_chunks(params.data_len);
+    const u32 num_full_chunks = compute_num_full_chunks(params.data_len);
 
     // View of our CTA's tile of A (global memory)
     Tensor mA = params.tma_load_A.get_tma_tensor(
@@ -659,25 +666,29 @@ class MerkleTreeRootsKernel {
         pipeline_0.producer_acquire(smem_pipe_write_0);
         pipeline_1.producer_acquire(smem_pipe_write_1);
 
-        // Get barriers for both pipelines
-        PipelineBarrierType* tma_barrier_0 =
-            pipeline_0.producer_get_barrier(smem_pipe_write_0);
-        PipelineBarrierType* tma_barrier_1 =
-            pipeline_1.producer_get_barrier(smem_pipe_write_1);
-        auto stage_0 = smem_pipe_write_0.index();
-        auto stage_1 = smem_pipe_write_1.index();
+        // With no full chunk the descriptor covers no backed memory; skip the
+        // copies entirely.
+        if (num_full_chunks > 0) {
+          // Get barriers for both pipelines
+          PipelineBarrierType* tma_barrier_0 =
+              pipeline_0.producer_get_barrier(smem_pipe_write_0);
+          PipelineBarrierType* tma_barrier_1 =
+              pipeline_1.producer_get_barrier(smem_pipe_write_1);
+          auto stage_0 = smem_pipe_write_0.index();
+          auto stage_1 = smem_pipe_write_1.index();
 
-        // Issue TMA copy to group 0
-        copy(params.tma_load_A.with(*tma_barrier_0, 0 /*mcast_mask*/),
-             tAgA_0(_, load_idx), tAsA_0(_, stage_0));
+          // Issue TMA copy to group 0
+          copy(params.tma_load_A.with(*tma_barrier_0, 0 /*mcast_mask*/),
+               tAgA_0(_, load_idx), tAsA_0(_, stage_0));
 
-        // Issue TMA copy to group 1
-        copy(params.tma_load_A.with(*tma_barrier_1, 0 /*mcast_mask*/),
-             tAgA_1(_, load_idx), tAsA_1(_, stage_1));
+          // Issue TMA copy to group 1
+          copy(params.tma_load_A.with(*tma_barrier_1, 0 /*mcast_mask*/),
+               tAgA_1(_, load_idx), tAsA_1(_, stage_1));
 
-        // Commit both pipelines
-        pipeline_0.producer_commit(smem_pipe_write_0, TmaTransactionBytesA);
-        pipeline_1.producer_commit(smem_pipe_write_1, TmaTransactionBytesA);
+          // Commit both pipelines
+          pipeline_0.producer_commit(smem_pipe_write_0, TmaTransactionBytesA);
+          pipeline_1.producer_commit(smem_pipe_write_1, TmaTransactionBytesA);
+        }
         ++smem_pipe_write_0;
         ++smem_pipe_write_1;
       }
@@ -715,8 +726,7 @@ class MerkleTreeRootsKernel {
 
     // Calculate if this thread is processing the last (potentially partial) chunk
     // Use ceiling division to include partial chunks in the count
-    const size_t num_chunks =
-        (params.data_len + blake3::CHUNK_SIZE - 1) / blake3::CHUNK_SIZE;
+    const u32 num_chunks = compute_num_chunks(params.data_len);
     const u32 remainder = params.data_len % blake3::CHUNK_SIZE;
     const u32 last_chunk_size =
         (remainder == 0) ? blake3::CHUNK_SIZE : remainder;
@@ -731,10 +741,9 @@ class MerkleTreeRootsKernel {
       pipeline.consumer_wait(smem_pipe_read);
       auto stage = smem_pipe_read.index();
 
-      // Zero-pad OOB data in this load if processing the last (partial) chunk
       if (is_last_chunk) {
-        zero_pad_partial_chunk_load(sA, tid_in_group, stage, load_idx,
-                                    last_chunk_size);
+        load_partial_chunk(params, sA, tid_in_group, stage, load_idx,
+                           last_chunk_size);
       }
 
       // Process kNumBlocksPerLoad blocks from this load
@@ -791,8 +800,7 @@ class MerkleTreeRootsKernel {
 
     // Calculate if this thread is processing the last (potentially partial) chunk
     // Use ceiling division to include partial chunks in the count
-    const size_t num_chunks =
-        (params.data_len + blake3::CHUNK_SIZE - 1) / blake3::CHUNK_SIZE;
+    const u32 num_chunks = compute_num_chunks(params.data_len);
     const u32 remainder = params.data_len % blake3::CHUNK_SIZE;
     const u32 last_chunk_size =
         (remainder == 0) ? blake3::CHUNK_SIZE : remainder;
@@ -807,10 +815,9 @@ class MerkleTreeRootsKernel {
       pipeline.consumer_wait(smem_pipe_read);
       auto stage = smem_pipe_read.index();
 
-      // Zero-pad OOB data in this load if processing the last (partial) chunk
       if (is_last_chunk) {
-        zero_pad_partial_chunk_load(sA, consumer_tid, stage, load_idx,
-                                    last_chunk_size);
+        load_partial_chunk(params, sA, consumer_tid, stage, load_idx,
+                           last_chunk_size);
       }
 
       // Process kNumBlocksPerLoad blocks from this load

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -5,6 +5,7 @@
 #include <c10/cuda/CUDAGuard.h>
 #include <torch/python.h>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 // Include only the host function declaration
 #include "blake3/blake3_constants.hpp"
@@ -18,6 +19,10 @@
 constexpr size_t DEFAULT_THREADS_PER_BLOCK = 128;    // merkle_tree_roots_kernel
 constexpr size_t DEFAULT_NUM_STAGES = 2;             // merkle_tree_roots_kernel
 constexpr size_t DEFAULT_LEAVES_PER_MT_BLOCK = 512;  // compute_blake_mt_kernel
+
+// merkle_tree_roots_kernel builds a TMA descriptor over `data`;
+// cuTensorMapEncodeTiled requires the global address to be 16-byte aligned.
+constexpr uintptr_t TMA_GLOBAL_ALIGNMENT_BYTES = 16;
 
 size_t get_required_scratchpad_bytes(
     size_t matrix_bytes, size_t threads_per_block = DEFAULT_THREADS_PER_BLOCK) {
@@ -50,6 +55,11 @@ void run_tensor_hash(
   TORCH_CHECK(out.dtype() == at::kByte, "out must be uint8");
   TORCH_CHECK(roots.dtype() == at::kByte, "roots must be uint8");
   TORCH_CHECK(data.dim() == 2, "data must be 2D tensor");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(data.data_ptr()) %
+                      TMA_GLOBAL_ALIGNMENT_BYTES ==
+                  0,
+              "data must be ", TMA_GLOBAL_ALIGNMENT_BYTES,
+              "-byte aligned for TMA");
   TORCH_CHECK(key.numel() == blake3::KEY_SIZE, "key must have exactly",
               blake3::KEY_SIZE, "bytes");
   TORCH_CHECK(out.numel() == blake3::CHAINING_VALUE_SIZE,

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -217,6 +217,40 @@ class TestTensorHash:
             f"Hash mismatch for shape {shape} with 512 threads: CUDA result doesn't match Python reference"
         )
 
+    @pytest.mark.parametrize("threads_per_block", [128, 512])
+    @pytest.mark.parametrize(
+        "nbytes",
+        [
+            512,  # single sub-chunk input
+            1056,  # one full chunk + 32-byte remainder
+            128 * 1024 + 512,  # partial chunk alone in the second CTA @128 threads
+        ],
+    )
+    def test_tensor_hash_unaligned_tail_of_allocation(self, nbytes, threads_per_block):
+        backing_bytes = 2 * 1024 * 1024
+        backing = torch.randint(0, 255, (backing_bytes,), dtype=torch.uint8, device="cuda")
+        matrix = backing[-nbytes:].reshape(1, nbytes)
+        assert matrix.is_contiguous()
+
+        scratchpad_size = get_required_scratchpad_bytes(matrix.numel())
+        scratchpad = torch.empty(scratchpad_size, dtype=torch.uint8, device="cuda")
+
+        cuda_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        key_tensor = torch.randint(0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda")
+        key_bytes = key_tensor.cpu().numpy().tobytes()
+
+        tensor_hash(
+            matrix, key_tensor, cuda_result, scratchpad, threads_per_block=threads_per_block
+        )
+        torch.cuda.synchronize()
+
+        python_result = hash_matrix(matrix.cpu(), key_bytes)
+
+        assert torch.equal(cuda_result, python_result), (
+            f"Hash mismatch for {nbytes}-byte tail input with {threads_per_block} threads: "
+            "CUDA result doesn't match Python reference"
+        )
+
     def test_tensor_hash_deterministic(self):
         """Test that tensor hash produces deterministic results."""
         shape = (8192, 8192)

--- a/miner/vllm-miner/pyproject.toml
+++ b/miner/vllm-miner/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["uv_build>=0.9.18,<0.10.0"]
+requires = ["uv_build>=0.9.18,<0.12.0"]
 build-backend = "uv_build"
 
 [dependency-groups]

--- a/miner/vllm-miner/src/vllm_miner/callbacks.py
+++ b/miner/vllm-miner/src/vllm_miner/callbacks.py
@@ -109,7 +109,7 @@ class MoEStatusCheckCallback:
                 expert_weight_col_offset = expert_index * self.n_per_expert
 
                 _LOGGER.info(
-                    "MoE block found! expert=%d, inner_rows=%s, outer_indices=%s, b_cols=%s",
+                    "MoE block found! expert={}, inner_rows={}, outer_indices={}, b_cols={}",
                     expert_index,
                     indices.A_row_indices,
                     outer_indices,

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -5,6 +5,7 @@ from blake3 import blake3
 from miner_base.commitment_hash import CommitmentHasher
 from miner_base.gpu_matmul_config import GPUMatmulConfigFactory
 from miner_utils import get_logger
+from pearl_gateway.comm.dataclasses import MiningJob
 from pearl_gateway.comm.mining_configuration import MoEConfig
 from pearl_gemm import (
     commitment_hash_from_merkle_roots,
@@ -68,6 +69,7 @@ class MoERoutingLayout:
 class MoENoiseContext:
     """Pre-computed tensors for one MoE forward pass (shared across experts)."""
 
+    mining_job: MiningJob  # job whose header/target the PoW key was derived from
     commitment_hash_A: torch.Tensor  # (32,) uint8
     commitment_hash_B: torch.Tensor  # (32,) uint8
     EAL: torch.Tensor  # (m, r) int8
@@ -203,6 +205,7 @@ def prepare_moe_noising(
     )
 
     return MoENoiseContext(
+        mining_job=mining_job,
         commitment_hash_A=commitment_hash_A,
         commitment_hash_B=commitment_hash_B,
         EAL=EAL,

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -367,7 +367,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
             B_stacked=B_stacked,
             routing_data=ctx.routing_data,
             routing_hash=ctx.routing_hash,
-            mining_job=get_async_manager().get_mining_job(),
+            mining_job=ctx.mining_job,
             noise_rank=ctx.noise_rank,
             num_experts=E,
             n_per_expert=N,


### PR DESCRIPTION
## Summary

1. Buffer overflow in miner for small tensor hash
2. Using the right coherent mining_job in callback (test only issue)
## Type

bugfix

## Scope

tensor_hash and MoE miner

## Changes

<!-- Bullet list of key changes -->

- Now handling tensor_hash tail correctly

## Test plan

<!-- How was this tested? -->

- [X] Existing tests pass (`task test`)
- [X] New small tensor hash tests
