### PR TITLE
feat(zkpow): export VerifyZKProofFFI for external callers

### DIFF
--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -111,10 +111,10 @@ func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error 
 	if e == 0 && topK != 0 {
 		return fmt.Errorf("invalid mining config: e=0 but top_k=%d (must be 0 for non-MoE)", topK)
 	}
-	return verifyZKProofFFI(header, c.Hash, c.ProofCommitment(), publicData, c.ProofData, nil)
+	return VerifyZKProofFFI(header, c.Hash, c.ProofCommitment(), publicData, c.ProofData, nil)
 }
 
-func verifyZKProofFFI(
+func VerifyZKProofFFI(
 	header *wire.BlockHeader,
 	certHash chainhash.Hash,
 	proofCommitment chainhash.Hash,

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -5,6 +5,7 @@ package zkpow
 import (
 	"fmt"
 
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/wire"
 )
 
@@ -17,6 +18,17 @@ const (
 )
 
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
+	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
+}
+
+func VerifyZKProofFFI(
+	header *wire.BlockHeader,
+	certHash chainhash.Hash,
+	proofCommitment chainhash.Hash,
+	publicData []byte,
+	proofData []byte,
+	nbitsOverride *uint32,
+) error {
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
 }
 


### PR DESCRIPTION
## Summary

Exports the ZK proof verification FFI entry point so packages outside `zkpow` can verify proofs directly.

## Type

feat

## Scope

node, zk-pow

## Changes

- Rename `verifyZKProofFFI` → exported `VerifyZKProofFFI` in `verify.go`, updating its internal call site in `verifyCertificateV2`.
- Add a matching `VerifyZKProofFFI` stub (and the `chainhash` import) to `zkpow_stub.go` so non-`zkpow` builds keep compiling, consistent with the package's other exported functions.

## Test plan

- [ ] Existing tests pass (`task test`)
- [ ] New tests added (if applicable)

Verified locally: untagged `go build ./node/zkpow/` and `gofmt` are clean; the `zkpow`-tagged build and full `task test` were not run in this workspace (the generated cgo header `zk_pow_ffi.h` is absent), and the tagged change is a pure identifier rename.