### PR TITLE
feat(miner): switch quantization scheme of moe to f8 down proj

### DIFF
--- a/miner/miner-base/src/miner_base/async_loop_manager.py
+++ b/miner/miner-base/src/miner_base/async_loop_manager.py
@@ -270,7 +270,7 @@ class AsyncLoopManager:
         try:
             check_cert_version_eligible(mining_job.cert_version, plain_proof)
         except ValueError as e:
-            _LOGGER.warning("Skipping block submission: %s", e)
+            _LOGGER.warning(f"Skipping block submission: {e}")
             return False
 
         if miner_settings.debug:

--- a/miner/pearl-gateway/src/pearl_gateway/submission_service.py
+++ b/miner/pearl-gateway/src/pearl_gateway/submission_service.py
@@ -47,7 +47,7 @@ class SubmissionService:
                 try:
                     check_cert_version_eligible(template.required_cert_version, plain_proof)
                 except ValueError as e:
-                    logger.warning("Rejecting proof: %s", e)
+                    logger.warning(f"Rejecting proof: {e}")
                     return {"status": f"error: {e}"}
 
                 block = ProofGenerator.generate_block(plain_proof, template, self.debug_mode)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -32,7 +32,7 @@ from .moe_gemm_operators import (
     permute_a_side_to_expert_order,
     prepare_moe_noising,
 )
-from .pearl_moe_method import W2_BLOCK_SHAPE, W13_SMOOTH_SHARED_EXPERT_INDEX
+from .pearl_moe_method import W2_BLOCK_SHAPE
 from .quantization_operators import quant_7bit, quant_fp8_block
 
 _GEMM2_TOP_K = 1
@@ -151,7 +151,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
     def _quant_a_7bit(self, hidden_states: torch.Tensor, K: int):
         """Quantize activations with the shared gate/up smooth scale when present."""
         w13_smooth = self._get_smooth_scale("w13_smooth_quant_scale")
-        smooth = w13_smooth[W13_SMOOTH_SHARED_EXPERT_INDEX, :K] if w13_smooth is not None else None
+        smooth = w13_smooth[:K] if w13_smooth is not None else None
         return quant_7bit(hidden_states, smooth_scale=smooth)
 
     def apply(

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -32,8 +32,8 @@ from .moe_gemm_operators import (
     permute_a_side_to_expert_order,
     prepare_moe_noising,
 )
-from .pearl_moe_method import W13_SMOOTH_SHARED_EXPERT_INDEX
-from .quantization_operators import quant_7bit, quant_7bit_smooth
+from .pearl_moe_method import W2_BLOCK_SHAPE, W13_SMOOTH_SHARED_EXPERT_INDEX
+from .quantization_operators import quant_7bit, quant_fp8_block
 
 _GEMM2_TOP_K = 1
 # MoE noise kernels require at least Hopper (matches dense PearlKernel min capability).
@@ -151,10 +151,8 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
     def _quant_a_7bit(self, hidden_states: torch.Tensor, K: int):
         """Quantize activations with the shared gate/up smooth scale when present."""
         w13_smooth = self._get_smooth_scale("w13_smooth_quant_scale")
-        if w13_smooth is not None:
-            smooth = w13_smooth[W13_SMOOTH_SHARED_EXPERT_INDEX, :K]
-            return quant_7bit_smooth(hidden_states, smooth_scale=smooth)
-        return quant_7bit(hidden_states)
+        smooth = w13_smooth[W13_SMOOTH_SHARED_EXPERT_INDEX, :K] if w13_smooth is not None else None
+        return quant_7bit(hidden_states, smooth_scale=smooth)
 
     def apply(
         self,
@@ -238,28 +236,22 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
 
         self.activation(activation, intermediate_cache2, intermediate_cache1.view(-1, N))
 
-        gemm2_input = self._apply_w2_smooth_quant(intermediate_cache2, topk_ids)
-        qintermediate_cache2, a2q_scale, _ = quant_7bit(gemm2_input)
-
-        gemm2_compute_type = _torch_dtype_to_triton_compute_type(hidden_states.dtype)
-        invoke_fused_moe_triton_kernel(
-            qintermediate_cache2,
-            w2,
-            intermediate_cache3,
-            a2q_scale,
-            self.w2_scale,
-            topk_weights,
-            sorted_token_ids,
-            expert_ids,
-            num_tokens_post_padded,
-            not apply_router_weight_on_input,
-            _GEMM2_TOP_K,
-            triton_config,
-            compute_type=gemm2_compute_type,
-            **self._int8_w8a8_triton_kwargs(),
+        # GEMM2 (down projection): not mined, kept in the original fp8 block
+        self._gemm2_triton(
+            intermediate_cache2=intermediate_cache2,
+            w2=w2,
+            intermediate_cache3=intermediate_cache3,
+            output=output,
+            topk_weights=topk_weights,
+            sorted_token_ids=sorted_token_ids,
+            expert_ids=expert_ids,
+            num_tokens_post_padded=num_tokens_post_padded,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+            align_block_size_m=triton_config["BLOCK_SIZE_M"],
+            num_tokens=num_tokens,
+            compute_type=_torch_dtype_to_triton_compute_type(hidden_states.dtype),
+            w1=w1,
         )
-
-        ops.moe_sum(intermediate_cache3, output)
 
     def _apply_per_expert_gemm1(
         self,
@@ -376,14 +368,54 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         )
         get_async_manager().schedule_status_check(cuda_event, callback)
 
-    def _apply_w2_smooth_quant(
+    def _gemm2_triton(
         self,
-        intermediate: torch.Tensor,
-        topk_ids: torch.Tensor,
-    ) -> torch.Tensor:
-        """Apply per-expert w2 smooth quant scale to the GEMM2 input."""
-        w2_smooth = self._get_smooth_scale("w2_smooth_quant_scale")
-        if w2_smooth is None:
-            return intermediate
-        smooth_per_token = w2_smooth[topk_ids.reshape(-1)]
-        return intermediate * smooth_per_token
+        *,
+        intermediate_cache2: torch.Tensor,
+        w2: torch.Tensor,
+        intermediate_cache3: torch.Tensor,
+        output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        num_tokens_post_padded: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        align_block_size_m: int,
+        num_tokens: int,
+        compute_type: tl.dtype,
+        w1: torch.Tensor,
+    ) -> None:
+        """Down projection via the Triton fp8 block grouped GEMM."""
+        quantized_intermediate, activation_scale = quant_fp8_block(intermediate_cache2)
+
+        gemm2_config = dict(
+            try_get_optimal_moe_config(
+                w1.shape, w2.shape, _GEMM2_TOP_K, "fp8_w8a8", num_tokens, W2_BLOCK_SHAPE
+            )
+        )
+        # Reuse the token alignment that produced sorted_token_ids/expert_ids.
+        gemm2_config["BLOCK_SIZE_M"] = align_block_size_m
+
+        invoke_fused_moe_triton_kernel(
+            quantized_intermediate,
+            w2,
+            intermediate_cache3,
+            activation_scale,
+            self.w2_scale,
+            topk_weights,
+            sorted_token_ids,
+            expert_ids,
+            num_tokens_post_padded,
+            not apply_router_weight_on_input,
+            _GEMM2_TOP_K,
+            gemm2_config,
+            compute_type=compute_type,
+            use_fp8_w8a8=True,
+            use_int8_w8a8=False,
+            use_int8_w8a16=False,
+            use_int4_w4a16=False,
+            per_channel_quant=False,
+            block_shape=W2_BLOCK_SHAPE,
+        )
+
+        ops.moe_sum(intermediate_cache3, output)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -32,10 +32,10 @@ from .moe_gemm_operators import (
     permute_a_side_to_expert_order,
     prepare_moe_noising,
 )
-from .pearl_moe_method import W2_BLOCK_SHAPE
 from .quantization_operators import quant_7bit, quant_fp8_block
 
 _GEMM2_TOP_K = 1
+_GEMM2_QUANT_SCHEME = "fp8_w8a8"
 # MoE noise kernels require at least Hopper (matches dense PearlKernel min capability).
 _MIN_COMPUTE_CAPABILITY_MAJOR = 9
 # vLLM sentinel meaning "infer expert count from the weight tensor".
@@ -71,10 +71,14 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         self,
         moe_config: FusedMoEConfig,
         quant_config: FusedMoEQuantConfig,
+        w2_block_shape: list[int],
+        act_group_size: int,
         layer: torch.nn.Module | None = None,
     ):
         super().__init__(moe_config, quant_config)
         self._layer = layer
+        self._w2_block_shape = w2_block_shape
+        self._act_group_size = act_group_size
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -386,11 +390,18 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         w1: torch.Tensor,
     ) -> None:
         """Down projection via the Triton fp8 block grouped GEMM."""
-        quantized_intermediate, activation_scale = quant_fp8_block(intermediate_cache2)
+        quantized_intermediate, activation_scale = quant_fp8_block(
+            intermediate_cache2, group_size=self._act_group_size
+        )
 
         gemm2_config = dict(
             try_get_optimal_moe_config(
-                w1.shape, w2.shape, _GEMM2_TOP_K, "fp8_w8a8", num_tokens, W2_BLOCK_SHAPE
+                w1.shape,
+                w2.shape,
+                _GEMM2_TOP_K,
+                _GEMM2_QUANT_SCHEME,
+                num_tokens,
+                self._w2_block_shape,
             )
         )
         # Reuse the token alignment that produced sorted_token_ids/expert_ids.
@@ -415,7 +426,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
             use_int8_w8a16=False,
             use_int4_w4a16=False,
             per_channel_quant=False,
-            block_shape=W2_BLOCK_SHAPE,
+            block_shape=self._w2_block_shape,
         )
 
         ops.moe_sum(intermediate_cache3, output)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_method.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_method.py
@@ -33,10 +33,8 @@ QUANT_METHOD_CHANNEL = FusedMoeWeightScaleSupported.CHANNEL.value
 QUANT_METHOD_BLOCK = FusedMoeWeightScaleSupported.BLOCK.value
 W13_WEIGHT_SHARDS_WITH_ACT_AND_MUL = 2
 W13_WEIGHT_SHARDS_WITHOUT_ACT_AND_MUL = 1
-# Fused gate+up smooth scale: checkpoint provides one half; we replicate to the other.
-W13_SMOOTH_PROJ_HALVES = 2
-# Expert row holding the shared gate/up smooth scale in checkpoints.
-W13_SMOOTH_SHARED_EXPERT_INDEX = 0
+# Checkpoint shard id carrying the shared gate/up smooth scale (gate == "w1").
+W13_SHARED_SHARD_ID = "w1"
 # Per-layer pinned PoW headers held while a forward's callback is pending.
 MOE_POW_HEADER_POOL_DEPTH = 16
 
@@ -48,6 +46,29 @@ W2_BLOCK_SHAPE = [W2_BLOCK_N, W2_BLOCK_K]
 
 MOE_BACKEND_AUTO = "auto"
 MOE_BACKEND_TRITON = "triton"
+
+
+def _shared_w13_loader(
+    param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    weight_name: str | None = None,
+    shard_id: str | None = None,
+    expert_id: int | None = None,
+    return_success: bool = False,
+    **kwargs,
+) -> bool | None:
+    """Weight loader for the shared per-layer gate/up smooth scale.
+
+    The checkpoint stores a single smooth-quant vector on ``experts.0.gate_proj``
+    (the fused-expert mapping routes it here with ``shard_id == "w1"``). It is
+    shared across all experts and across gate/up and lives on the (un-sharded)
+    hidden input dim, so we copy it verbatim. vLLM's default fused-expert loader
+    cannot handle it (it would TP-shard a ``*_scale`` param along the output dim
+    and requires a ``quant_method``), so we bypass it with this loader.
+    """
+    if shard_id in (None, W13_SHARED_SHARD_ID):
+        param.data.copy_(loaded_weight.reshape(param.shape).to(param.dtype))
+    return True if return_success else None
 
 
 class PearlMoEMethod(FusedMoEMethodBase):
@@ -66,7 +87,7 @@ class PearlMoEMethod(FusedMoEMethodBase):
         intermediate_size_per_partition: int,
         params_dtype: torch.dtype,
         **extra_weight_attrs,
-    ):
+    ) -> None:
         w13_num_shards = (
             W13_WEIGHT_SHARDS_WITH_ACT_AND_MUL
             if self.moe.is_act_and_mul
@@ -125,25 +146,16 @@ class PearlMoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight_scale, block_attrs)
 
         w13_smooth_quant_scale = torch.nn.Parameter(
-            torch.ones(num_experts, 2 * hidden_size, dtype=SMOOTH_SCALE_DTYPE),
+            torch.ones(hidden_size, dtype=SMOOTH_SCALE_DTYPE),
             requires_grad=False,
         )
         layer.register_parameter("w13_smooth_quant_scale", w13_smooth_quant_scale)
-        set_weight_attrs(w13_smooth_quant_scale, dict(extra_weight_attrs))
+        set_weight_attrs(w13_smooth_quant_scale, {"weight_loader": _shared_w13_loader})
 
         layer.w13_input_scale = None
         layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        w13_smooth = getattr(layer, "w13_smooth_quant_scale", None)
-        if w13_smooth is not None:
-            half = w13_smooth.shape[1] // W13_SMOOTH_PROJ_HALVES
-            w13_smooth.data[:, half:] = w13_smooth.data[:, :half]
-            # Checkpoint stores one shared gate/up smooth scale on this row.
-            src = W13_SMOOTH_SHARED_EXPERT_INDEX
-            if w13_smooth.shape[0] > src + 1:
-                w13_smooth.data[src + 1 :] = w13_smooth.data[src : src + 1]
-
         self._warn_if_backend_overridden()
 
         num_experts = layer.w13_weight.shape[0]

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_method.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_method.py
@@ -3,9 +3,11 @@ from typing import TYPE_CHECKING
 import torch
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from miner_utils import get_logger
+from vllm import envs
 from vllm.model_executor.layers.fused_moe import (
     FusedMoEActivationFormat,
     FusedMoEMethodBase,
+    FusedMoeWeightScaleSupported,
 )
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
@@ -27,7 +29,8 @@ WEIGHT_DTYPE = torch.int8
 SCALE_DTYPE = torch.float32
 SMOOTH_SCALE_DTYPE = torch.bfloat16
 SCALE_LAST_DIM = 1
-QUANT_METHOD_CHANNEL = "channel"
+QUANT_METHOD_CHANNEL = FusedMoeWeightScaleSupported.CHANNEL.value
+QUANT_METHOD_BLOCK = FusedMoeWeightScaleSupported.BLOCK.value
 W13_WEIGHT_SHARDS_WITH_ACT_AND_MUL = 2
 W13_WEIGHT_SHARDS_WITHOUT_ACT_AND_MUL = 1
 # Fused gate+up smooth scale: checkpoint provides one half; we replicate to the other.
@@ -36,6 +39,15 @@ W13_SMOOTH_PROJ_HALVES = 2
 W13_SMOOTH_SHARED_EXPERT_INDEX = 0
 # Per-layer pinned PoW headers held while a forward's callback is pending.
 MOE_POW_HEADER_POOL_DEPTH = 16
+
+# Down projection (GEMM2): not mined, kept in the original fp8 block quantization.
+W2_WEIGHT_DTYPE = torch.float8_e4m3fn
+W2_BLOCK_N = 128
+W2_BLOCK_K = 128
+W2_BLOCK_SHAPE = [W2_BLOCK_N, W2_BLOCK_K]
+
+MOE_BACKEND_AUTO = "auto"
+MOE_BACKEND_TRITON = "triton"
 
 
 class PearlMoEMethod(FusedMoEMethodBase):
@@ -73,9 +85,17 @@ class PearlMoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
+        # Down projection: fp8 weights block-wise scales.
+        layer.weight_block_size = W2_BLOCK_SHAPE
+        n_tiles = (hidden_size + W2_BLOCK_N - 1) // W2_BLOCK_N
+        k_tiles = (intermediate_size_per_partition + W2_BLOCK_K - 1) // W2_BLOCK_K
+
         w2_weight = torch.nn.Parameter(
             torch.empty(
-                num_experts, hidden_size, intermediate_size_per_partition, dtype=WEIGHT_DTYPE
+                num_experts,
+                hidden_size,
+                intermediate_size_per_partition,
+                dtype=W2_WEIGHT_DTYPE,
             ),
             requires_grad=False,
         )
@@ -94,29 +114,22 @@ class PearlMoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w13_weight_scale", w13_weight_scale)
 
         w2_weight_scale = torch.nn.Parameter(
-            torch.ones(num_experts, hidden_size, SCALE_LAST_DIM, dtype=SCALE_DTYPE),
+            torch.ones(num_experts, n_tiles, k_tiles, dtype=SCALE_DTYPE),
             requires_grad=False,
         )
         layer.register_parameter("w2_weight_scale", w2_weight_scale)
 
-        extra_weight_attrs.update({"quant_method": QUANT_METHOD_CHANNEL})
-        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
-        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
-
-        smooth_attrs = dict(extra_weight_attrs)
-        w2_smooth_quant_scale = torch.nn.Parameter(
-            torch.ones(num_experts, intermediate_size_per_partition, dtype=SMOOTH_SCALE_DTYPE),
-            requires_grad=False,
-        )
-        layer.register_parameter("w2_smooth_quant_scale", w2_smooth_quant_scale)
-        set_weight_attrs(w2_smooth_quant_scale, smooth_attrs)
+        channel_attrs = dict(extra_weight_attrs, quant_method=QUANT_METHOD_CHANNEL)
+        set_weight_attrs(w13_weight_scale, channel_attrs)
+        block_attrs = dict(extra_weight_attrs, quant_method=QUANT_METHOD_BLOCK)
+        set_weight_attrs(w2_weight_scale, block_attrs)
 
         w13_smooth_quant_scale = torch.nn.Parameter(
             torch.ones(num_experts, 2 * hidden_size, dtype=SMOOTH_SCALE_DTYPE),
             requires_grad=False,
         )
         layer.register_parameter("w13_smooth_quant_scale", w13_smooth_quant_scale)
-        set_weight_attrs(w13_smooth_quant_scale, smooth_attrs)
+        set_weight_attrs(w13_smooth_quant_scale, dict(extra_weight_attrs))
 
         layer.w13_input_scale = None
         layer.w2_input_scale = None
@@ -131,9 +144,36 @@ class PearlMoEMethod(FusedMoEMethodBase):
             if w13_smooth.shape[0] > src + 1:
                 w13_smooth.data[src + 1 :] = w13_smooth.data[src : src + 1]
 
+        self._warn_if_backend_overridden()
+
         num_experts = layer.w13_weight.shape[0]
         ensure_pinned_pool_at_least(num_experts * MOE_POW_HEADER_POOL_DEPTH)
         self._setup_kernel(layer)
+
+    def _warn_if_backend_overridden(self) -> None:
+        """Warn when vLLM requests a MoE backend other than Triton."""
+
+        requested = getattr(self.moe, "moe_backend", MOE_BACKEND_AUTO)
+        if requested and requested not in (MOE_BACKEND_AUTO, MOE_BACKEND_TRITON):
+            self._warn_backend_ignored(requested)
+            return
+
+        if (envs.is_set("VLLM_USE_DEEP_GEMM") and envs.VLLM_USE_DEEP_GEMM) or (
+            envs.is_set("VLLM_MOE_USE_DEEP_GEMM") and envs.VLLM_MOE_USE_DEEP_GEMM
+        ):
+            self._warn_backend_ignored("deep_gemm")
+        elif envs.is_set("VLLM_USE_FLASHINFER_MOE_FP8") and envs.VLLM_USE_FLASHINFER_MOE_FP8:
+            self._warn_backend_ignored("flashinfer")
+
+    @staticmethod
+    def _warn_backend_ignored(
+        requested: str,
+    ) -> None:
+        _LOGGER.warning(
+            "Requested MoE backend '%s' is ignored for PearlMoE; the down "
+            "projection always uses the Triton fp8-block GEMM.",
+            requested,
+        )
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig | None:
         return FusedMoEQuantConfig.make(

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_method.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_method.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 import torch
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from compressed_tensors.quantization import QuantizationArgs
 from miner_utils import get_logger
 from vllm import envs
 from vllm.model_executor.layers.fused_moe import (
@@ -40,9 +41,6 @@ MOE_POW_HEADER_POOL_DEPTH = 16
 
 # Down projection (GEMM2): not mined, kept in the original fp8 block quantization.
 W2_WEIGHT_DTYPE = torch.float8_e4m3fn
-W2_BLOCK_N = 128
-W2_BLOCK_K = 128
-W2_BLOCK_SHAPE = [W2_BLOCK_N, W2_BLOCK_K]
 
 MOE_BACKEND_AUTO = "auto"
 MOE_BACKEND_TRITON = "triton"
@@ -72,12 +70,31 @@ def _shared_w13_loader(
 
 
 class PearlMoEMethod(FusedMoEMethodBase):
-    def __init__(self, moe_config: FusedMoEConfig):
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        down_weight_quant: QuantizationArgs,
+        down_input_quant: QuantizationArgs,
+    ):
         super().__init__(moe_config)
+        block_shape = down_weight_quant.block_structure
+        if not block_shape:
+            raise ValueError(
+                "PearlMoE down projection requires a fp8 weight block_structure "
+                f"in the quantization config; got {block_shape!r}"
+            )
+        self.block_n, self.block_k = int(block_shape[0]), int(block_shape[1])
 
-    @classmethod
-    def from_config(cls, moe_config: FusedMoEConfig) -> "PearlMoEMethod":
-        return cls(moe_config)
+        group_size = down_input_quant.group_size
+        if group_size is None:
+            raise ValueError(
+                "PearlMoE down projection requires an activation group_size in "
+                "the quantization config; got None"
+            )
+        self.act_group_size = int(group_size)
+
+    def _w2_block_shape(self) -> list[int]:
+        return [self.block_n, self.block_k]
 
     def create_weights(
         self,
@@ -106,10 +123,10 @@ class PearlMoEMethod(FusedMoEMethodBase):
         layer.register_parameter("w13_weight", w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
-        # Down projection: fp8 weights block-wise scales.
-        layer.weight_block_size = W2_BLOCK_SHAPE
-        n_tiles = (hidden_size + W2_BLOCK_N - 1) // W2_BLOCK_N
-        k_tiles = (intermediate_size_per_partition + W2_BLOCK_K - 1) // W2_BLOCK_K
+        # Down projection: fp8 weights with block-wise scales.
+        layer.weight_block_size = self._w2_block_shape()
+        n_tiles = (hidden_size + self.block_n - 1) // self.block_n
+        k_tiles = (intermediate_size_per_partition + self.block_k - 1) // self.block_k
 
         w2_weight = torch.nn.Parameter(
             torch.empty(
@@ -207,6 +224,8 @@ class PearlMoEMethod(FusedMoEMethodBase):
                 moe_config=self.moe,
                 quant_config=self.moe_quant_config,
                 layer=layer,
+                w2_block_shape=self._w2_block_shape(),
+                act_group_size=self.act_group_size,
             )
             self.moe_kernel = mk.FusedMoEKernel(
                 prepare_finalize=prepare_finalize,
@@ -256,4 +275,6 @@ class PearlMoEMethod(FusedMoEMethodBase):
             moe_config=self.moe,
             quant_config=self.moe_quant_config,
             layer=layer,
+            w2_block_shape=self._w2_block_shape(),
+            act_group_size=self.act_group_size,
         )

--- a/miner/vllm-miner/src/vllm_miner/quantization_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/quantization_operators.py
@@ -1,5 +1,6 @@
 import torch
 from pearl_gemm import quantize
+from vllm.model_executor.layers.fused_moe.utils import moe_kernel_quantize_input
 
 from .mining_state import get_async_manager
 
@@ -7,7 +8,11 @@ MAX_VAL_7BIT = 63
 MAX_VAL_8BIT = 127
 
 
-def quantize_kernel(x: torch.Tensor, max_val: int = 63, smooth_scale: torch.Tensor | None = None):
+def quantize_kernel(
+    x: torch.Tensor,
+    max_val: int = MAX_VAL_7BIT,
+    smooth_scale: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, None]:
     """
     Symmetric per-token quantization with optional smooth scaling (CUDA kernel version)
 
@@ -30,26 +35,31 @@ def quantize_kernel(x: torch.Tensor, max_val: int = 63, smooth_scale: torch.Tens
 
 
 # Convenience wrappers
-def quant_7bit(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, None]:
-    """7-bit symmetric quantization (range: [-63, 63])."""
-    return quantize_kernel(x, max_val=MAX_VAL_7BIT, smooth_scale=None)
-
-
-def quant_8bit(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, None]:
-    """8-bit symmetric quantization (range: [-127, 127])."""
-
-    return quantize_kernel(x, max_val=MAX_VAL_8BIT, smooth_scale=None)
-
-
-def quant_7bit_smooth(
+def quant_7bit(
     x: torch.Tensor, smooth_scale: torch.Tensor | None = None
 ) -> tuple[torch.Tensor, torch.Tensor, None]:
-    """7-bit symmetric quantization (range: [-63, 63]) with smooth scale."""
+    """7-bit symmetric quantization (range: [-63, 63]), optional smooth scale."""
     return quantize_kernel(x, max_val=MAX_VAL_7BIT, smooth_scale=smooth_scale)
 
 
-def quant_8bit_smooth(
+def quant_8bit(
     x: torch.Tensor, smooth_scale: torch.Tensor | None = None
 ) -> tuple[torch.Tensor, torch.Tensor, None]:
-    """8-bit symmetric quantization (range: [-127, 127]) with smooth scale."""
+    """8-bit symmetric quantization (range: [-127, 127]), optional smooth scale."""
     return quantize_kernel(x, max_val=MAX_VAL_8BIT, smooth_scale=smooth_scale)
+
+
+def quant_fp8_block(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Dynamic per-token-group fp8 quantization for the block-scaled GEMM2."""
+
+    FP8_DTYPE = torch.float8_e4m3fn
+    FP8_GROUP_SIZE = 128
+    FP8_BLOCK = [FP8_GROUP_SIZE, FP8_GROUP_SIZE]
+
+    return moe_kernel_quantize_input(
+        A=x,
+        A_scale=None,
+        quant_dtype=FP8_DTYPE,
+        per_act_token_quant=False,
+        block_shape=FP8_BLOCK,
+    )

--- a/miner/vllm-miner/src/vllm_miner/quantization_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/quantization_operators.py
@@ -49,17 +49,12 @@ def quant_8bit(
     return quantize_kernel(x, max_val=MAX_VAL_8BIT, smooth_scale=smooth_scale)
 
 
-def quant_fp8_block(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+def quant_fp8_block(x: torch.Tensor, group_size: int) -> tuple[torch.Tensor, torch.Tensor]:
     """Dynamic per-token-group fp8 quantization for the block-scaled GEMM2."""
-
-    FP8_DTYPE = torch.float8_e4m3fn
-    FP8_GROUP_SIZE = 128
-    FP8_BLOCK = [FP8_GROUP_SIZE, FP8_GROUP_SIZE]
-
     return moe_kernel_quantize_input(
         A=x,
         A_scale=None,
-        quant_dtype=FP8_DTYPE,
+        quant_dtype=torch.float8_e4m3fn,
         per_act_token_quant=False,
-        block_shape=FP8_BLOCK,
+        block_shape=[group_size, group_size],
     )

--- a/miner/vllm-miner/src/vllm_miner/vllm_config.py
+++ b/miner/vllm-miner/src/vllm_miner/vllm_config.py
@@ -92,11 +92,21 @@ class PearlConfig(CompressedTensorsConfig):
 
         return is_8_bits and is_token and weight_quant.symmetric and is_dynamic
 
-    def _moe_quant_args(self) -> tuple[QuantizationArgs | None, QuantizationArgs | None]:
-        for key in ("FusedMoE", "Linear"):
-            scheme_dict = self.target_scheme_map.get(key)
-            if scheme_dict:
-                return scheme_dict.get("weights"), scheme_dict.get("input_activations")
+    # Expert-0 projection name used to resolve the gate/up scheme of a FusedMoE
+    # layer (mirrors vLLM's CompressedTensorsMoEMethod.get_moe_method).
+    _GATE_UP_PROBE_SUFFIX = ".0.gate_proj"
+
+    def _moe_gate_up_quant_args(
+        self, layer: torch.nn.Module, prefix: str
+    ) -> tuple[QuantizationArgs | None, QuantizationArgs | None]:
+        """Resolve the gate/up (GEMM1) quant args for a FusedMoE layer.
+
+        Pearl MoE checkpoints target each projection by regex, so we probe the
+        expert-0 gate projection to read the GEMM1 scheme.
+        """
+        scheme_dict = self.get_scheme_dict(layer, prefix + self._GATE_UP_PROBE_SUFFIX)
+        if scheme_dict:
+            return scheme_dict.get("weights"), scheme_dict.get("input_activations")
         return None, None
 
     @override
@@ -111,7 +121,7 @@ class PearlConfig(CompressedTensorsConfig):
         from .pearl_moe_method import PearlMoEMethod
 
         if isinstance(layer, FusedMoE):
-            weight_quant, input_quant = self._moe_quant_args()
+            weight_quant, input_quant = self._moe_gate_up_quant_args(layer, prefix)
             if self._is_mining_layer(weight_quant, input_quant):
                 _LOGGER.debug(f"Mining MoE layer (7-bit) detected for {prefix}")
                 return PearlMoEMethod(layer.moe_config)

--- a/miner/vllm-miner/src/vllm_miner/vllm_config.py
+++ b/miner/vllm-miner/src/vllm_miner/vllm_config.py
@@ -11,7 +11,11 @@ Both kernels handle smooth_quant_scale internally.
 from typing import Any, override
 
 import torch
-from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+from compressed_tensors.quantization import (
+    QuantizationArgs,
+    QuantizationStrategy,
+    QuantizationType,
+)
 from miner_utils import get_logger
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import (
@@ -61,7 +65,10 @@ class PearlConfig(CompressedTensorsConfig):
         )
 
     @staticmethod
-    def _is_mining_layer(weight_quant: QuantizationArgs, input_quant: QuantizationArgs) -> bool:
+    def _is_mining_layer(
+        weight_quant: QuantizationArgs | None,
+        input_quant: QuantizationArgs | None,
+    ) -> bool:
         """Check if this is a 7-bit mining layer configuration."""
         if weight_quant is None or input_quant is None:
             return False
@@ -77,7 +84,10 @@ class PearlConfig(CompressedTensorsConfig):
         return is_7_bits and is_token and weight_quant.symmetric and is_dynamic
 
     @staticmethod
-    def _is_non_mining_layer(weight_quant: QuantizationArgs, input_quant: QuantizationArgs) -> bool:
+    def _is_non_mining_layer(
+        weight_quant: QuantizationArgs | None,
+        input_quant: QuantizationArgs | None,
+    ) -> bool:
         """Check if this is an 8-bit non-mining layer configuration."""
         if weight_quant is None or input_quant is None:
             return False
@@ -92,19 +102,39 @@ class PearlConfig(CompressedTensorsConfig):
 
         return is_8_bits and is_token and weight_quant.symmetric and is_dynamic
 
-    # Expert-0 projection name used to resolve the gate/up scheme of a FusedMoE
-    # layer (mirrors vLLM's CompressedTensorsMoEMethod.get_moe_method).
+    @staticmethod
+    def _is_fp8_block_layer(
+        weight_quant: QuantizationArgs | None,
+        input_quant: QuantizationArgs | None,
+    ) -> bool:
+        """Check for fp8 block-wise weights + dynamic group fp8 activations (down proj)."""
+        if weight_quant is None or input_quant is None:
+            return False
+
+        def _is_float(quant: QuantizationArgs) -> bool:
+            return quant.type in (QuantizationType.FLOAT.value, QuantizationType.FLOAT)
+
+        is_fp8 = (
+            weight_quant.num_bits == input_quant.num_bits == 8
+            and _is_float(weight_quant)
+            and _is_float(input_quant)
+        )
+        is_block = weight_quant.strategy == QuantizationStrategy.BLOCK.value and bool(
+            weight_quant.block_structure
+        )
+        act_group = input_quant.strategy == QuantizationStrategy.GROUP.value and input_quant.dynamic
+        return is_fp8 and is_block and act_group
+
+    # Expert-0 projection suffixes used to resolve a FusedMoE layer's per-projection
+    # schemes (mirrors vLLM's CompressedTensorsMoEMethod.get_moe_method).
     _GATE_UP_PROBE_SUFFIX = ".0.gate_proj"
+    _DOWN_PROBE_SUFFIX = ".0.down_proj"
 
-    def _moe_gate_up_quant_args(
-        self, layer: torch.nn.Module, prefix: str
+    def _moe_proj_quant_args(
+        self, layer: torch.nn.Module, prefix: str, suffix: str
     ) -> tuple[QuantizationArgs | None, QuantizationArgs | None]:
-        """Resolve the gate/up (GEMM1) quant args for a FusedMoE layer.
-
-        Pearl MoE checkpoints target each projection by regex, so we probe the
-        expert-0 gate projection to read the GEMM1 scheme.
-        """
-        scheme_dict = self.get_scheme_dict(layer, prefix + self._GATE_UP_PROBE_SUFFIX)
+        """Resolve the (weight, input) quant args for one MoE projection."""
+        scheme_dict = self.get_scheme_dict(layer, prefix + suffix)
         if scheme_dict:
             return scheme_dict.get("weights"), scheme_dict.get("input_activations")
         return None, None
@@ -115,15 +145,22 @@ class PearlConfig(CompressedTensorsConfig):
         layer: torch.nn.Module,
         prefix: str,
     ) -> "QuantizeMethodBase | None":
-        """Route 7-bit FusedMoE layers to the Pearl MoE mining method."""
+        """Route mixed int7-gate/up + fp8-block-down FusedMoE layers to PearlMoE."""
         from vllm.model_executor.layers.fused_moe import FusedMoE
 
         from .pearl_moe_method import PearlMoEMethod
 
         if isinstance(layer, FusedMoE):
-            weight_quant, input_quant = self._moe_gate_up_quant_args(layer, prefix)
-            if self._is_mining_layer(weight_quant, input_quant):
-                _LOGGER.debug(f"Mining MoE layer (7-bit) detected for {prefix}")
+            gate_weight, gate_input = self._moe_proj_quant_args(
+                layer, prefix, self._GATE_UP_PROBE_SUFFIX
+            )
+            down_weight, down_input = self._moe_proj_quant_args(
+                layer, prefix, self._DOWN_PROBE_SUFFIX
+            )
+            if self._is_mining_layer(gate_weight, gate_input) and self._is_fp8_block_layer(
+                down_weight, down_input
+            ):
+                _LOGGER.debug(f"Pearl MoE (int7 gate/up + fp8 block down) detected for {prefix}")
                 return PearlMoEMethod(layer.moe_config)
 
         return super().get_quant_method(layer, prefix)

--- a/miner/vllm-miner/src/vllm_miner/vllm_config.py
+++ b/miner/vllm-miner/src/vllm_miner/vllm_config.py
@@ -161,7 +161,7 @@ class PearlConfig(CompressedTensorsConfig):
                 down_weight, down_input
             ):
                 _LOGGER.debug(f"Pearl MoE (int7 gate/up + fp8 block down) detected for {prefix}")
-                return PearlMoEMethod(layer.moe_config)
+                return PearlMoEMethod(layer.moe_config, down_weight, down_input)
 
         return super().get_quant_method(layer, prefix)
 

--- a/miner/vllm-miner/src/vllm_miner/vllm_kernels.py
+++ b/miner/vllm-miner/src/vllm_miner/vllm_kernels.py
@@ -25,12 +25,7 @@ from vllm.platforms import current_platform
 from .config import config
 from .gemm_operators import pearl_gemm_noisy, pearl_gemm_vanilla
 from .mining_state import get_async_manager
-from .quantization_operators import (
-    quant_7bit,
-    quant_7bit_smooth,
-    quant_8bit,
-    quant_8bit_smooth,
-)
+from .quantization_operators import quant_7bit, quant_8bit
 
 _LOGGER = get_logger("vllm.pearl_miner")
 
@@ -193,11 +188,7 @@ class PearlKernel(Int8ScaledMMLinearKernel):
         Uses noisy GEMM for large matrices (proof-of-work), vanilla GEMM for small ones.
         """
         # INT7 quantization with optional smooth scale
-        if smooth_scale is not None:
-            x_q, x_s, _ = quant_7bit_smooth(x, smooth_scale=smooth_scale)
-        else:
-            # Use CUDA-optimized int7 quantization when no smooth scale
-            x_q, x_s, _ = quant_7bit(x)
+        x_q, x_s, _ = quant_7bit(x, smooth_scale=smooth_scale)
 
         m, k, n = x_q.shape[0], x_q.shape[1], w_q.shape[0]
 
@@ -234,10 +225,7 @@ class PearlKernel(Int8ScaledMMLinearKernel):
         Apply weights in non-mining mode: int8 quantization + vanilla GEMM only.
         """
         # INT8 quantization with optional smooth scale
-        if smooth_scale is not None:
-            x_q, x_s, _ = quant_8bit_smooth(x, smooth_scale=smooth_scale)
-        else:
-            x_q, x_s, _ = quant_8bit(x)
+        x_q, x_s, _ = quant_8bit(x, smooth_scale=smooth_scale)
 
         return pearl_gemm_vanilla(
             x_q.contiguous(),

--- a/miner/vllm-miner/tests/moe_testing_helpers.py
+++ b/miner/vllm-miner/tests/moe_testing_helpers.py
@@ -9,6 +9,9 @@ from vllm_miner.moe_gemm_operators import MoERoutingLayout
 MOE_TEST_INT8_LOW = -63
 MOE_TEST_INT8_HIGH = 64
 _MOE_TEST_WEIGHT_SCALE_DIVISOR = 64.0
+# Down projection is fp8 e4m3 with [128, 128] block-wise scales.
+_MOE_TEST_W2_DTYPE = torch.float8_e4m3fn
+_MOE_TEST_W2_BLOCK = 128
 
 
 class RoutingSkew(Enum):
@@ -108,9 +111,9 @@ def make_moe_tensors(
 
     Shapes and dtypes:
       - w13_weight: (num_experts, 2*intermediate_size, hidden_dim) int8
-      - w2_weight: (num_experts, hidden_dim, intermediate_size) int8
+      - w2_weight: (num_experts, hidden_dim, intermediate_size) fp8 e4m3
       - w13_weight_scale: (num_experts, 2*intermediate_size, 1) float32
-      - w2_weight_scale: (num_experts, hidden_dim, 1) float32
+      - w2_weight_scale: (num_experts, ceil(hidden/128), ceil(intermediate/128)) float32
       - hidden_states: (num_tokens, hidden_dim) bf16
       - topk_ids: (num_tokens, top_k) int32
       - topk_weights: (num_tokens, top_k) float32 - normalized to sum to 1
@@ -120,13 +123,6 @@ def make_moe_tensors(
         MOE_TEST_INT8_LOW,
         MOE_TEST_INT8_HIGH,
         (num_experts, 2 * intermediate_size, hidden_dim),
-        dtype=torch.int8,
-        device=device,
-    )
-    w2_weight = torch.randint(
-        MOE_TEST_INT8_LOW,
-        MOE_TEST_INT8_HIGH,
-        (num_experts, hidden_dim, intermediate_size),
         dtype=torch.int8,
         device=device,
     )
@@ -141,8 +137,16 @@ def make_moe_tensors(
         )
         * weight_scale
     )
-    w2_weight_scale = (
-        torch.ones(num_experts, hidden_dim, 1, dtype=torch.float32, device=device) * weight_scale
+
+    # Down projection: fp8 e4m3 weights with [128, 128] block-wise scales.
+    block = _MOE_TEST_W2_BLOCK
+    n_tiles = (hidden_dim + block - 1) // block
+    k_tiles = (intermediate_size + block - 1) // block
+    w2_weight = (
+        torch.randn(num_experts, hidden_dim, intermediate_size, device=device) * weight_scale
+    ).to(_MOE_TEST_W2_DTYPE)
+    w2_weight_scale = torch.ones(
+        num_experts, n_tiles, k_tiles, dtype=torch.float32, device=device
     )
 
     hidden_states = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device)

--- a/miner/vllm-miner/tests/moe_testing_helpers.py
+++ b/miner/vllm-miner/tests/moe_testing_helpers.py
@@ -145,9 +145,7 @@ def make_moe_tensors(
     w2_weight = (
         torch.randn(num_experts, hidden_dim, intermediate_size, device=device) * weight_scale
     ).to(_MOE_TEST_W2_DTYPE)
-    w2_weight_scale = torch.ones(
-        num_experts, n_tiles, k_tiles, dtype=torch.float32, device=device
-    )
+    w2_weight_scale = torch.ones(num_experts, n_tiles, k_tiles, dtype=torch.float32, device=device)
 
     hidden_states = torch.randn(num_tokens, hidden_dim, dtype=torch.bfloat16, device=device)
 

--- a/miner/vllm-miner/tests/test_moe_block_submission.py
+++ b/miner/vllm-miner/tests/test_moe_block_submission.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 import torch
+from compressed_tensors.quantization import QuantizationArgs
 from miner_base.gpu_matmul_config import GPUMatmulConfigFactory
 from miner_base.settings import MinerSettings
 from miner_utils import get_logger
@@ -39,6 +40,23 @@ _NUM_TOKENS = 2048
 _TOP_K = 2
 _EASY_TARGET = 2**242
 
+_DOWN_WEIGHT_QUANT = QuantizationArgs(
+    num_bits=8,
+    type="float",
+    strategy="block",
+    block_structure=[128, 128],
+    symmetric=True,
+    dynamic=False,
+)
+_DOWN_INPUT_QUANT = QuantizationArgs(
+    num_bits=8,
+    type="float",
+    strategy="group",
+    group_size=128,
+    dynamic=True,
+    symmetric=True,
+)
+
 
 @pytest.fixture
 def async_manager():
@@ -67,7 +85,7 @@ def pearl_moe_layer():
         moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
         in_dtype=torch.bfloat16,
     )
-    moe_method = PearlMoEMethod(moe_config)
+    moe_method = PearlMoEMethod(moe_config, _DOWN_WEIGHT_QUANT, _DOWN_INPUT_QUANT)
 
     layer = torch.nn.Module()
     moe_method.create_weights(

--- a/miner/vllm-miner/tests/test_quantization.py
+++ b/miner/vllm-miner/tests/test_quantization.py
@@ -15,19 +15,19 @@ from utils import DEFAULT_LAYER_PARAM_NAMES, DEFAULT_QUANT_CONFIG
 # Quantization Operator Tests
 # =============================================================================
 from vllm_miner.quantization_operators import (
-    quant_7bit_smooth,
-    quant_8bit_smooth,
+    quant_7bit,
+    quant_8bit,
 )
 
 # Parametrize: (quant_func, max_val, name)
 QUANT_FUNCS = [
-    pytest.param(quant_7bit_smooth, 63, id="int7"),
-    pytest.param(quant_8bit_smooth, 127, id="int8"),
+    pytest.param(quant_7bit, 63, id="int7"),
+    pytest.param(quant_8bit, 127, id="int8"),
 ]
 
 
 class TestQuantWithSmoothScale:
-    """Tests for quant_7bit_smooth and quant_8bit_smooth."""
+    """Tests for quant_7bit and quant_8bit with an optional smooth scale."""
 
     @pytest.mark.parametrize("quant_func,max_val", QUANT_FUNCS)
     def test_smooth_scale_applied(self, quant_func, max_val):

--- a/miner/vllm-miner/tests/test_vllm_execution.py
+++ b/miner/vllm-miner/tests/test_vllm_execution.py
@@ -63,7 +63,7 @@ LLAMA_8B = ModelTestConfig(
 
 QWEN3_MOE = ModelTestConfig(
     id="qwen3_moe",
-    model="pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl",
+    model="pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl-moe",
     prompt=(
         "<|im_start|>system\n"
         "You are a French translator. Reply with ONLY the French translation of the user's "

--- a/miner/vllm-miner/tests/test_vllm_execution.py
+++ b/miner/vllm-miner/tests/test_vllm_execution.py
@@ -63,7 +63,7 @@ LLAMA_8B = ModelTestConfig(
 
 QWEN3_MOE = ModelTestConfig(
     id="qwen3_moe",
-    model="pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl-moe",
+    model="pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl",
     prompt=(
         "<|im_start|>system\n"
         "You are a French translator. Reply with ONLY the French translation of the user's "

--- a/miner/vllm-miner/tests/test_vllm_interface.py
+++ b/miner/vllm-miner/tests/test_vllm_interface.py
@@ -18,7 +18,7 @@ from utils import (
 from vllm import _custom_ops as vllm_ops
 from vllm_miner import PearlKernel
 from vllm_miner.config import config as pearl_config
-from vllm_miner.quantization_operators import quant_8bit_smooth
+from vllm_miner.quantization_operators import quant_8bit
 from vllm_miner.vllm_config import PearlConfig
 from vllm_miner.vllm_scheme import PearlScheme
 
@@ -126,7 +126,7 @@ def test_apply_weights_mining_disabled(m, n, k, async_manager):
     assert output.dtype == torch.bfloat16  # Output should be bfloat16
 
     # Compare with our own int8 quantization (same as kernel uses)
-    x_quantized_ref, x_s, _ = quant_8bit_smooth(x)
+    x_quantized_ref, x_s, _ = quant_8bit(x)
     ref_output = vllm_ops.cutlass_scaled_mm(
         x_quantized_ref,
         layer.weight_q.T,


### PR DESCRIPTION
## Summary

feat: We change the quantization scheme for MoE models to use f8 block quantization in the down projection.

## Scope

MoE miner plugin

## Test plan

<!-- How was this tested? -->

- [X] Existing tests pass (`task test`)
