### PR TITLE
perf(vllm-miner): cache the static-weight tensor_hash in the mining path

### DIFF
--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -54,6 +54,8 @@ void run_tensor_hash(
   TORCH_CHECK(key.dtype() == at::kByte, "key must be uint8");
   TORCH_CHECK(out.dtype() == at::kByte, "out must be uint8");
   TORCH_CHECK(roots.dtype() == at::kByte, "roots must be uint8");
+  TORCH_CHECK(data.dtype() == at::kByte || data.dtype() == at::kChar,
+              "data must be uint8 or int8");
   TORCH_CHECK(data.dim() == 2, "data must be 2D tensor");
   TORCH_CHECK(reinterpret_cast<uintptr_t>(data.data_ptr()) %
                       TMA_GLOBAL_ALIGNMENT_BYTES ==
@@ -103,8 +105,10 @@ void run_tensor_hash(
   auto stream = at::cuda::getCurrentCUDAStream();
   auto dprops = at::cuda::getCurrentDeviceProperties();
 
-  tensor_hash(data.data_ptr<uint8_t>(), data.numel(), out.data_ptr<uint8_t>(),
-              key.data_ptr<uint8_t>(), num_blocks,
+  // Hash the tensor storage bytes. int8 and uint8 are both one byte per
+  // element, so they must commit to identical roots for identical bit patterns.
+  tensor_hash(reinterpret_cast<uint8_t const*>(data.data_ptr()), data.numel(),
+              out.data_ptr<uint8_t>(), key.data_ptr<uint8_t>(), num_blocks,
               static_cast<uint32_t>(threads_per_block),
               static_cast<uint32_t>(num_stages),
               static_cast<uint32_t>(leaves_per_mt_block),

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -559,7 +559,8 @@ def tensor_hash(
     """Hash a tensor using a key with configurable kernel parameters.
 
     Args:
-        data (Tensor): Input tensor to hash
+        data (Tensor): 2D uint8 or int8 tensor to hash as raw storage bytes.
+            int8 and uint8 inputs with the same bit pattern produce the same root.
         key (Tensor): Key tensor used for hashing
         out (Tensor): Output tensor for hash result
         roots (Tensor): Scratchpad tensor for intermediate results

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -115,6 +115,40 @@ class TestTensorHash:
             "Commitment hash from merkle roots mismatch: CUDA result doesn't match Python reference"
         )
 
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (16, 16),
+            (257, 1024),
+            (1024, 1024),
+            (2048, 3072),
+        ],
+    )
+    def test_tensor_hash_int8_hashes_raw_bytes(self, shape):
+        """Dense mining hashes int8 A/B tensors directly without uint8 casts."""
+        matrix = torch.randint(-63, 64, shape, dtype=torch.int8, device="cuda")
+        scratchpad = torch.empty(
+            get_required_scratchpad_bytes(matrix.numel()),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        direct_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        cast_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        key_tensor = torch.randint(0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda")
+        key_bytes = key_tensor.cpu().numpy().tobytes()
+
+        tensor_hash(matrix, key_tensor, direct_result, scratchpad)
+        tensor_hash(matrix.to(torch.uint8), key_tensor, cast_result, scratchpad)
+        torch.cuda.synchronize()
+
+        python_result = hash_matrix(matrix.cpu(), key_bytes)
+        assert torch.equal(direct_result, python_result), (
+            f"tensor_hash must hash the raw int8 bytes used by MatrixMerkleTree for {shape}"
+        )
+        assert torch.equal(direct_result, cast_result), (
+            f"direct int8 hashing must match the previous uint8 cast path for {shape}"
+        )
+
     def test_commitment_hash_from_merkle_roots_moe(self):
         """MoE folding path matches the CommitmentHasher reference."""
         # Cumulative exclusive ends per expert; last == m * top_k.

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -21,6 +21,7 @@ from .mining_state import (
     get_async_manager,
     get_pinned_pool,
 )
+from .weight_hash_cache import cached_weight_hash
 
 _LOGGER = get_logger("vllm.pearl_miner")
 
@@ -129,13 +130,14 @@ def pearl_gemm_noisy(
         tensor_hash_scratchpad,
     )
 
-    B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
-    tensor_hash(
-        B,
-        key_tensor,
-        B_tensor_hash,
-        tensor_hash_scratchpad,
-    )
+    # B is the layer weight (constant for the process); its keyed merkle root is
+    # cached across forward passes within a mining job (bit-identical to fresh).
+    def _hash_weight(B=B, key_tensor=key_tensor, scratchpad=tensor_hash_scratchpad):
+        out = torch.empty(32, device="cuda", dtype=torch.uint8)
+        tensor_hash(B, key_tensor, out, scratchpad)
+        return out
+
+    B_tensor_hash = cached_weight_hash(B, hash_key, _hash_weight)
 
     # Generate commitment hash for noise generation
     commitment_hash_A_tensor = torch.empty(32, device="cuda", dtype=torch.uint8)

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -123,7 +123,7 @@ def pearl_gemm_noisy(
 
     A_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        A.to(torch.uint8),
+        A,
         key_tensor,
         A_tensor_hash,
         tensor_hash_scratchpad,
@@ -131,7 +131,7 @@ def pearl_gemm_noisy(
 
     B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        B.to(torch.uint8),
+        B,
         key_tensor,
         B_tensor_hash,
         tensor_hash_scratchpad,

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -19,6 +19,7 @@ from pearl_gemm.moe import build_routing_data, get_build_routing_data_scratchpad
 from .config import config
 from .gemm_operators import generate_noise_factors
 from .mining_state import get_async_manager
+from .weight_hash_cache import cached_weight_hash
 
 _LOGGER = get_logger("vllm.pearl_miner")
 
@@ -148,7 +149,13 @@ def prepare_moe_noising(
     key_tensor = _to_gpu_u8(hash_key, device)
 
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
-    B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
+    # B_stacked is the static stacked expert weights; cache its keyed root across
+    # forward passes within a mining job (bit-identical to a fresh recompute).
+    B_hash = cached_weight_hash(
+        B_stacked,
+        hash_key,
+        lambda: _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device),
+    )
 
     num_routed_slots = num_tokens * top_k
     routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)

--- a/miner/vllm-miner/src/vllm_miner/weight_hash_cache.py
+++ b/miner/vllm-miner/src/vllm_miner/weight_hash_cache.py
@@ -1,0 +1,95 @@
+"""Cache for the keyed merkle hash of a static mining weight.
+
+The noisy mining GEMM hashes BOTH operands (``tensor_hash``) to seed the PoW
+commitment. The ``B`` operand is the layer weight: constant for the process
+lifetime, while the hash key only changes when the mining job changes (gateway
+polled ~1/s) and a forward pass runs in milliseconds. So ``tensor_hash(weight)``
+recomputes the identical 32-byte root every forward pass -- pure waste
+(0.13-0.41 ms/layer on H100, the dominant per-layer cost at decode batch sizes).
+
+This caches that root. A cached value is ALWAYS bit-identical to recomputing, so
+the proof-of-work path is unchanged; any uncertainty degrades to a redundant
+recompute, never a wrong hash:
+
+* the mining-job ``key`` bytes are part of the cache key -> a new job misses;
+* a ``weakref`` to the exact tensor is checked on a hit -> a freed/reused
+  ``data_ptr`` (ABA) misses and recomputes;
+* ``device`` (type + index) is part of the key -> CUDA ``data_ptr`` ints that
+  collide across GPUs cannot produce a wrong hit.
+
+Entries self-evict via a ``weakref`` finalizer when their weight is garbage
+collected (a size cap is kept only as a backstop for non-collectable churn).
+
+Dict operations are atomic under the GIL, and all mining ops run on the default
+CUDA stream (no explicit streams in the plugin), so the cached tensor's producing
+``tensor_hash`` is ordered before any consumer on the same stream — identical to
+the un-cached code's own same-stream assumption.
+
+Validity assumes the weight is IMMUTABLE (Pearl weights are persistent
+``nn.Parameter``s set once at load and never mutated in place). The cache cannot
+detect in-place mutation of the same object (``copy_``/``set_``/adapter swaps);
+call :func:`clear_cache` on any such weight-reload path.
+"""
+
+import weakref
+from collections.abc import Callable
+
+import torch
+
+_CACHE: dict[tuple, tuple] = {}
+_MAX_ENTRIES = 4096
+
+
+def cached_weight_hash(
+    weight: torch.Tensor,
+    key_bytes: bytes,
+    compute: Callable[[], torch.Tensor],
+) -> torch.Tensor:
+    """Return the keyed merkle hash of ``weight``, reusing a cached value only
+    when the exact same (still-alive) tensor and mining-job key are unchanged.
+
+    On any miss it calls ``compute()`` (which must produce the hash) and caches
+    the result; the returned bytes are always identical to recomputing.
+    """
+    cache_key = (
+        weight.device.type,
+        weight.device.index,
+        weight.data_ptr(),
+        tuple(weight.shape),
+        weight.dtype,
+    )
+    entry = _CACHE.get(cache_key)
+    if entry is not None:
+        cached_key_bytes, weak_weight, cached_hash = entry
+        if cached_key_bytes == key_bytes and weak_weight() is weight:
+            return cached_hash
+
+    result = compute()
+
+    # Register a finalizer so the entry is dropped as soon as `weight` is GC'd,
+    # instead of lingering until the size cap clears the whole cache. The
+    # `entry[1] is ref` check ensures a finalizer only removes ITS OWN entry and
+    # never a newer one that reused the same cache_key (e.g. data_ptr reuse).
+    def _evict(ref: weakref.ref, key: tuple = cache_key) -> None:
+        entry = _CACHE.get(key)
+        if entry is not None and entry[1] is ref:
+            _CACHE.pop(key, None)
+
+    try:
+        weak_weight = weakref.ref(weight, _evict)
+    except TypeError:
+        return result  # not weak-referenceable: skip caching (still correct)
+    if len(_CACHE) >= _MAX_ENTRIES:  # backstop for non-collectable churn
+        _CACHE.clear()
+    _CACHE[cache_key] = (key_bytes, weak_weight, result)
+    return result
+
+
+def clear_cache() -> None:
+    """Drop all cached weight hashes (test/maintenance helper)."""
+    _CACHE.clear()
+
+
+def cache_size() -> int:
+    """Number of live cache entries (introspection/test helper)."""
+    return len(_CACHE)

--- a/miner/vllm-miner/tests/test_pearl_noisy_gemm.py
+++ b/miner/vllm-miner/tests/test_pearl_noisy_gemm.py
@@ -407,3 +407,57 @@ def test_pearl_gemm_noisy_with_controlled_noise(make_random_test_matrices):
         )
     else:
         print("✓ Confirmed that denoising produces consistent results across runs")
+
+
+def test_weight_hash_cache_hits_invalidates_and_is_aba_safe():
+    """The static-weight hash cache must: return the computed value on a miss,
+    reuse it on a hit, recompute when the mining-job key changes, and never
+    return a stale value when a freed tensor's data_ptr is reused (ABA). A wrong
+    cached hash would silently corrupt the PoW commitment, so this is the guard.
+    """
+    import gc
+
+    from vllm_miner import weight_hash_cache as whc
+
+    calls = {"n": 0}
+
+    def make_hash(tag: int):
+        def _compute():
+            calls["n"] += 1
+            return torch.tensor([tag] * 32, dtype=torch.uint8)
+
+        return _compute
+
+    whc.clear_cache()
+    w = torch.zeros(256, dtype=torch.int8)
+    k1, k2 = b"\x01" * 32, b"\x02" * 32
+
+    h1 = whc.cached_weight_hash(w, k1, make_hash(1))  # miss -> compute
+    h2 = whc.cached_weight_hash(w, k1, make_hash(9))  # hit -> cached (compute not called)
+    assert h1.tolist() == [1] * 32
+    assert h2 is h1, "repeat call with same tensor+key must reuse the cached value"
+    assert calls["n"] == 1, "a hit must not recompute"
+
+    h3 = whc.cached_weight_hash(w, k2, make_hash(2))  # key change -> recompute
+    assert h3.tolist() == [2] * 32 and calls["n"] == 2, "key change must recompute"
+
+    # ABA: free w, reuse its address with a different tensor -> must NOT false-hit.
+    whc.clear_cache()
+    calls["n"] = 0
+    a = torch.zeros(256, dtype=torch.int8)
+    whc.cached_weight_hash(a, k1, make_hash(1))
+    del a
+    gc.collect()
+    b = torch.zeros(256, dtype=torch.int8)  # may reuse the freed address
+    out = whc.cached_weight_hash(b, k1, make_hash(2))
+    assert out.tolist() == [2] * 32, "a different (live) tensor must recompute, even if addr reused"
+
+    # GC finalizer: a cached weight that is freed must auto-evict its entry.
+    whc.clear_cache()
+    c = torch.zeros(256, dtype=torch.int8)
+    whc.cached_weight_hash(c, k1, make_hash(1))
+    assert whc.cache_size() == 1
+    del c
+    gc.collect()
+    assert whc.cache_size() == 0, "freeing a cached weight must evict its entry"
+    whc.clear_cache()

--- a/miner/vllm-miner/tests/test_reference_vs_kernels.py
+++ b/miner/vllm-miner/tests/test_reference_vs_kernels.py
@@ -77,8 +77,8 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Create random int8 tensor for MatrixMerkleTree
         matrix_int8 = torch.randint(-128, 127, (m, n), dtype=torch.int8)
 
-        # Convert to uint8 for tensor_hash (CUDA implementation expects uint8)
-        matrix_uint8 = matrix_int8.to(torch.uint8).cuda()
+        matrix_cuda = matrix_int8.cuda()
+        matrix_uint8 = matrix_cuda.to(torch.uint8)
 
         # Create key tensor for CUDA implementation
         key_tensor = _to_cuda_u8(test_noise_seed_A)
@@ -89,16 +89,19 @@ class TestMatrixMerkleTreeVsTensorHash:
 
         # Compute hash using tensor_hash (CUDA implementation)
         cuda_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
+        cast_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
         tensor_hash_scratchpad = torch.empty(
-            pearl_gemm.get_required_scratchpad_bytes(matrix_uint8.numel()),
+            pearl_gemm.get_required_scratchpad_bytes(matrix_cuda.numel()),
             device="cuda",
             dtype=torch.uint8,
         )
-        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_cuda, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cast_result, tensor_hash_scratchpad)
         torch.cuda.synchronize()
 
         # Convert CUDA result back to bytes for comparison
         cuda_root = cuda_result.cpu().numpy().tobytes()
+        cast_root = cast_result.cpu().numpy().tobytes()
 
         blake3_result = blake3(matrix_int8.cpu().numpy().tobytes(), key=test_noise_seed_A).digest()
 
@@ -109,6 +112,9 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Compare results
         assert python_root == cuda_root, (
             f"Hash mismatch for shape {m, n}: MatrixMerkleTree root doesn't match tensor_hash result"
+        )
+        assert cuda_root == cast_root, (
+            f"Hash mismatch for shape {m, n}: direct int8 tensor_hash differs from uint8 cast path"
         )
 
     def test_commitment_hash_reference_vs_cuda(self, test_noise_seed_A):


### PR DESCRIPTION
Stack note: this PR is now stacked on #193 (direct int8 tensor_hash). The branch was rebased to preserve that order; after #193 lands, this diff should collapse to the static-weight hash cache layer.

## Modal H100 stacked benchmark

Environment: `NVIDIA H100 80GB HBM3`, CUDA `sm_90`, Torch `2.11.0+cu130`, repo Dockerfile image.

This isolates #187 on top of #193. BpEB caching is disabled (`cache_noised_weight=False`) so #194 does not affect the measurement. It compares full `pearl_gemm_noisy` with the weight-hash cache cleared before every call (simulating #193 without #187) against steady-state cache hits with the same weight and mining job.

| shape | no weight-hash cache | weight-hash cache hit | result |
|---|---:|---:|---:|
| gate_up 4096x28672x4096 | 1.797 ms | 1.700 ms | **+5.7%** |
| gate_up threshold 1024x28672x4096 | 1.115 ms | 1.013 ms | **+10.1%** |
| down 4096x4096x14336 | 1.271 ms | 1.180 ms | **+7.7%** |
| square 4096x4096x4096 | 0.781 ms | 0.757 ms | **+3.2%** |

## Summary
In mining mode the noisy GEMM seeds its proof-of-work commitment by keyed-merkle-hashing
BOTH operands (`tensor_hash`). Operand `B` is the layer **weight** — a persistent `nn.Parameter`
set once at load — and the hash key only changes when the mining job changes (gateway polled
~1/s), while a forward pass runs in milliseconds. So `tensor_hash(weight)` recomputes the
**identical** 32-byte root on every forward pass: provably redundant work.

This caches that root (shared helper `weight_hash_cache.cached_weight_hash`, used by both the
dense `pearl_gemm_noisy` and MoE `prepare_moe_noising` paths). The activation hash (`A`) is unchanged.

## Where the gain is: prefill-heavy mining
The noisy GEMM — and therefore the weight hash — only runs on GEMMs with **m ≥ 1024 tokens**
(the `should_use_noisy_gemm` gate). That is, **mining happens on heavy prefill, not on small
requests**: chunked-prefill steps cross 1024 tokens and hash; decode / small-request steps
(m = a few tokens) take the vanilla path and never hash. The cache's benefit scales with the
share of compute spent in noisy-prefill GEMMs.

This matters because a Pearl miner serves **many concurrent users with distinct contexts**, so
cross-request prefix-cache reuse is low and those large prefills are genuinely (re)computed — i.e.
they mine. The numbers below use distinct prompts (`--dataset-name random`), which models that
multi-user regime. (A single user replaying one growing conversation, where prefix caching reuses
the history, is the opposite case — prefills collapse, mining is rare, and the cache shows ~0%;
that is self-serve, not how Pearl serves.)

Measured on H100 / Llama-3.1-8B, mining ON, **interleaved** cache-vs-master A/B (alternated
run-by-run to remove run-order/thermal drift), call-count instrumentation for the noisy share:

| workload (distinct prompts) | noisy-GEMM share | cache vs master |
|---|---|---|
| prefill-saturated (in2048/out1, chunk 2048) | ~52% of GEMM calls | **+7.2% req/s** (15.05 vs 14.05) |
| heavy-prefill serving (in2048/out256) | ~14% of GEMM calls | **+3.1% req/s** (30.1 vs 29.2; +2.6% with prefix cache off) |
| multi-turn chat, full-context prefill (32×6 turns, no prefix reuse) | ~6% | **+2.5%** (wall 25.6 vs 26.3s) |
| decode-diluted (in64/out512) | ~1.6% | ~0% (mining barely runs) |

## Why it's correct (PoW-equivalent)
A cache **hit is always bit-identical** to recomputing, and every uncertainty degrades to a
redundant recompute — never a wrong hash:
- the mining-job **key bytes** are part of the cache key → a new job misses and recomputes;
- a **weakref** to the exact tensor is checked on a hit → a freed/reused `data_ptr` (ABA) misses;
- **device** type+index are in the key → CUDA `data_ptr` ints that collide across GPUs can't false-hit.

Valid under the immutable-weight invariant (Pearl weights are persistent params, never mutated
in place); `clear_cache()` is provided for any weight-reload path. All mining ops run on the
default CUDA stream, so the cached tensor's producer is ordered before its consumers — the same
same-stream assumption the un-cached code already relied on. Entries self-evict via a `weakref`
finalizer when the weight is GC'd.

## Tests
CPU unit test: a miss computes; a repeat hit returns the same object and does **not** recompute; a
key change recomputes; ABA (free a tensor, alloc a new one that may reuse the address) recomputes
rather than false-hitting; a GC'd weight auto-evicts its entry. Existing noisy-GEMM correctness
suite passes unchanged.

