### PR TITLE
perf(miner): hash int8 GEMM inputs without casts

### DIFF
--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -54,6 +54,8 @@ void run_tensor_hash(
   TORCH_CHECK(key.dtype() == at::kByte, "key must be uint8");
   TORCH_CHECK(out.dtype() == at::kByte, "out must be uint8");
   TORCH_CHECK(roots.dtype() == at::kByte, "roots must be uint8");
+  TORCH_CHECK(data.dtype() == at::kByte || data.dtype() == at::kChar,
+              "data must be uint8 or int8");
   TORCH_CHECK(data.dim() == 2, "data must be 2D tensor");
   TORCH_CHECK(reinterpret_cast<uintptr_t>(data.data_ptr()) %
                       TMA_GLOBAL_ALIGNMENT_BYTES ==
@@ -103,8 +105,10 @@ void run_tensor_hash(
   auto stream = at::cuda::getCurrentCUDAStream();
   auto dprops = at::cuda::getCurrentDeviceProperties();
 
-  tensor_hash(data.data_ptr<uint8_t>(), data.numel(), out.data_ptr<uint8_t>(),
-              key.data_ptr<uint8_t>(), num_blocks,
+  // Hash the tensor storage bytes. int8 and uint8 are both one byte per
+  // element, so they must commit to identical roots for identical bit patterns.
+  tensor_hash(reinterpret_cast<uint8_t const*>(data.data_ptr()), data.numel(),
+              out.data_ptr<uint8_t>(), key.data_ptr<uint8_t>(), num_blocks,
               static_cast<uint32_t>(threads_per_block),
               static_cast<uint32_t>(num_stages),
               static_cast<uint32_t>(leaves_per_mt_block),

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -559,7 +559,8 @@ def tensor_hash(
     """Hash a tensor using a key with configurable kernel parameters.
 
     Args:
-        data (Tensor): Input tensor to hash
+        data (Tensor): 2D uint8 or int8 tensor to hash as raw storage bytes.
+            int8 and uint8 inputs with the same bit pattern produce the same root.
         key (Tensor): Key tensor used for hashing
         out (Tensor): Output tensor for hash result
         roots (Tensor): Scratchpad tensor for intermediate results

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -115,6 +115,40 @@ class TestTensorHash:
             "Commitment hash from merkle roots mismatch: CUDA result doesn't match Python reference"
         )
 
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (16, 16),
+            (257, 1024),
+            (1024, 1024),
+            (2048, 3072),
+        ],
+    )
+    def test_tensor_hash_int8_hashes_raw_bytes(self, shape):
+        """Dense mining hashes int8 A/B tensors directly without uint8 casts."""
+        matrix = torch.randint(-63, 64, shape, dtype=torch.int8, device="cuda")
+        scratchpad = torch.empty(
+            get_required_scratchpad_bytes(matrix.numel()),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        direct_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        cast_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        key_tensor = torch.randint(0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda")
+        key_bytes = key_tensor.cpu().numpy().tobytes()
+
+        tensor_hash(matrix, key_tensor, direct_result, scratchpad)
+        tensor_hash(matrix.to(torch.uint8), key_tensor, cast_result, scratchpad)
+        torch.cuda.synchronize()
+
+        python_result = hash_matrix(matrix.cpu(), key_bytes)
+        assert torch.equal(direct_result, python_result), (
+            f"tensor_hash must hash the raw int8 bytes used by MatrixMerkleTree for {shape}"
+        )
+        assert torch.equal(direct_result, cast_result), (
+            f"direct int8 hashing must match the previous uint8 cast path for {shape}"
+        )
+
     def test_commitment_hash_from_merkle_roots_moe(self):
         """MoE folding path matches the CommitmentHasher reference."""
         # Cumulative exclusive ends per expert; last == m * top_k.

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -123,7 +123,7 @@ def pearl_gemm_noisy(
 
     A_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        A.to(torch.uint8),
+        A,
         key_tensor,
         A_tensor_hash,
         tensor_hash_scratchpad,
@@ -131,7 +131,7 @@ def pearl_gemm_noisy(
 
     B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        B.to(torch.uint8),
+        B,
         key_tensor,
         B_tensor_hash,
         tensor_hash_scratchpad,

--- a/miner/vllm-miner/tests/test_reference_vs_kernels.py
+++ b/miner/vllm-miner/tests/test_reference_vs_kernels.py
@@ -77,8 +77,8 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Create random int8 tensor for MatrixMerkleTree
         matrix_int8 = torch.randint(-128, 127, (m, n), dtype=torch.int8)
 
-        # Convert to uint8 for tensor_hash (CUDA implementation expects uint8)
-        matrix_uint8 = matrix_int8.to(torch.uint8).cuda()
+        matrix_cuda = matrix_int8.cuda()
+        matrix_uint8 = matrix_cuda.to(torch.uint8)
 
         # Create key tensor for CUDA implementation
         key_tensor = _to_cuda_u8(test_noise_seed_A)
@@ -89,16 +89,19 @@ class TestMatrixMerkleTreeVsTensorHash:
 
         # Compute hash using tensor_hash (CUDA implementation)
         cuda_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
+        cast_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
         tensor_hash_scratchpad = torch.empty(
-            pearl_gemm.get_required_scratchpad_bytes(matrix_uint8.numel()),
+            pearl_gemm.get_required_scratchpad_bytes(matrix_cuda.numel()),
             device="cuda",
             dtype=torch.uint8,
         )
-        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_cuda, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cast_result, tensor_hash_scratchpad)
         torch.cuda.synchronize()
 
         # Convert CUDA result back to bytes for comparison
         cuda_root = cuda_result.cpu().numpy().tobytes()
+        cast_root = cast_result.cpu().numpy().tobytes()
 
         blake3_result = blake3(matrix_int8.cpu().numpy().tobytes(), key=test_noise_seed_A).digest()
 
@@ -109,6 +112,9 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Compare results
         assert python_root == cuda_root, (
             f"Hash mismatch for shape {m, n}: MatrixMerkleTree root doesn't match tensor_hash result"
+        )
+        assert cuda_root == cast_root, (
+            f"Hash mismatch for shape {m, n}: direct int8 tensor_hash differs from uint8 cast path"
         )
 
     def test_commitment_hash_reference_vs_cuda(self, test_noise_seed_A):


### PR DESCRIPTION
Stack layer 1/3.

This updates `tensor_hash` to accept int8 tensors directly and hash their raw storage bytes, so the dense mining path no longer has to stage A/B through `.to(torch.uint8)` before hashing.

## Modal H100 benchmark


Environment: `NVIDIA H100 80GB HBM3`, CUDA `sm_90`, Torch `2.11.0+cu130`, repo Dockerfile image.

This isolates #193 by comparing the new direct path (`tensor_hash(int8)`) against the old dense-mining behavior (`tensor_hash(t.to(torch.uint8))`) for hashing both A and B. The benchmark checks the two paths produce identical roots before timing.

| shape | old uint8-cast hash pair | direct int8 hash pair | result |
|---|---:|---:|---:|
| gate_up 4096x28672x4096 | 0.401 ms | 0.184 ms | **2.18x faster / +117.6%** |
| gate_up threshold 1024x28672x4096 | 0.380 ms | 0.182 ms | **2.09x faster / +108.9%** |
| down 4096x4096x14336 | 0.373 ms | 0.183 ms | **2.04x faster / +103.8%** |
| square 4096x4096x4096 | 0.140 ms | 0.080 ms | **1.74x faster / +74.1%** |

## Verification

- `uv run pytest tests/test_bpeb_cache.py tests/test_pearl_noisy_gemm.py::test_weight_hash_cache_hits_invalidates_and_is_aba_safe -q` run on the full stacked branch: 7 passed.
- Local CUDA tensor_hash focused tests could not run on this machine because the installed `pearl-gemm` extension is built for `sm_90a` while the local GPU is an RTX 5090 Laptop GPU, `sm_120`: no kernel image is available for execution on the device.
