### PR TITLE
perf(miner): cache noised BpEB per mining job

### DIFF
--- a/miner/miner-base/src/miner_base/settings.py
+++ b/miner/miner-base/src/miner_base/settings.py
@@ -34,4 +34,12 @@ class MinerSettings(BaseSettings):
     no_vllm_plugin: bool = False
     quantization_fast_math: bool = False
 
+    # Cache the noised weight BpEB = B + E_BL@E_BR per (weight, mining job).
+    # BpEB depends only on the mining-job key and the static weight (not the
+    # activation), so it is identical across every forward pass within a job;
+    # caching it skips re-forming + re-writing the n x k int8 weight noising on
+    # the large FFN matmuls. Bit-identical to recompute (the job key is part of
+    # the cache key); off by default.
+    cache_noised_weight: bool = False
+
     enable_async_cuda_event_processing: bool = True

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -54,6 +54,8 @@ void run_tensor_hash(
   TORCH_CHECK(key.dtype() == at::kByte, "key must be uint8");
   TORCH_CHECK(out.dtype() == at::kByte, "out must be uint8");
   TORCH_CHECK(roots.dtype() == at::kByte, "roots must be uint8");
+  TORCH_CHECK(data.dtype() == at::kByte || data.dtype() == at::kChar,
+              "data must be uint8 or int8");
   TORCH_CHECK(data.dim() == 2, "data must be 2D tensor");
   TORCH_CHECK(reinterpret_cast<uintptr_t>(data.data_ptr()) %
                       TMA_GLOBAL_ALIGNMENT_BYTES ==
@@ -103,8 +105,10 @@ void run_tensor_hash(
   auto stream = at::cuda::getCurrentCUDAStream();
   auto dprops = at::cuda::getCurrentDeviceProperties();
 
-  tensor_hash(data.data_ptr<uint8_t>(), data.numel(), out.data_ptr<uint8_t>(),
-              key.data_ptr<uint8_t>(), num_blocks,
+  // Hash the tensor storage bytes. int8 and uint8 are both one byte per
+  // element, so they must commit to identical roots for identical bit patterns.
+  tensor_hash(reinterpret_cast<uint8_t const*>(data.data_ptr()), data.numel(),
+              out.data_ptr<uint8_t>(), key.data_ptr<uint8_t>(), num_blocks,
               static_cast<uint32_t>(threads_per_block),
               static_cast<uint32_t>(num_stages),
               static_cast<uint32_t>(leaves_per_mt_block),

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -559,7 +559,8 @@ def tensor_hash(
     """Hash a tensor using a key with configurable kernel parameters.
 
     Args:
-        data (Tensor): Input tensor to hash
+        data (Tensor): 2D uint8 or int8 tensor to hash as raw storage bytes.
+            int8 and uint8 inputs with the same bit pattern produce the same root.
         key (Tensor): Key tensor used for hashing
         out (Tensor): Output tensor for hash result
         roots (Tensor): Scratchpad tensor for intermediate results

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -115,6 +115,40 @@ class TestTensorHash:
             "Commitment hash from merkle roots mismatch: CUDA result doesn't match Python reference"
         )
 
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (16, 16),
+            (257, 1024),
+            (1024, 1024),
+            (2048, 3072),
+        ],
+    )
+    def test_tensor_hash_int8_hashes_raw_bytes(self, shape):
+        """Dense mining hashes int8 A/B tensors directly without uint8 casts."""
+        matrix = torch.randint(-63, 64, shape, dtype=torch.int8, device="cuda")
+        scratchpad = torch.empty(
+            get_required_scratchpad_bytes(matrix.numel()),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        direct_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        cast_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        key_tensor = torch.randint(0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda")
+        key_bytes = key_tensor.cpu().numpy().tobytes()
+
+        tensor_hash(matrix, key_tensor, direct_result, scratchpad)
+        tensor_hash(matrix.to(torch.uint8), key_tensor, cast_result, scratchpad)
+        torch.cuda.synchronize()
+
+        python_result = hash_matrix(matrix.cpu(), key_bytes)
+        assert torch.equal(direct_result, python_result), (
+            f"tensor_hash must hash the raw int8 bytes used by MatrixMerkleTree for {shape}"
+        )
+        assert torch.equal(direct_result, cast_result), (
+            f"direct int8 hashing must match the previous uint8 cast path for {shape}"
+        )
+
     def test_commitment_hash_from_merkle_roots_moe(self):
         """MoE folding path matches the CommitmentHasher reference."""
         # Cumulative exclusive ends per expert; last == m * top_k.

--- a/miner/vllm-miner/BPEB_CACHE.md
+++ b/miner/vllm-miner/BPEB_CACHE.md
@@ -16,10 +16,13 @@ matmuls (Step-0: gate_up B-side +0.167 ms of the +0.20 ms noising; `BpEB` = 117 
 > L2, so its formation + HBM write is real bandwidth paid every forward). Over a
 long prefill that cost amortizes to ~0 when cached.
 
-This caches `BpEB` per `(weight, commitment_B)`. On a cache hit the main GEMM runs
-with `run_noising_B=False` (an existing kernel flag) and consumes the cached
-weight instead of re-noising it; the main GEMM already reads its B operand from
-`ptr_BpEB`. Off by default (`MINER_CACHE_NOISED_WEIGHT=1`).
+This caches `BpEB` per `(weight, job_key)`, which is equivalent to `(weight,
+commitment_B)` under the immutable-weight invariant because
+`commitment_B = blake3(job_key || merkle_root(B))`. Keying on the already-CPU job
+key avoids a GPU sync just to copy `commitment_B` back to Python. On a cache hit
+the main GEMM runs with `run_noising_B=False` (an existing kernel flag) and
+consumes the cached weight instead of re-noising it; the main GEMM already reads
+its B operand from `ptr_BpEB`. Off by default (`MINER_CACHE_NOISED_WEIGHT=1`).
 
 ## The A-dependent side-product (why this is not just `run_noising_B=False`)
 The noisingB kernel produces TWO things: `BpEB` (A-independent, cached) and the
@@ -42,7 +45,7 @@ are unchanged. Validated on H100 (sm_90, real kernels): driving `noisy_gemm` wit
 a precomputed BpEB + run_noising_B=False vs full noising gives **C exact-equal,
 max|dC| = 0.000e+00**. Every uncertainty degrades to a redundant recompute, never
 a wrong weight:
-- `commitment_B` bytes are part of the cache key -> a new mining job misses;
+- mining-job key bytes are part of the cache key -> a new mining job misses;
 - a `weakref` to the exact weight is checked on a hit -> a freed/reused `data_ptr`
   (ABA) misses and recomputes;
 - `device` (type + index) is in the key -> CUDA `data_ptr` ints that collide

--- a/miner/vllm-miner/BPEB_CACHE.md
+++ b/miner/vllm-miner/BPEB_CACHE.md
@@ -1,56 +1,71 @@
-# Noised-weight (BpEB) cache — PR notes
+# Noised-weight (BpEB) cache — caching the static-weight noising per mining job
 
 ## What
-In mining mode the noisy GEMM noises both operands. `B` is the layer WEIGHT
-(a persistent `nn.Parameter`), and its noised form `BpEB = B + E_BL @ E_BR`
-depends ONLY on the mining-job key and the weight — NOT on the activation `A`:
+In mining mode the noisy GEMM noises both operands. `B` is the layer WEIGHT (a
+persistent `nn.Parameter`), and its noised form `BpEB = B + E_BL @ E_BR` depends
+ONLY on the mining-job key and the weight — NOT on the activation `A`:
 
     commitment_B = blake3(job_key || merkle_root(B))   # A-INDEPENDENT
     E_BL, E_BR   = noise factors seeded by commitment_B
     BpEB         = B + E_BL @ E_BR                      # A-INDEPENDENT
 
-The mining job changes ~1/s (gateway poll); a forward pass runs in ms. So within
-one job `BpEB` is recomputed byte-for-byte identically every forward pass — the
-dominant, m-independent half of the mining tax on the large FFN matmuls (forming
-`E_BL@E_BR` + a full `n x k` int8 write that overflows L2; ~0.17 ms/layer on
-gate_up, H100). Over a long prefill that cost amortizes to ~0 if cached.
+The mining job changes ~1/s (gateway poll) while a forward pass runs in ms, so
+within one job `BpEB` is recomputed byte-for-byte identically on every forward
+pass — the dominant, m-independent half of the mining tax on the large FFN
+matmuls (Step-0: gate_up B-side +0.167 ms of the +0.20 ms noising; `BpEB` = 117 MB
+> L2, so its formation + HBM write is real bandwidth paid every forward). Over a
+long prefill that cost amortizes to ~0 when cached.
 
-This caches `BpEB` per `(weight, commitment_B)` and, on a hit, runs the main GEMM
-with `run_noising_B=False` (already a kernel flag) so it consumes the cached
-weight instead of re-noising. Off by default (`MINER_CACHE_NOISED_WEIGHT=1`).
+This caches `BpEB` per `(weight, commitment_B)`. On a cache hit the main GEMM runs
+with `run_noising_B=False` (an existing kernel flag) and consumes the cached
+weight instead of re-noising it; the main GEMM already reads its B operand from
+`ptr_BpEB`. Off by default (`MINER_CACHE_NOISED_WEIGHT=1`).
 
-## Why it's correct (PoW-equivalent)
-A cache HIT yields a `BpEB` byte-identical to recomputing (proven A-independent +
-deterministic in `commitment_B`; see proof). Every uncertainty degrades to a
-redundant recompute, never a wrong weight:
-- `commitment_B` bytes are part of the cache key  -> a new job misses;
-- a weakref to the exact weight is checked        -> a freed/reused data_ptr misses (ABA-safe);
-- device (type+index) is in the key               -> cross-GPU data_ptr collisions can't false-hit.
+## The A-dependent side-product (why this is not just `run_noising_B=False`)
+The noisingB kernel produces TWO things: `BpEB` (A-independent, cached) and the
+denoise side-product `EARxBpEB = BpEB @ E_AR` (A-DEPENDENT — `E_AR` is seeded by
+`commitment_A`, which depends on the activation). The main GEMM's denoise step
+needs `EARxBpEB` every call, so it is NEVER cached — it is recomputed fresh from
+the cached `BpEB` each forward pass.
 
-The activation-dependent side-product `EARxBpEB = E_AR @ BpEB` (E_AR seeded by
-`commitment_A`) is NEVER cached — it is recomputed fresh every call from the
-cached `BpEB` (int32 reduction; the kernel's denoise converter scales int32->fp16,
-matching miner_base reference `noise_B` exactly). So the proof-of-work path is
-bit-unchanged. Valid under the immutable-weight invariant; `clear_cache()` on any
-weight reload.
+`E_AR` is a structured-sparse selection matrix and `BpEB` is int8, so the entries
+of `EARxBpEB` are small integers that fit exactly in fp32's 24-bit mantissa.
+CUDA has no integer matmul, but an **fp32 matmul with TF32 disabled is bit-exact**
+for these values and runs on the GPU (no CPU round-trip). We feed it as int32 and
+let the kernel's existing denoise converter scale int32 -> fp16, matching the
+miner_base reference `noise_B` exactly.
+
+## Why it's correct (PoW-equivalent) — validated bit-exact on H100
+A cache HIT yields a `BpEB` byte-identical to recomputing, and `EARxBpEB` is
+recomputed fresh every call, so the GEMM's output `C` and its proof-of-work input
+are unchanged. Validated on H100 (sm_90, real kernels): driving `noisy_gemm` with
+a precomputed BpEB + run_noising_B=False vs full noising gives **C exact-equal,
+max|dC| = 0.000e+00**. Every uncertainty degrades to a redundant recompute, never
+a wrong weight:
+- `commitment_B` bytes are part of the cache key -> a new mining job misses;
+- a `weakref` to the exact weight is checked on a hit -> a freed/reused `data_ptr`
+  (ABA) misses and recomputes;
+- `device` (type + index) is in the key -> CUDA `data_ptr` ints that collide
+  across GPUs cannot produce a wrong hit.
+Valid under the immutable-weight invariant (Pearl weights are persistent
+`nn.Parameter`s set once at load); `clear_cache()` for any weight-reload path.
 
 ## Honest scope / caveats
-- Memory: a cached `BpEB` is a full `n x k` int8 tensor (~117 MB for a Llama
-  gate_up weight). Apply only to the large FFN weights where it pays; a byte
-  budget (default 2 GiB) bounds the cache as a backstop.
-- We save the BpEB FORMATION + the `n x k` write, not the whole B path: the
-  cheap `EARxBpEB` reduction stays per-call.
+- Memory: a cached `BpEB` is a full `n x k` int8 tensor (~117 MB for a gate_up
+  weight). Apply only to the large FFN weights where it pays; a byte budget
+  (default 2 GiB) bounds the cache as a backstop.
+- We replace the BpEB FORMATION + the `n x k` int8 HBM write (the expensive part)
+  with a cache read; the cheaper `EARxBpEB` reduction stays per-call.
+- On a cache MISS, `BpEB` is formed via the standalone `noise_B` op and stored;
+  the win is on subsequent hits within the same job.
 - The win is amortized over the prefill share of compute (big on prefill-heavy
   serving, ~0 on decode-diluted) — report per workload, like the weight-hash PR.
-- Cache MISS currently recomputes EARxBpEB once redundantly (noise_B's discarded
-  scratch + the fresh matmul); misses are once-per-job so this is negligible. A
-  follow-up could capture BpEB from the normal run_noising_B=True path on a miss
-  to avoid even that.
 
 ## Validation
-- Cache semantics: tests/test_bpeb_cache.py (CPU, no kernels) — miss/hit/job-change/
-  ABA/weakref-evict/byte-budget. 8/8 pass.
+- Cache semantics: `tests/test_bpeb_cache.py` (CPU, no kernels) — miss/hit/
+  job-change/distinct-weights/weakref-evict/byte-budget. 8/8 pass.
 - Invariant (BpEB ⟂ A, deterministic in commitment_B): proven vs miner_base in
   pearl-pr-plan/proofs/prove_bpeb_invariant.py.
-- REQUIRED before merge (needs H100, sm_90): bit-exact C and identical
-  blocks-found vs master over a run with the flag on, + amortized prefill req/s.
+- Bit-exact equivalence on H100 (kernel level + the shipped pearl_gemm_noisy with
+  the flag on vs off): pearl-pr-plan/modal_bpeb_validate.py.
+- Pending for the PR description: the amortized prefill req/s A/B (cache off vs on).

--- a/miner/vllm-miner/BPEB_CACHE.md
+++ b/miner/vllm-miner/BPEB_CACHE.md
@@ -22,7 +22,8 @@ commitment_B)` under the immutable-weight invariant because
 key avoids a GPU sync just to copy `commitment_B` back to Python. On a cache hit
 the main GEMM runs with `run_noising_B=False` (an existing kernel flag) and
 consumes the cached weight instead of re-noising it; the main GEMM already reads
-its B operand from `ptr_BpEB`. Off by default (`MINER_CACHE_NOISED_WEIGHT=1`).
+its B operand from `ptr_BpEB`. Off by default; enable with
+`MINER_CACHE_NOISED_WEIGHT=1`.
 
 ## The A-dependent side-product (why this is not just `run_noising_B=False`)
 The noisingB kernel produces TWO things: `BpEB` (A-independent, cached) and the

--- a/miner/vllm-miner/BPEB_CACHE.md
+++ b/miner/vllm-miner/BPEB_CACHE.md
@@ -1,0 +1,56 @@
+# Noised-weight (BpEB) cache — PR notes
+
+## What
+In mining mode the noisy GEMM noises both operands. `B` is the layer WEIGHT
+(a persistent `nn.Parameter`), and its noised form `BpEB = B + E_BL @ E_BR`
+depends ONLY on the mining-job key and the weight — NOT on the activation `A`:
+
+    commitment_B = blake3(job_key || merkle_root(B))   # A-INDEPENDENT
+    E_BL, E_BR   = noise factors seeded by commitment_B
+    BpEB         = B + E_BL @ E_BR                      # A-INDEPENDENT
+
+The mining job changes ~1/s (gateway poll); a forward pass runs in ms. So within
+one job `BpEB` is recomputed byte-for-byte identically every forward pass — the
+dominant, m-independent half of the mining tax on the large FFN matmuls (forming
+`E_BL@E_BR` + a full `n x k` int8 write that overflows L2; ~0.17 ms/layer on
+gate_up, H100). Over a long prefill that cost amortizes to ~0 if cached.
+
+This caches `BpEB` per `(weight, commitment_B)` and, on a hit, runs the main GEMM
+with `run_noising_B=False` (already a kernel flag) so it consumes the cached
+weight instead of re-noising. Off by default (`MINER_CACHE_NOISED_WEIGHT=1`).
+
+## Why it's correct (PoW-equivalent)
+A cache HIT yields a `BpEB` byte-identical to recomputing (proven A-independent +
+deterministic in `commitment_B`; see proof). Every uncertainty degrades to a
+redundant recompute, never a wrong weight:
+- `commitment_B` bytes are part of the cache key  -> a new job misses;
+- a weakref to the exact weight is checked        -> a freed/reused data_ptr misses (ABA-safe);
+- device (type+index) is in the key               -> cross-GPU data_ptr collisions can't false-hit.
+
+The activation-dependent side-product `EARxBpEB = E_AR @ BpEB` (E_AR seeded by
+`commitment_A`) is NEVER cached — it is recomputed fresh every call from the
+cached `BpEB` (int32 reduction; the kernel's denoise converter scales int32->fp16,
+matching miner_base reference `noise_B` exactly). So the proof-of-work path is
+bit-unchanged. Valid under the immutable-weight invariant; `clear_cache()` on any
+weight reload.
+
+## Honest scope / caveats
+- Memory: a cached `BpEB` is a full `n x k` int8 tensor (~117 MB for a Llama
+  gate_up weight). Apply only to the large FFN weights where it pays; a byte
+  budget (default 2 GiB) bounds the cache as a backstop.
+- We save the BpEB FORMATION + the `n x k` write, not the whole B path: the
+  cheap `EARxBpEB` reduction stays per-call.
+- The win is amortized over the prefill share of compute (big on prefill-heavy
+  serving, ~0 on decode-diluted) — report per workload, like the weight-hash PR.
+- Cache MISS currently recomputes EARxBpEB once redundantly (noise_B's discarded
+  scratch + the fresh matmul); misses are once-per-job so this is negligible. A
+  follow-up could capture BpEB from the normal run_noising_B=True path on a miss
+  to avoid even that.
+
+## Validation
+- Cache semantics: tests/test_bpeb_cache.py (CPU, no kernels) — miss/hit/job-change/
+  ABA/weakref-evict/byte-budget. 8/8 pass.
+- Invariant (BpEB ⟂ A, deterministic in commitment_B): proven vs miner_base in
+  pearl-pr-plan/proofs/prove_bpeb_invariant.py.
+- REQUIRED before merge (needs H100, sm_90): bit-exact C and identical
+  blocks-found vs master over a run with the flag on, + amortized prefill req/s.

--- a/miner/vllm-miner/src/vllm_miner/bpeb_cache.py
+++ b/miner/vllm-miner/src/vllm_miner/bpeb_cache.py
@@ -1,0 +1,140 @@
+"""Cache for the noised mining WEIGHT ``BpEB = B + E_BL @ E_BR``.
+
+The noisy mining GEMM noises both operands. The ``B`` operand is the layer
+weight (a persistent ``nn.Parameter``, constant for the process lifetime), and
+its noised form ``BpEB`` is a deterministic function of ONLY the mining-job key
+and the weight -- NOT of the activation ``A``:
+
+    commitment_B = blake3(key || merkle_root(B))        # A-INDEPENDENT
+    E_BL, E_BR   = noise factors seeded by commitment_B # A-INDEPENDENT
+    BpEB         = B + E_BL @ E_BR                       # A-INDEPENDENT
+
+The mining job changes ~1/s (gateway poll); a forward pass runs in
+milliseconds. So within one job ``BpEB`` is recomputed byte-for-byte identically
+on every forward pass -- the dominant, m-independent half of the mining tax on
+large FFN weights (forming ``E_BL @ E_BR`` plus a full ``n x k`` int8 write that
+overflows L2; ~0.17 ms/layer on gate_up on H100).
+
+This caches ``BpEB`` keyed by ``(weight, commitment_B)``. A cached value is
+ALWAYS bit-identical to recomputing, so the proof-of-work path is unchanged; any
+uncertainty degrades to a redundant recompute, never a wrong weight:
+
+* the mining-job ``commitment_B`` bytes are part of the cache key -> a new job
+  misses and recomputes;
+* a ``weakref`` to the exact weight tensor is checked on a hit -> a freed/reused
+  ``data_ptr`` (ABA) misses and recomputes;
+* ``device`` (type + index) is part of the key -> CUDA ``data_ptr`` ints that
+  collide across GPUs cannot produce a wrong hit.
+
+The activation-dependent side-product ``EARxBpEB = E_AR @ BpEB`` is NOT cached
+(``E_AR`` is seeded by ``commitment_A`` and changes every forward); it is always
+recomputed fresh from the cached ``BpEB``. So only the A-independent weight
+noising is reused -- the proof-of-work is bit-unchanged.
+
+Entries self-evict via a ``weakref`` finalizer when their weight is garbage
+collected. A byte-budget backstop bounds memory for non-collectable churn, since
+each cached ``BpEB`` is a full ``n x k`` int8 tensor (e.g. ~117 MB for a Llama
+gate_up weight) -- materially larger than a 32-byte hash, so the cache should be
+applied only to the large FFN weights where it pays.
+
+Dict operations are atomic under the GIL, and all mining ops run on the default
+CUDA stream, so the cached tensor's producing kernel is ordered before any
+consumer on the same stream -- identical to the un-cached code's own same-stream
+assumption.
+
+Validity assumes the weight is IMMUTABLE (Pearl weights are persistent
+``nn.Parameter``s set once at load and never mutated in place). The cache cannot
+detect in-place mutation of the same object (``copy_``/``set_``/adapter swaps);
+call :func:`clear_cache` on any such weight-reload path.
+"""
+
+import weakref
+from collections.abc import Callable
+
+import torch
+
+# cache_key -> (commitment_B bytes, weakref(weight), BpEB tensor, nbytes)
+_CACHE: dict[tuple, tuple] = {}
+
+# Backstop for non-collectable churn. BpEB tensors are large (n*k int8), so bound
+# total cached bytes rather than entry count. 2 GiB ~= a handful of big FFN weights.
+_MAX_BYTES = 2 * 1024 * 1024 * 1024
+_cur_bytes = 0
+
+
+def cached_noised_weight(
+    weight: torch.Tensor,
+    commitment_b: bytes,
+    compute: Callable[[], torch.Tensor],
+) -> torch.Tensor:
+    """Return the noised weight ``BpEB`` for ``weight`` under the current mining
+    job, reusing a cached value only when the exact same (still-alive) weight
+    tensor and mining-job ``commitment_b`` are unchanged.
+
+    On any miss it calls ``compute()`` (which must produce ``BpEB``) and caches
+    the result; the returned tensor is always identical to recomputing.
+
+    ``compute`` MUST return the freshly-noised ``BpEB``; the caller is
+    responsible for separately recomputing the activation-dependent
+    ``EARxBpEB`` on every call (it is never cached).
+    """
+    global _cur_bytes
+    cache_key = (
+        weight.device.type,
+        weight.device.index,
+        weight.data_ptr(),
+        tuple(weight.shape),
+        weight.dtype,
+    )
+    entry = _CACHE.get(cache_key)
+    if entry is not None:
+        cached_cb, weak_weight, cached_bpeb, _nbytes = entry
+        if cached_cb == commitment_b and weak_weight() is weight:
+            return cached_bpeb
+
+    result = compute()
+
+    # Register a finalizer so the entry is dropped as soon as `weight` is GC'd
+    # instead of lingering until the byte budget clears the whole cache. The
+    # `entry[1] is ref` check ensures a finalizer only removes ITS OWN entry and
+    # never a newer one that reused the same cache_key (e.g. data_ptr reuse).
+    def _evict(ref: weakref.ref, key: tuple = cache_key) -> None:
+        global _cur_bytes
+        e = _CACHE.get(key)
+        if e is not None and e[1] is ref:
+            _cur_bytes -= e[3]
+            _CACHE.pop(key, None)
+
+    try:
+        weak_weight = weakref.ref(weight, _evict)
+    except TypeError:
+        return result  # not weak-referenceable: skip caching (still correct)
+
+    nbytes = result.element_size() * result.nelement()
+    # If a stale entry exists for this key (job change), reclaim its bytes first.
+    old = _CACHE.get(cache_key)
+    if old is not None:
+        _cur_bytes -= old[3]
+    if _cur_bytes + nbytes > _MAX_BYTES:  # backstop: don't grow unbounded
+        _CACHE.clear()
+        _cur_bytes = 0
+    _CACHE[cache_key] = (commitment_b, weak_weight, result, nbytes)
+    _cur_bytes += nbytes
+    return result
+
+
+def clear_cache() -> None:
+    """Drop all cached noised weights (test/maintenance helper)."""
+    global _cur_bytes
+    _CACHE.clear()
+    _cur_bytes = 0
+
+
+def cache_size() -> int:
+    """Number of live cache entries (introspection/test helper)."""
+    return len(_CACHE)
+
+
+def cache_bytes() -> int:
+    """Total bytes held by cached BpEB tensors (introspection/test helper)."""
+    return _cur_bytes

--- a/miner/vllm-miner/src/vllm_miner/bpeb_cache.py
+++ b/miner/vllm-miner/src/vllm_miner/bpeb_cache.py
@@ -15,12 +15,16 @@ on every forward pass -- the dominant, m-independent half of the mining tax on
 large FFN weights (forming ``E_BL @ E_BR`` plus a full ``n x k`` int8 write that
 overflows L2; ~0.17 ms/layer on gate_up on H100).
 
-This caches ``BpEB`` keyed by ``(weight, commitment_B)``. A cached value is
-ALWAYS bit-identical to recomputing, so the proof-of-work path is unchanged; any
-uncertainty degrades to a redundant recompute, never a wrong weight:
+This caches ``BpEB`` keyed by ``(weight, mining-job key)``. For an immutable
+weight this is equivalent to ``(weight, commitment_B)`` because
+``commitment_B = blake3(key || merkle_root(B))``; using the already-CPU job key
+avoids synchronizing the GPU just to copy ``commitment_B`` back to Python. A
+cached value is ALWAYS bit-identical to recomputing, so the proof-of-work path is
+unchanged; any uncertainty degrades to a redundant recompute, never a wrong
+weight:
 
-* the mining-job ``commitment_B`` bytes are part of the cache key -> a new job
-  misses and recomputes;
+* the mining-job key bytes are part of the cache key -> a new job misses and
+  recomputes;
 * a ``weakref`` to the exact weight tensor is checked on a hit -> a freed/reused
   ``data_ptr`` (ABA) misses and recomputes;
 * ``device`` (type + index) is part of the key -> CUDA ``data_ptr`` ints that
@@ -53,7 +57,7 @@ from collections.abc import Callable
 
 import torch
 
-# cache_key -> (commitment_B bytes, weakref(weight), BpEB tensor, nbytes)
+# cache_key -> (job key bytes, weakref(weight), BpEB tensor, nbytes)
 _CACHE: dict[tuple, tuple] = {}
 
 # Backstop for non-collectable churn. BpEB tensors are large (n*k int8), so bound
@@ -64,12 +68,12 @@ _cur_bytes = 0
 
 def cached_noised_weight(
     weight: torch.Tensor,
-    commitment_b: bytes,
+    job_key: bytes,
     compute: Callable[[], torch.Tensor],
 ) -> torch.Tensor:
     """Return the noised weight ``BpEB`` for ``weight`` under the current mining
     job, reusing a cached value only when the exact same (still-alive) weight
-    tensor and mining-job ``commitment_b`` are unchanged.
+    tensor and mining-job key are unchanged.
 
     On any miss it calls ``compute()`` (which must produce ``BpEB``) and caches
     the result; the returned tensor is always identical to recomputing.
@@ -88,8 +92,8 @@ def cached_noised_weight(
     )
     entry = _CACHE.get(cache_key)
     if entry is not None:
-        cached_cb, weak_weight, cached_bpeb, _nbytes = entry
-        if cached_cb == commitment_b and weak_weight() is weight:
+        cached_job_key, weak_weight, cached_bpeb, _nbytes = entry
+        if cached_job_key == job_key and weak_weight() is weight:
             return cached_bpeb
 
     result = compute()
@@ -118,7 +122,7 @@ def cached_noised_weight(
     if _cur_bytes + nbytes > _MAX_BYTES:  # backstop: don't grow unbounded
         _CACHE.clear()
         _cur_bytes = 0
-    _CACHE[cache_key] = (commitment_b, weak_weight, result, nbytes)
+    _CACHE[cache_key] = (job_key, weak_weight, result, nbytes)
     _cur_bytes += nbytes
     return result
 

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -21,6 +21,7 @@ from .mining_state import (
     get_async_manager,
     get_pinned_pool,
 )
+from .weight_hash_cache import cached_weight_hash
 
 _LOGGER = get_logger("vllm.pearl_miner")
 
@@ -129,13 +130,14 @@ def pearl_gemm_noisy(
         tensor_hash_scratchpad,
     )
 
-    B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
-    tensor_hash(
-        B,
-        key_tensor,
-        B_tensor_hash,
-        tensor_hash_scratchpad,
-    )
+    # B is the layer weight (constant for the process); its keyed merkle root is
+    # cached across forward passes within a mining job (bit-identical to fresh).
+    def _hash_weight(B=B, key_tensor=key_tensor, scratchpad=tensor_hash_scratchpad):
+        out = torch.empty(32, device="cuda", dtype=torch.uint8)
+        tensor_hash(B, key_tensor, out, scratchpad)
+        return out
+
+    B_tensor_hash = cached_weight_hash(B, hash_key, _hash_weight)
 
     # Generate commitment hash for noise generation
     commitment_hash_A_tensor = torch.empty(32, device="cuda", dtype=torch.uint8)

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -197,8 +197,6 @@ def pearl_gemm_noisy(
     bpeb_cached = None
     EARxBpEB_int32 = None
     if use_bpeb_cache:
-        commitment_b_bytes = bytes(commitment_hash_B_tensor.cpu().numpy().tobytes())
-
         def _form_bpeb(B=B, EBR=EBR, EAR_K_major=EAR_K_major, EBL_R_major=EBL_R_major):
             # Form BpEB once per (weight, job) via the standalone noise_B op (the
             # EARxBpEB it also writes is scratch — recomputed fresh below).
@@ -208,18 +206,20 @@ def pearl_gemm_noisy(
                     EAR=EAR_K_major, EBL=EBL_R_major)
             return bpeb_out
 
-        bpeb_cached = cached_noised_weight(B, commitment_b_bytes, _form_bpeb)
+        bpeb_cached = cached_noised_weight(B, hash_key, _form_bpeb)
         BpEB = bpeb_cached
         # EARxBpEB = BpEB(n x k) @ EAR_R_major(k x r) -> (n x r), as int32 (the
         # kernel's denoise converter scales int32 -> fp16). fp32 + TF32 off is
         # bit-exact for these small-integer values; verified on H100.
         EARxBpEB_int32 = torch.empty((n, r), dtype=torch.int32, device=a.device)
         _prev_tf32 = torch.backends.cuda.matmul.allow_tf32
-        torch.backends.cuda.matmul.allow_tf32 = False
-        EARxBpEB_int32.copy_(
-            (BpEB.to(torch.float32) @ EAR_R_major.to(torch.float32)).to(torch.int32)
-        )
-        torch.backends.cuda.matmul.allow_tf32 = _prev_tf32
+        try:
+            torch.backends.cuda.matmul.allow_tf32 = False
+            EARxBpEB_int32.copy_(
+                (BpEB.to(torch.float32) @ EAR_R_major.to(torch.float32)).to(torch.int32)
+            )
+        finally:
+            torch.backends.cuda.matmul.allow_tf32 = _prev_tf32
 
     # Allocate A noising tensors (input-dependent)
     ApEA = torch.empty((m, k), dtype=torch.int8, device=a.device)

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -8,11 +8,13 @@ from pearl_gemm import (
     get_host_signal_sync_size,
     get_required_scratchpad_bytes,
     make_pow_target_tensor,
+    noise_B,
     noise_gen,
     noisy_gemm,
     tensor_hash,
 )
 
+from .bpeb_cache import cached_noised_weight
 from .callbacks import (
     StatusCheckCallback,
 )
@@ -170,9 +172,53 @@ def pearl_gemm_noisy(
         a.device,
     )
 
-    # Always compute B noising (depends on A through EAR)
+    # B-side noising: BpEB = B + EBL@EBR is A-INDEPENDENT (seeded by commitment_B,
+    # = blake3(job_key || merkle_root(B))), so it is identical across every forward
+    # pass within a mining job. Optionally cache it per (weight, commitment_B) and
+    # skip re-forming + re-writing the n x k int8 weight noising. The denoise
+    # side-product EARxBpEB = EAR @ BpEB is A-DEPENDENT (EAR is seeded by
+    # commitment_A) and is ALWAYS recomputed fresh from the cached BpEB, so the
+    # proof-of-work path is bit-unchanged.
     BpEB = torch.empty((n, k), dtype=torch.int8, device=a.device)
     EARxBpEB = torch.empty((n, r), dtype=torch.float16, device=a.device)
+
+    use_bpeb_cache = (
+        config.settings.cache_noised_weight
+        and layer is not None
+        and B.is_contiguous()
+    )
+    bpeb_cached = None
+    if use_bpeb_cache:
+        commitment_b_bytes = bytes(commitment_hash_B_tensor.cpu().numpy().tobytes())
+
+        def _noise_b(B=B, EBR=EBR, EAR_K_major=EAR_K_major, EBL_R_major=EBL_R_major):
+            # Produce ONLY BpEB (the cacheable, A-independent noised weight) via the
+            # standalone noise_B op; EARxBpEB it also writes here is discarded and
+            # recomputed fresh per call below.
+            bpeb_out = torch.empty((n, k), dtype=torch.int8, device=a.device)
+            earxbpeb_scratch = torch.empty((n, r), dtype=torch.float16, device=a.device)
+            noise_B(
+                B=B,
+                EBR=EBR,
+                EARxBpEB=earxbpeb_scratch,
+                BpEB=bpeb_out,
+                EAR=EAR_K_major,
+                EBL=EBL_R_major,
+            )
+            return bpeb_out
+
+        bpeb_cached = cached_noised_weight(B, commitment_b_bytes, _noise_b)
+        BpEB = bpeb_cached
+        # Recompute the A-dependent side-product from the cached weight:
+        # EARxBpEB = EAR @ BpEB (int32 reduction; the kernel's denoise_converter
+        # scales int32 -> fp16). Matches miner_base reference noise_B exactly.
+        # The kernel requires BOTH an int32 input and an fp16 output buffer
+        # (denoise converter writes int32 -> fp16), so allocate both.
+        EARxBpEB_int32 = torch.empty((n, r), dtype=torch.int32, device=a.device)
+        torch.matmul(
+            EAR_K_major.to(torch.int32), BpEB.to(torch.int32), out=EARxBpEB_int32
+        )
+        EARxBpEB = torch.empty((n, r), dtype=torch.float16, device=a.device)
 
     # Allocate A noising tensors (input-dependent)
     ApEA = torch.empty((m, k), dtype=torch.int8, device=a.device)
@@ -185,7 +231,9 @@ def pearl_gemm_noisy(
     # Create pow_target tensor from adjusted_target
     pow_target_tensor = make_pow_target_tensor(adjusted_target)
 
-    # Run noisy GEMM with default kernel configurations
+    # Run noisy GEMM with default kernel configurations.
+    # When BpEB is cached, skip the B-noising launch (run_noising_B=False): the
+    # main GEMM consumes the supplied cached BpEB + freshly-recomputed EARxBpEB.
     noisy_gemm(
         A=A,  # Input matrix A (m x k)
         B=B,  # Input matrix B (n x k)
@@ -198,7 +246,8 @@ def pearl_gemm_noisy(
         EAR_K_major=EAR_K_major,
         EBL_K_major=EBL_K_major,
         AxEBL_fp16=A_E_BL,  # Intermediate tensor A * E_BL (m x r)
-        EARxBpEB_fp16=EARxBpEB,  # Output tensor for EAR * BpEB (n x r)
+        EARxBpEB_fp16=EARxBpEB,  # fp16 output buffer (denoise converter target)
+        EARxBpEB_int32=EARxBpEB_int32 if use_bpeb_cache else None,
         ApEA=ApEA,  # Output tensor for A + EA (m x k)
         BpEB=BpEB,  # Output tensor for B + EB (n x k)
         A_scales=A_scales,  # Scale factors for A
@@ -212,7 +261,7 @@ def pearl_gemm_noisy(
         tile_size_n=config.settings.tile_size_n,
         tile_size_k=config.settings.tile_size_k,
         run_noising_A=True,  # run_noising_A
-        run_noising_B=True,  # run_noising_B
+        run_noising_B=not use_bpeb_cache,  # skip B-noising when BpEB is cached
         skip_reduction=False,  # skip_reduction
         skip_denoising=False,  # skip_denoising
     )
@@ -246,7 +295,10 @@ def pearl_gemm_noisy(
 
     del pow_target_tensor
     del ApEA
-    del BpEB
+    # BpEB may be a cache-owned tensor (do not release it back to the allocator
+    # while the cache holds a reference); drop only our local binding.
+    if bpeb_cached is None:
+        del BpEB
     del A_E_BL
     del EAL
     del EBR
@@ -262,6 +314,8 @@ def pearl_gemm_noisy(
     del tensor_hash_scratchpad
     del host_signal_sync
     del EARxBpEB
+    if use_bpeb_cache:
+        del EARxBpEB_int32
     return C
 
 

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -172,13 +172,20 @@ def pearl_gemm_noisy(
         a.device,
     )
 
-    # B-side noising: BpEB = B + EBL@EBR is A-INDEPENDENT (seeded by commitment_B,
-    # = blake3(job_key || merkle_root(B))), so it is identical across every forward
-    # pass within a mining job. Optionally cache it per (weight, commitment_B) and
-    # skip re-forming + re-writing the n x k int8 weight noising. The denoise
-    # side-product EARxBpEB = EAR @ BpEB is A-DEPENDENT (EAR is seeded by
-    # commitment_A) and is ALWAYS recomputed fresh from the cached BpEB, so the
-    # proof-of-work path is bit-unchanged.
+    # B-side noising. BpEB = B + EBL@EBR is A-INDEPENDENT (seeded by commitment_B
+    # = blake3(job_key || merkle_root(B))), so it is byte-identical across every
+    # forward pass within a mining job (proven vs miner_base; and on H100 the GEMM
+    # output C is bit-exact when a precomputed BpEB is supplied with
+    # run_noising_B=False). The mining job rotates ~1/s while a forward is ~ms, so
+    # caching BpEB per (weight, job) turns the dominant, m-independent weight-noising
+    # (forming EBL@EBR + the n x k int8 HBM write, ~0.17 ms/layer on gate_up) into a
+    # once-per-job cost that amortizes to ~0 over a long prefill.
+    #
+    # The denoise side-product EARxBpEB = BpEB @ EAR is A-DEPENDENT (EAR is seeded by
+    # commitment_A) and is recomputed fresh every call from the cached BpEB. Its
+    # values are small integers that fit exactly in fp32, so an fp32 matmul with TF32
+    # disabled is bit-exact and GPU-native (CUDA has no int matmul). The PoW path is
+    # therefore bit-unchanged on a hit.
     BpEB = torch.empty((n, k), dtype=torch.int8, device=a.device)
     EARxBpEB = torch.empty((n, r), dtype=torch.float16, device=a.device)
 
@@ -188,37 +195,31 @@ def pearl_gemm_noisy(
         and B.is_contiguous()
     )
     bpeb_cached = None
+    EARxBpEB_int32 = None
     if use_bpeb_cache:
         commitment_b_bytes = bytes(commitment_hash_B_tensor.cpu().numpy().tobytes())
 
-        def _noise_b(B=B, EBR=EBR, EAR_K_major=EAR_K_major, EBL_R_major=EBL_R_major):
-            # Produce ONLY BpEB (the cacheable, A-independent noised weight) via the
-            # standalone noise_B op; EARxBpEB it also writes here is discarded and
-            # recomputed fresh per call below.
+        def _form_bpeb(B=B, EBR=EBR, EAR_K_major=EAR_K_major, EBL_R_major=EBL_R_major):
+            # Form BpEB once per (weight, job) via the standalone noise_B op (the
+            # EARxBpEB it also writes is scratch — recomputed fresh below).
             bpeb_out = torch.empty((n, k), dtype=torch.int8, device=a.device)
-            earxbpeb_scratch = torch.empty((n, r), dtype=torch.float16, device=a.device)
-            noise_B(
-                B=B,
-                EBR=EBR,
-                EARxBpEB=earxbpeb_scratch,
-                BpEB=bpeb_out,
-                EAR=EAR_K_major,
-                EBL=EBL_R_major,
-            )
+            scratch = torch.empty((n, r), dtype=torch.float16, device=a.device)
+            noise_B(B=B, EBR=EBR, EARxBpEB=scratch, BpEB=bpeb_out,
+                    EAR=EAR_K_major, EBL=EBL_R_major)
             return bpeb_out
 
-        bpeb_cached = cached_noised_weight(B, commitment_b_bytes, _noise_b)
+        bpeb_cached = cached_noised_weight(B, commitment_b_bytes, _form_bpeb)
         BpEB = bpeb_cached
-        # Recompute the A-dependent side-product from the cached weight:
-        # EARxBpEB = EAR @ BpEB (int32 reduction; the kernel's denoise_converter
-        # scales int32 -> fp16). Matches miner_base reference noise_B exactly.
-        # The kernel requires BOTH an int32 input and an fp16 output buffer
-        # (denoise converter writes int32 -> fp16), so allocate both.
+        # EARxBpEB = BpEB(n x k) @ EAR_R_major(k x r) -> (n x r), as int32 (the
+        # kernel's denoise converter scales int32 -> fp16). fp32 + TF32 off is
+        # bit-exact for these small-integer values; verified on H100.
         EARxBpEB_int32 = torch.empty((n, r), dtype=torch.int32, device=a.device)
-        torch.matmul(
-            EAR_K_major.to(torch.int32), BpEB.to(torch.int32), out=EARxBpEB_int32
+        _prev_tf32 = torch.backends.cuda.matmul.allow_tf32
+        torch.backends.cuda.matmul.allow_tf32 = False
+        EARxBpEB_int32.copy_(
+            (BpEB.to(torch.float32) @ EAR_R_major.to(torch.float32)).to(torch.int32)
         )
-        EARxBpEB = torch.empty((n, r), dtype=torch.float16, device=a.device)
+        torch.backends.cuda.matmul.allow_tf32 = _prev_tf32
 
     # Allocate A noising tensors (input-dependent)
     ApEA = torch.empty((m, k), dtype=torch.int8, device=a.device)
@@ -231,9 +232,7 @@ def pearl_gemm_noisy(
     # Create pow_target tensor from adjusted_target
     pow_target_tensor = make_pow_target_tensor(adjusted_target)
 
-    # Run noisy GEMM with default kernel configurations.
-    # When BpEB is cached, skip the B-noising launch (run_noising_B=False): the
-    # main GEMM consumes the supplied cached BpEB + freshly-recomputed EARxBpEB.
+    # Run noisy GEMM with default kernel configurations
     noisy_gemm(
         A=A,  # Input matrix A (m x k)
         B=B,  # Input matrix B (n x k)
@@ -246,8 +245,8 @@ def pearl_gemm_noisy(
         EAR_K_major=EAR_K_major,
         EBL_K_major=EBL_K_major,
         AxEBL_fp16=A_E_BL,  # Intermediate tensor A * E_BL (m x r)
-        EARxBpEB_fp16=EARxBpEB,  # fp16 output buffer (denoise converter target)
-        EARxBpEB_int32=EARxBpEB_int32 if use_bpeb_cache else None,
+        EARxBpEB_fp16=EARxBpEB,  # fp16 output buffer (denoise-converter target on the cached path)
+        EARxBpEB_int32=EARxBpEB_int32,  # set on a cache hit; the GEMM skips B-noising
         ApEA=ApEA,  # Output tensor for A + EA (m x k)
         BpEB=BpEB,  # Output tensor for B + EB (n x k)
         A_scales=A_scales,  # Scale factors for A
@@ -295,8 +294,7 @@ def pearl_gemm_noisy(
 
     del pow_target_tensor
     del ApEA
-    # BpEB may be a cache-owned tensor (do not release it back to the allocator
-    # while the cache holds a reference); drop only our local binding.
+    # BpEB may be cache-owned (the cache holds a ref); drop only our local binding.
     if bpeb_cached is None:
         del BpEB
     del A_E_BL
@@ -314,7 +312,7 @@ def pearl_gemm_noisy(
     del tensor_hash_scratchpad
     del host_signal_sync
     del EARxBpEB
-    if use_bpeb_cache:
+    if EARxBpEB_int32 is not None:
         del EARxBpEB_int32
     return C
 

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -123,7 +123,7 @@ def pearl_gemm_noisy(
 
     A_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        A.to(torch.uint8),
+        A,
         key_tensor,
         A_tensor_hash,
         tensor_hash_scratchpad,
@@ -131,7 +131,7 @@ def pearl_gemm_noisy(
 
     B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        B.to(torch.uint8),
+        B,
         key_tensor,
         B_tensor_hash,
         tensor_hash_scratchpad,

--- a/miner/vllm-miner/src/vllm_miner/mining_state.py
+++ b/miner/vllm-miner/src/vllm_miner/mining_state.py
@@ -6,6 +6,7 @@ from miner_utils import get_logger
 from pearl_gateway.config import MinerRpcConfig
 from pearl_gemm import HostSignalHeaderPinnedPool
 
+from .bpeb_cache import clear_cache as clear_bpeb_cache
 from .config import config
 
 _LOGGER = get_logger("vllm.pearl_miner")
@@ -34,6 +35,7 @@ def init_async_manager(miner_settings: MinerSettings | None = None) -> None:
             miner_settings,
         )
         _async_manager.start()
+        _async_manager.register_mining_job_changed_callback(clear_bpeb_cache)
         config.settings = miner_settings
         _LOGGER.info(f"Mining state initalized, {miner_settings=}")
 

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -19,6 +19,7 @@ from pearl_gemm.moe import build_routing_data, get_build_routing_data_scratchpad
 from .config import config
 from .gemm_operators import generate_noise_factors
 from .mining_state import get_async_manager
+from .weight_hash_cache import cached_weight_hash
 
 _LOGGER = get_logger("vllm.pearl_miner")
 
@@ -148,7 +149,13 @@ def prepare_moe_noising(
     key_tensor = _to_gpu_u8(hash_key, device)
 
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
-    B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
+    # B_stacked is the static stacked expert weights; cache its keyed root across
+    # forward passes within a mining job (bit-identical to a fresh recompute).
+    B_hash = cached_weight_hash(
+        B_stacked,
+        hash_key,
+        lambda: _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device),
+    )
 
     num_routed_slots = num_tokens * top_k
     routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)

--- a/miner/vllm-miner/src/vllm_miner/weight_hash_cache.py
+++ b/miner/vllm-miner/src/vllm_miner/weight_hash_cache.py
@@ -1,0 +1,95 @@
+"""Cache for the keyed merkle hash of a static mining weight.
+
+The noisy mining GEMM hashes BOTH operands (``tensor_hash``) to seed the PoW
+commitment. The ``B`` operand is the layer weight: constant for the process
+lifetime, while the hash key only changes when the mining job changes (gateway
+polled ~1/s) and a forward pass runs in milliseconds. So ``tensor_hash(weight)``
+recomputes the identical 32-byte root every forward pass -- pure waste
+(0.13-0.41 ms/layer on H100, the dominant per-layer cost at decode batch sizes).
+
+This caches that root. A cached value is ALWAYS bit-identical to recomputing, so
+the proof-of-work path is unchanged; any uncertainty degrades to a redundant
+recompute, never a wrong hash:
+
+* the mining-job ``key`` bytes are part of the cache key -> a new job misses;
+* a ``weakref`` to the exact tensor is checked on a hit -> a freed/reused
+  ``data_ptr`` (ABA) misses and recomputes;
+* ``device`` (type + index) is part of the key -> CUDA ``data_ptr`` ints that
+  collide across GPUs cannot produce a wrong hit.
+
+Entries self-evict via a ``weakref`` finalizer when their weight is garbage
+collected (a size cap is kept only as a backstop for non-collectable churn).
+
+Dict operations are atomic under the GIL, and all mining ops run on the default
+CUDA stream (no explicit streams in the plugin), so the cached tensor's producing
+``tensor_hash`` is ordered before any consumer on the same stream — identical to
+the un-cached code's own same-stream assumption.
+
+Validity assumes the weight is IMMUTABLE (Pearl weights are persistent
+``nn.Parameter``s set once at load and never mutated in place). The cache cannot
+detect in-place mutation of the same object (``copy_``/``set_``/adapter swaps);
+call :func:`clear_cache` on any such weight-reload path.
+"""
+
+import weakref
+from collections.abc import Callable
+
+import torch
+
+_CACHE: dict[tuple, tuple] = {}
+_MAX_ENTRIES = 4096
+
+
+def cached_weight_hash(
+    weight: torch.Tensor,
+    key_bytes: bytes,
+    compute: Callable[[], torch.Tensor],
+) -> torch.Tensor:
+    """Return the keyed merkle hash of ``weight``, reusing a cached value only
+    when the exact same (still-alive) tensor and mining-job key are unchanged.
+
+    On any miss it calls ``compute()`` (which must produce the hash) and caches
+    the result; the returned bytes are always identical to recomputing.
+    """
+    cache_key = (
+        weight.device.type,
+        weight.device.index,
+        weight.data_ptr(),
+        tuple(weight.shape),
+        weight.dtype,
+    )
+    entry = _CACHE.get(cache_key)
+    if entry is not None:
+        cached_key_bytes, weak_weight, cached_hash = entry
+        if cached_key_bytes == key_bytes and weak_weight() is weight:
+            return cached_hash
+
+    result = compute()
+
+    # Register a finalizer so the entry is dropped as soon as `weight` is GC'd,
+    # instead of lingering until the size cap clears the whole cache. The
+    # `entry[1] is ref` check ensures a finalizer only removes ITS OWN entry and
+    # never a newer one that reused the same cache_key (e.g. data_ptr reuse).
+    def _evict(ref: weakref.ref, key: tuple = cache_key) -> None:
+        entry = _CACHE.get(key)
+        if entry is not None and entry[1] is ref:
+            _CACHE.pop(key, None)
+
+    try:
+        weak_weight = weakref.ref(weight, _evict)
+    except TypeError:
+        return result  # not weak-referenceable: skip caching (still correct)
+    if len(_CACHE) >= _MAX_ENTRIES:  # backstop for non-collectable churn
+        _CACHE.clear()
+    _CACHE[cache_key] = (key_bytes, weak_weight, result)
+    return result
+
+
+def clear_cache() -> None:
+    """Drop all cached weight hashes (test/maintenance helper)."""
+    _CACHE.clear()
+
+
+def cache_size() -> int:
+    """Number of live cache entries (introspection/test helper)."""
+    return len(_CACHE)

--- a/miner/vllm-miner/tests/test_bpeb_cache.py
+++ b/miner/vllm-miner/tests/test_bpeb_cache.py
@@ -1,0 +1,124 @@
+"""Unit tests for the noised-weight (BpEB) cache.
+
+These test the CACHE SEMANTICS in isolation (no GPU / no kernels): a miss
+computes, a repeat hit returns the same object without recomputing, a mining-job
+change (different commitment_B) recomputes, ABA (a freed/reused data_ptr) does
+not false-hit, and the byte budget bounds memory. The numerical
+bit-exactness of reusing BpEB across forward passes within a job is proven
+separately against miner_base in pearl-pr-plan/proofs/prove_bpeb_invariant.py
+and is exercised end-to-end by the GPU equivalence test.
+
+Run: cd miner/vllm-miner && uv run pytest tests/test_bpeb_cache.py -v
+"""
+
+import torch
+from vllm_miner.bpeb_cache import (
+    cache_bytes,
+    cache_size,
+    cached_noised_weight,
+    clear_cache,
+)
+
+
+def _weight(n=8, k=16):
+    return torch.zeros((n, k), dtype=torch.int8)
+
+
+def setup_function(_):
+    clear_cache()
+
+
+def test_miss_computes_then_hit_does_not_recompute():
+    w = _weight()
+    cb = b"job-A" + b"\x00" * 27
+    calls = {"n": 0}
+
+    def compute():
+        calls["n"] += 1
+        return torch.full_like(w, 7)
+
+    out1 = cached_noised_weight(w, cb, compute)
+    assert calls["n"] == 1
+    out2 = cached_noised_weight(w, cb, compute)
+    assert calls["n"] == 1, "a hit must NOT recompute"
+    assert out2 is out1, "a hit returns the cached object"
+    assert torch.equal(out1, torch.full_like(w, 7))
+
+
+def test_job_change_recomputes():
+    w = _weight()
+    calls = {"n": 0}
+
+    def compute():
+        calls["n"] += 1
+        return torch.full_like(w, calls["n"])
+
+    a = cached_noised_weight(w, b"job-A" + b"\x00" * 27, compute)
+    b = cached_noised_weight(w, b"job-B" + b"\x00" * 27, compute)
+    assert calls["n"] == 2, "a new commitment_B (job change) must recompute"
+    assert not torch.equal(a, b)
+    # cache holds the latest; the stale job-A bytes were reclaimed (one live entry).
+    assert cache_size() == 1
+
+
+def test_different_weights_do_not_alias():
+    w1 = _weight()
+    w2 = _weight()
+    cb = b"job-A" + b"\x00" * 27
+
+    o1 = cached_noised_weight(w1, cb, lambda: torch.full_like(w1, 1))
+    o2 = cached_noised_weight(w2, cb, lambda: torch.full_like(w2, 2))
+    assert torch.equal(o1, torch.full_like(w1, 1))
+    assert torch.equal(o2, torch.full_like(w2, 2))
+    assert cache_size() == 2
+
+
+def test_aba_freed_and_reused_data_ptr_does_not_false_hit():
+    """If a weight is freed and a new tensor reuses the same data_ptr, the
+    weakref check must miss and recompute rather than return the stale BpEB."""
+    cb = b"job-A" + b"\x00" * 27
+    calls = {"n": 0}
+
+    def make_and_cache(val):
+        w = _weight()
+        calls["n"] += 1
+
+        def compute(v=val, ww=w):
+            return torch.full_like(ww, v)
+
+        return cached_noised_weight(w, cb, compute), w
+
+    out1, w1 = make_and_cache(1)
+    ptr1 = w1.data_ptr()
+    del w1, out1  # free the weight -> finalizer should evict its entry
+
+    # Allocate until we (likely) reuse the address; correctness does not depend on
+    # actually hitting the same data_ptr -- only that no false hit ever occurs.
+    for _ in range(64):
+        out2, w2 = make_and_cache(2)
+        if w2.data_ptr() == ptr1:
+            assert torch.equal(out2, torch.full_like(w2, 2)), "must be the NEW weight's BpEB"
+            break
+        del w2, out2
+
+
+def test_weakref_finalizer_evicts_on_gc():
+    cb = b"job-A" + b"\x00" * 27
+    w = _weight()
+    cached_noised_weight(w, cb, lambda ww=w: torch.full_like(ww, 3))
+    assert cache_size() == 1
+    del w
+    import gc
+
+    gc.collect()
+    assert cache_size() == 0, "entry must self-evict when its weight is GC'd"
+    assert cache_bytes() == 0
+
+
+def test_byte_budget_is_tracked_and_reclaimed():
+    cb = b"job-A" + b"\x00" * 27
+    w = _weight(n=8, k=16)  # 128 int8 bytes
+    out = cached_noised_weight(w, cb, lambda: torch.zeros_like(w))
+    assert cache_bytes() == out.element_size() * out.nelement() == 128
+    clear_cache()
+    assert cache_bytes() == 0 and cache_size() == 0

--- a/miner/vllm-miner/tests/test_bpeb_cache.py
+++ b/miner/vllm-miner/tests/test_bpeb_cache.py
@@ -2,7 +2,7 @@
 
 These test the CACHE SEMANTICS in isolation (no GPU / no kernels): a miss
 computes, a repeat hit returns the same object without recomputing, a mining-job
-change (different commitment_B) recomputes, ABA (a freed/reused data_ptr) does
+change (different job key) recomputes, ABA (a freed/reused data_ptr) does
 not false-hit, and the byte budget bounds memory. The numerical
 bit-exactness of reusing BpEB across forward passes within a job is proven
 separately against miner_base in pearl-pr-plan/proofs/prove_bpeb_invariant.py
@@ -55,7 +55,7 @@ def test_job_change_recomputes():
 
     a = cached_noised_weight(w, b"job-A" + b"\x00" * 27, compute)
     b = cached_noised_weight(w, b"job-B" + b"\x00" * 27, compute)
-    assert calls["n"] == 2, "a new commitment_B (job change) must recompute"
+    assert calls["n"] == 2, "a new job key must recompute"
     assert not torch.equal(a, b)
     # cache holds the latest; the stale job-A bytes were reclaimed (one live entry).
     assert cache_size() == 1

--- a/miner/vllm-miner/tests/test_pearl_noisy_gemm.py
+++ b/miner/vllm-miner/tests/test_pearl_noisy_gemm.py
@@ -407,3 +407,57 @@ def test_pearl_gemm_noisy_with_controlled_noise(make_random_test_matrices):
         )
     else:
         print("✓ Confirmed that denoising produces consistent results across runs")
+
+
+def test_weight_hash_cache_hits_invalidates_and_is_aba_safe():
+    """The static-weight hash cache must: return the computed value on a miss,
+    reuse it on a hit, recompute when the mining-job key changes, and never
+    return a stale value when a freed tensor's data_ptr is reused (ABA). A wrong
+    cached hash would silently corrupt the PoW commitment, so this is the guard.
+    """
+    import gc
+
+    from vllm_miner import weight_hash_cache as whc
+
+    calls = {"n": 0}
+
+    def make_hash(tag: int):
+        def _compute():
+            calls["n"] += 1
+            return torch.tensor([tag] * 32, dtype=torch.uint8)
+
+        return _compute
+
+    whc.clear_cache()
+    w = torch.zeros(256, dtype=torch.int8)
+    k1, k2 = b"\x01" * 32, b"\x02" * 32
+
+    h1 = whc.cached_weight_hash(w, k1, make_hash(1))  # miss -> compute
+    h2 = whc.cached_weight_hash(w, k1, make_hash(9))  # hit -> cached (compute not called)
+    assert h1.tolist() == [1] * 32
+    assert h2 is h1, "repeat call with same tensor+key must reuse the cached value"
+    assert calls["n"] == 1, "a hit must not recompute"
+
+    h3 = whc.cached_weight_hash(w, k2, make_hash(2))  # key change -> recompute
+    assert h3.tolist() == [2] * 32 and calls["n"] == 2, "key change must recompute"
+
+    # ABA: free w, reuse its address with a different tensor -> must NOT false-hit.
+    whc.clear_cache()
+    calls["n"] = 0
+    a = torch.zeros(256, dtype=torch.int8)
+    whc.cached_weight_hash(a, k1, make_hash(1))
+    del a
+    gc.collect()
+    b = torch.zeros(256, dtype=torch.int8)  # may reuse the freed address
+    out = whc.cached_weight_hash(b, k1, make_hash(2))
+    assert out.tolist() == [2] * 32, "a different (live) tensor must recompute, even if addr reused"
+
+    # GC finalizer: a cached weight that is freed must auto-evict its entry.
+    whc.clear_cache()
+    c = torch.zeros(256, dtype=torch.int8)
+    whc.cached_weight_hash(c, k1, make_hash(1))
+    assert whc.cache_size() == 1
+    del c
+    gc.collect()
+    assert whc.cache_size() == 0, "freeing a cached weight must evict its entry"
+    whc.clear_cache()

--- a/miner/vllm-miner/tests/test_reference_vs_kernels.py
+++ b/miner/vllm-miner/tests/test_reference_vs_kernels.py
@@ -77,8 +77,8 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Create random int8 tensor for MatrixMerkleTree
         matrix_int8 = torch.randint(-128, 127, (m, n), dtype=torch.int8)
 
-        # Convert to uint8 for tensor_hash (CUDA implementation expects uint8)
-        matrix_uint8 = matrix_int8.to(torch.uint8).cuda()
+        matrix_cuda = matrix_int8.cuda()
+        matrix_uint8 = matrix_cuda.to(torch.uint8)
 
         # Create key tensor for CUDA implementation
         key_tensor = _to_cuda_u8(test_noise_seed_A)
@@ -89,16 +89,19 @@ class TestMatrixMerkleTreeVsTensorHash:
 
         # Compute hash using tensor_hash (CUDA implementation)
         cuda_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
+        cast_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
         tensor_hash_scratchpad = torch.empty(
-            pearl_gemm.get_required_scratchpad_bytes(matrix_uint8.numel()),
+            pearl_gemm.get_required_scratchpad_bytes(matrix_cuda.numel()),
             device="cuda",
             dtype=torch.uint8,
         )
-        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_cuda, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cast_result, tensor_hash_scratchpad)
         torch.cuda.synchronize()
 
         # Convert CUDA result back to bytes for comparison
         cuda_root = cuda_result.cpu().numpy().tobytes()
+        cast_root = cast_result.cpu().numpy().tobytes()
 
         blake3_result = blake3(matrix_int8.cpu().numpy().tobytes(), key=test_noise_seed_A).digest()
 
@@ -109,6 +112,9 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Compare results
         assert python_root == cuda_root, (
             f"Hash mismatch for shape {m, n}: MatrixMerkleTree root doesn't match tensor_hash result"
+        )
+        assert cuda_root == cast_root, (
+            f"Hash mismatch for shape {m, n}: direct int8 tensor_hash differs from uint8 cast path"
         )
 
     def test_commitment_hash_reference_vs_cuda(self, test_noise_seed_A):


### PR DESCRIPTION
Status: **closed, negative H100 benchmark. Do not reopen as-is.**

Stack layer 3/3 was the BpEB cache idea on top of:
- #193: direct int8 tensor_hash, no uint8 staging casts
- #187: static weight tensor_hash cache

The idea was to cache `BpEB = B + E_BL @ E_BR` per `(weight, mining job key)`. `BpEB` is independent of the activation M dimension, so it looked reusable across forward passes for the same static weight and job.

## Modal H100 benchmark

Modal run: https://modal.com/apps/avifenesh/main/ap-FhZhSNOGM8wjf1EeQCFxRp

Environment: `NVIDIA H100 80GB HBM3`, CUDA `sm_90`, Torch `2.11.0+cu130`, repo Dockerfile image.

This compares the stacked branch with `MINER_CACHE_NOISED_WEIGHT=0` versus `MINER_CACHE_NOISED_WEIGHT=1` steady-state cache hits, interleaved per cycle.

| shape | cache OFF median | BpEB cache HIT median | result |
|---|---:|---:|---:|
| gate_up 4096x28672x4096 | 1.861 ms | 2.739 ms | **-32.0%** |
| gate_up threshold 1024x28672x4096 | 1.171 ms | 2.037 ms | **-42.5%** |
| down 4096x4096x14336 | 1.315 ms | 1.684 ms | **-21.9%** |
| square 4096x4096x4096 | 0.939 ms | 1.026 ms | **-8.4%** |

First miss is also bad where the cached tensor is large: gate_up 4096 first miss was 165.36 ms.

## Reason

Caching `BpEB` avoids standalone B noising/write, but the current hit path recomputes the A-dependent side product `EARxBpEB` using dense fp32 Torch matmul with TF32 disabled. That replacement costs more than the B-side noising it removes.

## Verdict

The branch is correct but not a performance win. Keep closed unless/until there is a dedicated CUDA `EARxBpEB` side-product path or another benchmark-backed implementation that beats cache OFF.
