### PR TITLE
feat(zkpow): restore VerifyCertificateWithNbits for pool share validation

### DIFF
--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -44,6 +44,27 @@ func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) err
 	}
 }
 
+// VerifyCertificateWithNbits verifies a certificate using nbitsOverride as the
+// difficulty target instead of the block header's nbits field. It mirrors
+// VerifyCertificate and is intended for off-chain pool share validation, where a
+// proof is checked against a lower (share) target than the network target.
+//
+// WARNING: This bypasses the header's embedded difficulty. Never use it in block
+// acceptance or relay paths.
+//
+// Only V2 certificates support an nbits override; V1 has no override-capable
+// verification path and is rejected.
+func VerifyCertificateWithNbits(header *wire.BlockHeader, cert wire.BlockCertificate, nbitsOverride uint32) error {
+	switch c := cert.(type) {
+	case *wire.CertificateV2:
+		return verifyCertificateV2WithOverride(header, c, &nbitsOverride)
+	case *wire.CertificateV1:
+		return fmt.Errorf("nbits override not supported for V1 certificates")
+	default:
+		return fmt.Errorf("unknown certificate type: %T", cert)
+	}
+}
+
 // ================================================================================
 // V1 CERTIFICATE VERIFICATION
 // ================================================================================
@@ -96,6 +117,13 @@ func verifyCertificateV1(header *wire.BlockHeader, c *wire.CertificateV1) error 
 // ================================================================================
 
 func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error {
+	return verifyCertificateV2WithOverride(header, c, nil)
+}
+
+// verifyCertificateV2WithOverride runs the V2 sanity checks and proof verification.
+// When nbitsOverride is non-nil, the difficulty target is taken from it instead of
+// the block header's nbits field (used for pool share-difficulty checks).
+func verifyCertificateV2WithOverride(header *wire.BlockHeader, c *wire.CertificateV2, nbitsOverride *uint32) error {
 	// Guard against directly-constructed structs that bypassed Deserialize.
 	if c.PublicDataLen > wire.PublicDataMaxSizeV2 {
 		return fmt.Errorf("invalid public_data_len %d (max %d)", c.PublicDataLen, wire.PublicDataMaxSizeV2)
@@ -111,7 +139,7 @@ func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error 
 	if e == 0 && topK != 0 {
 		return fmt.Errorf("invalid mining config: e=0 but top_k=%d (must be 0 for non-MoE)", topK)
 	}
-	return verifyZKProofFFI(header, c.Hash, c.ProofCommitment(), publicData, c.ProofData, nil)
+	return verifyZKProofFFI(header, c.Hash, c.ProofCommitment(), publicData, c.ProofData, nbitsOverride)
 }
 
 func verifyZKProofFFI(

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -20,6 +20,10 @@ func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) err
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
 }
 
+func VerifyCertificateWithNbits(header *wire.BlockHeader, cert wire.BlockCertificate, nbitsOverride uint32) error {
+	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
+}
+
 func Mine(header *wire.BlockHeader) (*wire.CertificateV2, error) {
 	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable mining")
 }


### PR DESCRIPTION
## Summary

Restores an exported `VerifyCertificateWithNbits` helper (the capability removed in #177) so off-chain pool share validation can verify a certificate against a lower share-difficulty target instead of the header's network difficulty.

## Type

feat

## Scope

node (zkpow)

## Changes

- Add `VerifyCertificateWithNbits(header, cert, nbitsOverride)`, which dispatches on the `BlockCertificate` interface like `VerifyCertificate`: V2 certificates use the override-capable FFI path (`verify_zk_proof_v2_with_nbits`); V1 certificates are rejected, since no V1 nbits-override FFI exists.
- Extract `verifyCertificateV2WithOverride` so the normal and override paths share the same V2 sanity checks (including the `e=0` ⇒ `top_k=0` guard from #177) and cannot drift.
- Add a matching `VerifyCertificateWithNbits` stub in `zkpow_stub.go` for non-`zkpow` builds.

> Note: the previously removed `VerifyCertificateV1WithNbits` took a V1 certificate but routed through the V2 FFI (the only override path), which is why it was dropped as stale; this restores the capability on the correct, V2 path.

## Test plan

- [ ] Existing tests pass (`task test`)
- [ ] New tests added (if applicable)

Verified locally: `go build ./node/zkpow/` (non-`zkpow` stub path), `go vet ./node/zkpow/`, and `gofmt` all pass. The `zkpow`-tagged build/tests could not be run in this environment because the generated Rust FFI artifacts (`zk_pow_ffi.h` and `libzk_pow_ffi.a`) are not present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)