### PR TITLE
feat(wallet): add RPM package target for Linux releases

### DIFF
--- a/apps/apps/pearl-desktop-wallet/electron-builder.json
+++ b/apps/apps/pearl-desktop-wallet/electron-builder.json
@@ -67,6 +67,12 @@
         "arch": [
           "x64"
         ]
+      },
+      {
+        "target": "rpm",
+        "arch": [
+          "x64"
+        ]
       }
     ],
     "extraResources": [
@@ -107,5 +113,10 @@
     "buildUniversalInstaller": false,
     "artifactName": "Pearl-Wallet-Setup-${version}.${ext}"
   },
-  "publish": null
+  "publish": null,
+  "rpm": {
+    "artifactName": "pearl-desktop-wallet-${version}.${arch}.${ext}",
+    "packageName": "pearl-desktop-wallet",
+    "compression": "xz"
+  }
 }


### PR DESCRIPTION
Closes #178.

Added `rpm` as a Linux build target in `electron-builder.json` alongside the existing `deb` target. This will produce a `.rpm` package in future releases for Fedora/RHEL/CentOS users.