### PR TITLE
Add real-prompt EAGLE mining benchmark

### DIFF
--- a/docs/pearl-eagle-real-prompt-benchmark.md
+++ b/docs/pearl-eagle-real-prompt-benchmark.md
@@ -1,0 +1,553 @@
+# Pearl EAGLE real-prompt mining benchmark
+
+Date: 2026-06-17
+
+This note captures the benchmark evidence for Pearl-specific EAGLE speculative
+decoding as a mining enabler. The primary comparator is **vanilla no-mining**,
+not vanilla mining. Vanilla mining is only a diagnostic that shows the old mining
+tax.
+
+The conservative C=32 PR result is that **EAGLE + mining beats vanilla
+no-mining on real prompts from ~128 tokens upward**. Under that canonical serving
+load, mining becomes *serving-throughput-free* from ~128 tokens onward: the
+mining-capable EAGLE path is faster than the no-mining baseline, so the mined
+work is not paid for with lower serving throughput. The throughput-positive
+bound for enabling the mining-capable path drops from the old ~1024-token
+heuristic to ~128 tokens: about an 8x reduction, i.e. the practical "~10x lower
+bound" story.
+
+The very-short `<128` bucket is useful but noisier: one run had K2 positive, the
+canonical C=32 repeats had K2/K3 negative. Treat `<128` as experimental
+follow-up, not the headline claim. Later C sweeps show the bound is
+concurrency-sensitive, so production policy should be validated at the target
+serving concurrency instead of treated as universal. Across C1/C4/C16/C32, the
+best EAGLE+mining configuration is serving-throughput-free or better for the
+policy-relevant buckets. At C64, the result is mixed against vanilla no-mining
+(positive at ~128–512, roughly near/touching no-mining for the longest bucket,
+weaker at 513–1024), but EAGLE remains meaningfully better than vanilla mining
+for long prompts.
+
+## Novelty: EAGLE changes where noise is paid
+
+The important mechanism is not merely "lower a prompt threshold". The novelty is
+that EAGLE changes **where the noisy mining work is paid** in the serving path.
+
+Vanilla mining pays noisy GEMM as a pure tax in the normal target-model path. In
+contrast, Pearl-specific EAGLE puts the mining-capable target work behind the
+speculative decode / verification loop: a target pass can validate multiple
+drafted tokens, and accepted draft tokens amortize the noisy target work. That is
+why `EAGLE + mining` can beat `vanilla no-mining` instead of just beating
+`vanilla mining`.
+
+This is **not** a prefill trick and not a change to the GEMM shape threshold. The
+existing noisy-GEMM gate remains at `min_m/min_n/min_k = 1024`. The benchmark
+shows that, when the noisy target path is used inside speculative decoding, the
+noise is paid in a different part of the generation loop and becomes hidden/net
+positive in the validated regimes.
+
+## Why real prompts are required
+
+Random-token throughput benchmarks are useful stress tests, but they are a poor
+proxy for EAGLE. EAGLE is trained to predict the verifier's natural next-token
+distribution. Random prompts/continuations are close to adversarial for the
+acceptance metric and materially understate the useful win.
+
+Use real prompts for PR/performance evidence, and treat random-token results as
+stress-only. The primary metric in this note is request throughput (`req/s`) at
+fixed `max_tokens=96`, greedy decoding, and the stated client concurrency.
+
+## Artifact under test
+
+Scratch Pearl EAGLE3 checkpoint trained on the 200k seq4096 hidden-state run:
+
+```text
+/workspace/pearl_eagle3_train_200k_seq4096/output/checkpoints_eagle3_scratch/3
+```
+
+The lower-learning-rate checkpoint was also evaluated and is weaker:
+
+```text
+/workspace/pearl_eagle3_train_200k_seq4096/output/checkpoints_eagle3_lr5e5/4
+```
+
+## Held-out acceptance eval
+
+Dataset: `RedHatAI/speculator_benchmarks`, 9 subsets × 16 prompts, `max_tokens=96`.
+
+| checkpoint | K | acceptance length | draft-token accept | pos0 | pos1 |
+|---|---:|---:|---:|---:|---:|
+| scratch | 2 | **1.750** | **37.5%** | **49.6%** | **25.4%** |
+| lr5e5 | 2 | 1.355 | 17.7% | 29.2% | 6.2% |
+
+The scratch checkpoint is the one worth using for throughput and policy work.
+
+Scratch K=2 by subset:
+
+| subset | acceptance length | draft-token accept |
+|---|---:|---:|
+| qa | 1.60 | 30.1% |
+| writing | 1.77 | 38.7% |
+| summarization | 1.90 | 45.2% |
+| math_reasoning | 1.90 | 45.0% |
+| HumanEval | 1.93 | 46.7% |
+| translation | 1.42 | 21.0% |
+| question | 1.77 | 38.6% |
+| rag | 1.76 | 38.0% |
+| tool_call | 1.82 | 40.9% |
+
+## Real-prompt throughput, mixed prompt lengths
+
+Dataset: `RedHatAI/speculator_benchmarks`, 9 subsets × 24 prompts, `max_tokens=96`, concurrency 32.
+
+| case | req/s | output tok/s | total tok/s | acceptance length | draft-token accept |
+|---|---:|---:|---:|---:|---:|
+| vanilla no-mining | 12.90 | 1238.6 | 4544.7 | — | — |
+| vanilla mining | 11.71 | 1124.1 | 4124.4 | — | — |
+| scratch EAGLE K2 mining | 14.66 | 1407.6 | 5164.5 | 1.742 | 37.1% |
+| scratch EAGLE K3 mining | **14.80** | **1421.1** | **5214.1** | 1.831 | 27.7% |
+| scratch EAGLE K4 mining | 14.29 | 1372.3 | 5035.1 | 1.892 | 22.3% |
+
+Relative to vanilla no-mining:
+
+- EAGLE K2 mining: +13.6% req/s.
+- EAGLE K3 mining: +14.7% req/s.
+- EAGLE K4 mining: +10.8% req/s.
+
+Relative to vanilla mining:
+
+- EAGLE K2 mining: +25.2% req/s.
+- EAGLE K3 mining: +26.4% req/s.
+- EAGLE K4 mining: +22.1% req/s.
+
+## Length-bucket throughput
+
+Dataset: `RedHatAI/speculator_benchmarks`, prompts bucketed by Pearl tokenizer
+input length, `max_tokens=96`, concurrency 32. Buckets used up to 64 prompts each
+(the 1025–2048 bucket had 39 prompts available).
+
+| avg prompt len | vanilla no-mining | vanilla mining | EAGLE K2 mining | EAGLE K3 mining |
+|---:|---:|---:|---:|---:|
+| 44 | 12.83 | 12.76 | **14.07** | 12.88 |
+| 182 | 12.82 | 12.55 | 14.58 | **16.15** |
+| 351 | 12.26 | 11.86 | **14.67** | 14.61 |
+| 699 | 11.75 | 10.98 | 12.75 | **13.10** |
+| 1331 | 7.42 | 6.78 | 8.91 | **9.75** |
+
+Relative to vanilla no-mining:
+
+| avg prompt len | EAGLE K2 mining | EAGLE K3 mining |
+|---:|---:|---:|
+| 44 | **+9.6%** | +0.4% |
+| 182 | +13.7% | **+25.9%** |
+| 351 | **+19.6%** | +19.1% |
+| 699 | +8.5% | **+11.4%** |
+| 1331 | +20.1% | **+31.4%** |
+
+Acceptance by bucket:
+
+| avg prompt len | K2 acceptance length | K2 draft accept | K3 acceptance length | K3 draft accept |
+|---:|---:|---:|---:|---:|
+| 44 | 1.697 | 34.8% | 1.794 | 26.5% |
+| 182 | 1.830 | 41.5% | 1.954 | 31.8% |
+| 351 | 1.863 | 43.2% | 2.004 | 33.5% |
+| 699 | 1.945 | 47.3% | 2.101 | 36.7% |
+| 1331 | 1.826 | 41.3% | 1.960 | 32.0% |
+
+### Canonical rerun R1
+
+The first canonical rerun used the harness in this repo with the same buckets,
+`max_tokens=96`, greedy decoding, concurrency 32, and the scratch checkpoint. It
+confirms the main result from ~128 tokens upward, while showing that `<128` is
+noisy and should not be the headline claim yet.
+
+| avg prompt len | vanilla no-mining | vanilla mining | EAGLE K2 mining | EAGLE K3 mining |
+|---:|---:|---:|---:|---:|
+| 49.8 | 13.03 | 12.80 (-1.8%) | 12.41 (-4.7%) | 11.96 (-8.2%) |
+| 186.6 | 12.82 | 13.09 (+2.1%) | 14.05 (+9.6%) | 15.64 (+22.0%) |
+| 350.0 | 12.32 | 12.09 (-1.9%) | 14.22 (+15.4%) | 13.17 (+6.9%) |
+| 708.3 | 11.68 | 11.02 (-5.6%) | 12.29 (+5.3%) | 12.25 (+4.9%) |
+| 1331.3 | 7.38 | 6.92 (-6.2%) | 9.01 (+22.2%) | 8.88 (+20.4%) |
+
+R1 supports the conservative policy bound:
+
+```text
+prompt_len >= 128: EAGLE + mining beats vanilla no-mining
+prompt_len < 128: keep experimental / validate more before defaulting
+```
+
+### Canonical rerun aggregate: R1–R3
+
+Raw outputs on AWS:
+
+```text
+/workspace/real_prompt_length_bucket_canonical_r1/combined_summary.csv
+/workspace/real_prompt_length_bucket_canonical_r2/combined_summary.csv
+/workspace/real_prompt_length_bucket_canonical_r3/combined_summary.csv
+```
+
+Three canonical reruns make the conservative bound clearer. The table reports
+mean deltas against the primary baseline, `vanilla_no_mining`; ranges in
+parentheses are the min/max delta across the three runs.
+
+| avg prompt len | vanilla no-mining req/s | vanilla mining | EAGLE K2 mining | EAGLE K3 mining | best EAGLE |
+|---:|---:|---:|---:|---:|---:|
+| 49.8 | 13.03 | -2.7% | -4.5% (-7.7..-1.1) | -4.1% (-8.2..-1.0) | -4.1% |
+| 186.6 | 12.87 | -2.0% | +21.3% (+9.6..+31.8) | +22.1% (+18.9..+25.3) | +22.1% |
+| 350.0 | 12.44 | -4.7% | +14.9% (+12.0..+17.4) | +8.9% (+6.9..+10.5) | +14.9% |
+| 708.3 | 11.80 | -6.9% | +4.4% (+1.6..+6.5) | +3.7% (+1.6..+4.9) | +4.4% |
+| 1331.3 | 7.45 | -8.7% | +19.2% (+16.8..+22.2) | +21.7% (+20.4..+23.9) | +21.7% |
+
+Mean acceptance across R1–R3 stayed healthy:
+
+| avg prompt len | K2 acceptance length | K2 draft accept | K3 acceptance length | K3 draft accept |
+|---:|---:|---:|---:|---:|
+| 49.8 | 1.714 | 35.7% | 1.796 | 26.5% |
+| 186.6 | 1.854 | 42.7% | 1.999 | 33.3% |
+| 350.0 | 1.821 | 41.1% | 1.939 | 31.3% |
+| 708.3 | 1.846 | 42.3% | 1.967 | 32.2% |
+| 1331.3 | 1.845 | 42.2% | 1.977 | 32.6% |
+
+The robust C=32 claim is therefore:
+
+```text
+At the canonical C=32 load, EAGLE lowers the throughput-positive mining bound from ~1024 tokens to ~128 tokens.
+```
+
+Equivalently: from ~128 tokens onward, mining is throughput-free in this setup
+because `EAGLE + mining` is faster than `vanilla no-mining`. Above ~1024 tokens,
+the result is not merely throughput-free: the best EAGLE+mining case is about
++22% vs no-mining and about +34% vs vanilla mining across the R1–R3 repeats.
+
+The `<128` bucket is not a serving win in these canonical repeats despite good
+acceptance, so it should not be part of the headline policy.
+
+### Concurrency + K4 validation sweep
+
+Raw outputs on AWS:
+
+```text
+/workspace/real_prompt_length_bucket_c16_k4/combined_summary.csv
+/workspace/real_prompt_length_bucket_c32_k4/combined_summary.csv
+/workspace/real_prompt_length_bucket_c64_k4/combined_summary.csv
+```
+
+A follow-up sweep checked C=16/32/64 and added K4. This was a validation sweep,
+not the primary PR evidence. It shows two useful things:
+
+1. At C16/C32/C64, K4 is not the best choice in any tested bucket.
+2. The throughput win is concurrency-sensitive; C=64 needs separate production
+   validation before using the same ~128-bound policy.
+
+| C | avg prompt len | vanilla no-mining req/s | vanilla mining | K2 mining | K3 mining | K4 mining | best EAGLE |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 16 | 49.8 | 7.40 | +0.1% | +1.8% | +6.9% | +3.5% | K3 +6.9% |
+| 16 | 186.6 | 7.47 | -4.8% | +23.8% | +19.9% | +20.5% | K2 +23.8% |
+| 16 | 350.0 | 7.31 | -4.7% | +15.3% | +13.5% | +13.0% | K2 +15.3% |
+| 16 | 708.3 | 7.12 | -8.6% | +8.0% | +13.7% | +10.3% | K3 +13.7% |
+| 16 | 1331.3 | 5.61 | -13.9% | +1.0% | +3.6% | +3.3% | K3 +3.6% |
+| 32 | 49.8 | 12.93 | -1.4% | -5.8% | -4.1% | -4.9% | K3 -4.1% |
+| 32 | 186.6 | 12.64 | -1.1% | +22.2% | +30.3% | +14.3% | K3 +30.3% |
+| 32 | 350.0 | 12.19 | -5.3% | +14.7% | +13.5% | +11.4% | K2 +14.7% |
+| 32 | 708.3 | 11.65 | -7.6% | +2.4% | +7.0% | -3.7% | K3 +7.0% |
+| 32 | 1331.3 | 7.48 | -9.8% | +17.5% | +24.0% | +14.5% | K3 +24.0% |
+| 64 | 49.8 | 23.90 | -6.4% | -19.6% | -14.3% | -22.9% | K3 -14.3% |
+| 64 | 186.6 | 24.96 | -12.5% | +5.3% | +1.9% | -0.1% | K2 +5.3% |
+| 64 | 350.0 | 23.24 | -13.7% | +6.2% | +5.6% | +0.1% | K2 +6.2% |
+| 64 | 708.3 | 20.21 | -11.8% | -10.3% | -8.7% | -10.9% | K3 -8.7% |
+| 64 | 1331.3 | 11.75 | -13.6% | -6.1% | -2.9% | -9.1% | K3 -2.9% |
+
+Interpretation of the C16/C32/C64 sweep:
+
+- K4 increases acceptance length but loses enough throughput that it should not
+  be the default at C16+.
+- C16 is under-saturated enough that EAGLE helps broadly.
+- C32 is the stable canonical point for the ~128-bound claim.
+- C64 is a different serving regime: vanilla no-mining is much faster. In this
+  quick sweep, EAGLE stays positive vs vanilla no-mining in the ~128–512 buckets,
+  is close to no-mining in the longest bucket, and is weaker in the 513–1024
+  bucket. Do not generalize the C32 policy to C64 without a larger/interleaved
+  run at the target production concurrency.
+- At C64 long prompts, EAGLE still improves over **vanilla mining**: K3 is +3.5%
+  vs vanilla mining in the 513–1024 bucket and +12.3% vs vanilla mining in the
+  1025–2048 bucket, even though those buckets are -8.7% and -2.9% vs vanilla
+  no-mining respectively. This distinction matters: at high concurrency EAGLE is
+  no longer always faster than no-mining, but it still hides a meaningful part of
+  the mining tax.
+
+### Very-low-concurrency sweep: C1/C4
+
+Raw outputs on AWS:
+
+```text
+/workspace/real_prompt_length_bucket_c1_k4/combined_summary.csv
+/workspace/real_prompt_length_bucket_c4_k4/combined_summary.csv
+```
+
+Very low concurrency is a different regime. Here EAGLE improves every tested
+bucket, including `<128`, and deeper drafting becomes useful. K4 wins at C4;
+K3 wins at C1.
+
+| C | avg prompt len | vanilla no-mining req/s | vanilla mining | K2 mining | K3 mining | K4 mining | best EAGLE |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 49.8 | 0.47 | -0.8% | +37.4% | +43.4% | +39.8% | K3 +43.4% |
+| 1 | 186.6 | 0.46 | +2.0% | +50.6% | +62.3% | +54.5% | K3 +62.3% |
+| 1 | 350.0 | 0.46 | +3.0% | +49.4% | +61.8% | +52.8% | K3 +61.8% |
+| 1 | 708.3 | 0.47 | -0.2% | +51.5% | +63.3% | +57.2% | K3 +63.3% |
+| 1 | 1331.3 | 0.47 | -3.8% | +44.4% | +53.7% | +47.5% | K3 +53.7% |
+| 4 | 49.8 | 1.89 | -4.9% | +30.4% | +28.3% | +32.7% | K4 +32.7% |
+| 4 | 186.6 | 1.90 | -5.0% | +37.3% | +39.3% | +43.8% | K4 +43.8% |
+| 4 | 350.0 | 1.89 | -5.2% | +42.0% | +40.7% | +44.5% | K4 +44.5% |
+| 4 | 708.3 | 1.90 | -7.4% | +43.9% | +42.2% | +49.0% | K4 +49.0% |
+| 4 | 1331.3 | 1.82 | -10.4% | +26.7% | +26.8% | +29.9% | K4 +29.9% |
+
+Interpretation of the low-C sweep:
+
+- If serving is deliberately low-concurrency / latency-oriented, EAGLE+mining can
+  be beneficial even below 128 tokens.
+- K4 should not be globally dismissed: it wins at C4, but loses at C1 and at
+  C16+.
+- The production policy should therefore use concurrency/load as part of the
+  rollout guard, not only prompt length. Up through C32, the evidence supports
+  the "free-or-better than no-mining" framing for the policy-relevant buckets;
+  at C64, use the more careful framing: near no-mining in the longest bucket,
+  still better than vanilla mining, and mixed elsewhere.
+
+### Mining-path validation
+
+To verify the benchmark was actually mining, a tiny instrumented validation run
+wrapped `pearl_gemm_noisy()` in the vLLM worker process and traced calls while
+serving one long real prompt with mining enabled. Raw trace:
+
+```text
+/workspace/noisy_gemm_trace.jsonl
+```
+
+The trace recorded 640 calls into the actual noisy-GEMM mining function across
+2 EngineCore worker PIDs. Example shapes:
+
+```text
+m=1927, n=4096,  k=4096
+m=1927, n=28672, k=4096
+m=1927, n=6144,  k=4096
+```
+
+`submit_block=false` in the trace is expected: the benchmark sets
+`MINER_SKIP_BLOCK_SUBMISSION=1` so it exercises noisy GEMM / noise generation
+without submitting found blocks.
+
+## Interpretation
+
+For PR and product decisions, compare against **vanilla no-mining**. That is the
+real baseline: if EAGLE+mining beats it, we are not merely improving the mining
+path; we are getting mined work as part of a faster serving path. In that
+throughput sense, mining is free and comes with a throughput gift. `vanilla_mining`
+should remain in the table to show the old problem: mining by itself is slower,
+while EAGLE hides that tax and then beats the no-mining path.
+
+The old policy question was:
+
+```text
+At what prompt length does mining become worth the throughput cost?
+```
+
+The real-prompt EAGLE result changes the policy question because it changes where
+the noisy work is paid. This is not "mine in prefill sooner". It is "run the
+noisy target path inside a speculative decode/verification loop where accepted
+draft tokens amortize the noise". Above ~128 tokens, these runs show:
+
+```text
+vanilla mining <= vanilla no-mining
+EAGLE + mining > vanilla no-mining
+```
+
+So EAGLE is doing three things at once:
+
+1. It changes where the noisy GEMM tax is paid: not as a naked vanilla-mining
+   cost, and not as a prefill trick, but inside the speculative decode /
+   verification path.
+2. It hides the mining overhead: the serving path no longer pays the vanilla
+   mining throughput tax from ~128 tokens onward at C32.
+3. It provides a serving-throughput win while mining: the mined path is faster
+   than vanilla no-mining, and much faster than vanilla mining in the long-prompt
+   buckets.
+
+The conservative C=32 conclusion is not "prove no threshold forever". It is:
+
+```text
+old throughput-positive mining bound: ~1024 prompt tokens
+new throughput-positive EAGLE+mining bound at C=32: ~128 prompt tokens
+```
+
+That is the practical ~10x bound reduction for the canonical load. The `<128`
+bucket should remain an experimental optimization target until
+repeated/interleaved runs make it stable. The C64 sweep also shows the policy
+must be validated at the target serving concurrency; if future evidence shows
+`<128` and high-concurrency long prompts are reliably positive vs no-mining too,
+the policy can be strengthened from "~128 bound at C=32" to a broader dynamic
+policy. Existing low-C data already supports a different latency-oriented policy:
+K3 at C1 and K4 at C4.
+
+A conservative policy from this benchmark is:
+
+```text
+if Pearl-specific EAGLE is available and acceptance is healthy:
+    if prompt_len >= 128:
+        enable mining with EAGLE
+        prefer K3, with K2 as a safer fallback
+    else:
+        keep the existing no-mining / old policy unless explicitly experimenting
+else:
+    fall back to the existing mining threshold policy
+```
+
+A bolder experimental policy for further validation is:
+
+```text
+low-concurrency / latency mode:
+    C1: prefer K3 + mining
+    C4: prefer K4 + mining
+canonical C32 throughput mode:
+    prompt_len < 128: keep experimental / default no-mining
+    prompt_len >= 128: prefer K2/K3 + mining
+high-concurrency C64 mode:
+    validate at production load; compare against both no-mining and mining baselines
+    expect mixed results vs no-mining, but still better than vanilla mining in long buckets
+```
+
+The PR should lead with the conservative C=32 claim: mining becomes
+serving-throughput-free from ~128 tokens onward, lowering the throughput-positive
+bound from ~1024 to ~128, with large wins over vanilla mining in the long-prompt
+buckets. It should also mention the concurrency sweep: C1/C4/C16/C32 are
+free-or-better for the relevant buckets; C64 is approximately no-mining-equivalent
+in the longest bucket and still better than vanilla mining, but mixed enough to
+need separate production-load validation. Do not frame it as an unconditional
+no-threshold or all-concurrency claim.
+
+## Methodology and implementation notes
+
+This experiment measures the **net** serving-throughput effect of running
+`EAGLE + mining` versus `vanilla no-mining`. It does not decompose EAGLE-only
+speedup from mining-only overhead. `vanilla_mining` remains in the tables to show
+the non-speculative mining tax, but the headline claim is the net production
+comparison against no-mining.
+
+The benchmark sets:
+
+```text
+MINER_SKIP_BLOCK_SUBMISSION=1
+MINER_NO_GATEWAY=1
+```
+
+so it measures the noisy-GEMM / noise-generation compute path without gateway or
+block-submission/network overhead. The results should therefore be read as a
+compute-path throughput benchmark, not a full end-to-end mining economics
+benchmark.
+
+The separate mining-path validation run used the same harness shape plus a
+temporary process-local `sitecustomize` wrapper to trace `pearl_gemm_noisy()`.
+That trace proves the noisy-GEMM path is reachable and exercised under the
+benchmark mining environment; it is not an always-on production instrumentation
+and has been removed from the AWS workspace after collecting the trace.
+
+The benchmark does **not** require changing the existing noisy-GEMM shape
+threshold in the vLLM miner. The current plugin still gates noisy GEMM with:
+
+```text
+miner/vllm-miner/src/vllm_miner/config.yaml
+min_m = 1024
+min_n = 1024
+min_k = 1024
+```
+
+and the runtime check remains:
+
+```python
+config.should_use_noisy_gemm(m, n, k) and not config.settings.no_mining
+```
+
+So the evidence is not "lower the internal GEMM threshold and hope mining pays".
+It is stronger: with the existing GEMM threshold, Pearl-specific EAGLE changes
+where the noisy work lands in the generation loop. Running the mining-capable
+server with EAGLE hides the mining tax and improves throughput on real prompts
+from ~128 tokens upward.
+
+There is no in-process prompt-length switch in this plugin today. A production
+`prompt_len >= 128` rollout should therefore be treated as a serving/router
+policy, or as a separate deployment mode, unless a future change adds dynamic
+per-request routing.
+
+## Canonical benchmark harness
+
+The repository includes a reusable harness:
+
+```text
+scripts/benchmarks/real_prompt_spec_decode_bench.py
+```
+
+Example mixed-prompt run:
+
+```bash
+python scripts/benchmarks/real_prompt_spec_decode_bench.py \
+  --model pearl-ai/Llama-3.1-8B-Instruct-pearl \
+  --eagle-checkpoint /workspace/pearl_eagle3_train_200k_seq4096/output/checkpoints_eagle3_scratch/3 \
+  --vllm-bin /workspace/pearl-build/.venv/bin/vllm \
+  --output-dir /workspace/aws_real_prompt_throughput_bench \
+  --gpu 0 \
+  --samples-per-subset 24 \
+  --max-tokens 96 \
+  --concurrency 32 \
+  --cases vanilla_no_mining,vanilla_mining,eagle_k2_mining,eagle_k3_mining,eagle_k4_mining
+```
+
+Example length-bucket run:
+
+```bash
+python scripts/benchmarks/real_prompt_spec_decode_bench.py \
+  --model pearl-ai/Llama-3.1-8B-Instruct-pearl \
+  --eagle-checkpoint /workspace/pearl_eagle3_train_200k_seq4096/output/checkpoints_eagle3_scratch/3 \
+  --vllm-bin /workspace/pearl-build/.venv/bin/vllm \
+  --output-dir /workspace/aws_real_prompt_length_bucket_bench \
+  --gpu 0 \
+  --bucket-lengths 0:128,129:256,257:512,513:1024,1025:2048 \
+  --samples-per-bucket 64 \
+  --max-tokens 96 \
+  --concurrency 32 \
+  --cases vanilla_no_mining,vanilla_mining,eagle_k2_mining,eagle_k3_mining
+```
+
+The harness writes:
+
+- `prompt_manifest.json`
+- per-case `summary.json`
+- per-case `server.log`
+- `combined_summary.json`
+- `combined_summary.csv`
+
+The combined outputs include explicit deltas against `vanilla_no_mining`:
+
+- `requests_vs_vanilla_no_mining_pct`
+- `output_tokens_vs_vanilla_no_mining_pct`
+- `total_tokens_vs_vanilla_no_mining_pct`
+
+Those deltas are the headline PR numbers. Deltas against `vanilla_mining` are
+secondary diagnostics, not the main claim.
+
+## PR checklist
+
+Before changing serving defaults, use this checklist:
+
+1. Re-run the length-bucket benchmark at least 2–3 times or interleaved to reduce
+   warmup/order effects.
+2. Keep random-token results out of the primary claim; mention them only as a
+   stress test.
+3. Add policy behind an experimental flag first:
+   - conservative headline: enable EAGLE + mining for `prompt_len >= 128` at
+     the validated serving concurrency;
+   - experimental follow-up: low-C K3/K4 routing, K2/K3 at C32, and separate
+     C64 / production-concurrency validation.
+4. Track live acceptance counters:
+   - acceptance length,
+   - accepted/drafted token rate,
+   - per-position acceptance.
+5. Fall back to the old threshold if acceptance drops below the tested healthy
+   band on production traffic.

--- a/scripts/benchmarks/real_prompt_spec_decode_bench.py
+++ b/scripts/benchmarks/real_prompt_spec_decode_bench.py
@@ -1,0 +1,731 @@
+#!/usr/bin/env python3
+"""Run real-prompt vLLM speculative decoding throughput benchmarks.
+
+This benchmark is intended for Pearl/EAGLE mining experiments. It uses real
+prompts from JSONL files (by default ``RedHatAI/speculator_benchmarks``), serves
+one vLLM configuration at a time, sends OpenAI-compatible completion requests,
+and records both throughput and vLLM speculative-decoding counters.
+
+Why this exists: random-token vLLM throughput runs are useful for stress tests,
+but they are the opposite of what EAGLE learns. EAGLE learns natural verifier
+continuations, so acceptance and mining tradeoffs must be measured on real
+prompt distributions.
+
+Example:
+
+    python scripts/benchmarks/real_prompt_spec_decode_bench.py \
+      --model pearl-ai/Llama-3.1-8B-Instruct-pearl \
+      --eagle-checkpoint /workspace/.../checkpoints_eagle3_scratch/3 \
+      --output-dir /workspace/pearl-real-prompt-bench \
+      --gpu 0 \
+      --bucket-lengths 0:128,129:256,257:512,513:1024,1025:2048 \
+      --samples-per-bucket 64 \
+      --cases vanilla_no_mining,vanilla_mining,eagle_k2_mining,eagle_k3_mining
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import csv
+import json
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SPEC_METRIC_NAMES = (
+    "vllm:spec_decode_num_drafts",
+    "vllm:spec_decode_num_draft_tokens",
+    "vllm:spec_decode_num_accepted_tokens",
+)
+
+DEFAULT_SUBSETS = (
+    "qa,writing,summarization,math_reasoning,HumanEval,translation,question,rag,tool_call"
+)
+DEFAULT_CASES = "vanilla_no_mining,vanilla_mining,eagle_k2_mining,eagle_k3_mining"
+
+
+@dataclass(frozen=True)
+class PromptRecord:
+    group: str
+    subset: str
+    prompt: str
+    prompt_len: int | None = None
+
+
+@dataclass(frozen=True)
+class CaseConfig:
+    name: str
+    mining: bool
+    spec_k: int = 0
+
+
+class BenchmarkError(RuntimeError):
+    """Raised when a benchmark case cannot complete."""
+
+
+def log(message: str) -> None:
+    print(f"[{time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}] {message}", flush=True)
+
+
+def prompt_from_row(row: dict[str, Any]) -> str:
+    """Extract a prompt string from common real-prompt JSONL schemas."""
+    for key in ("prompt", "question", "text", "instruction"):
+        value = row.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+
+    messages = row.get("messages")
+    if isinstance(messages, list):
+        parts: list[str] = []
+        for message in messages:
+            if isinstance(message, dict):
+                role = message.get("role", "")
+                content = message.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    parts.append(f"{role}: {content}" if role else content)
+        if parts:
+            return "\n".join(parts)
+
+    # Last-resort fallback keeps the row deterministic and debuggable.
+    return json.dumps(row, ensure_ascii=False)[:4000]
+
+
+def parse_bucket_lengths(spec: str | None) -> list[tuple[str, int, int]]:
+    if not spec:
+        return []
+    buckets: list[tuple[str, int, int]] = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            lo_s, hi_s = part.split(":", 1)
+            lo = int(lo_s)
+            hi = int(hi_s)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"Invalid bucket {part!r}; expected '<lo>:<hi>'"
+            ) from exc
+        if lo < 0 or hi < lo:
+            raise argparse.ArgumentTypeError(f"Invalid bucket range {part!r}")
+        buckets.append((f"{lo:04d}_{hi:04d}", lo, hi))
+    return buckets
+
+
+def parse_case(case_name: str) -> CaseConfig:
+    name = case_name.strip()
+    if name == "vanilla_no_mining":
+        return CaseConfig(name=name, mining=False, spec_k=0)
+    if name == "vanilla_mining":
+        return CaseConfig(name=name, mining=True, spec_k=0)
+    match = re.fullmatch(r"(?:scratch_)?eagle_k(\d+)_mining", name)
+    if match:
+        return CaseConfig(name=name, mining=True, spec_k=int(match.group(1)))
+    raise argparse.ArgumentTypeError(
+        f"Unknown case {name!r}; use vanilla_no_mining, vanilla_mining, "
+        "or eagle_k<N>_mining"
+    )
+
+
+def load_jsonl_prompts_from_hf(
+    *, repo: str, subset: str, cache_dir: str | None = None
+) -> list[str]:
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:  # pragma: no cover - depends on remote env
+        raise BenchmarkError(
+            "huggingface_hub is required to load HF benchmark prompts"
+        ) from exc
+
+    path = hf_hub_download(
+        repo_id=repo,
+        filename=f"{subset}.jsonl",
+        repo_type="dataset",
+        cache_dir=cache_dir,
+    )
+    prompts: list[str] = []
+    with Path(path).open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            prompts.append(prompt_from_row(json.loads(line)))
+    return prompts
+
+
+def load_prompt_records(args: argparse.Namespace) -> list[PromptRecord]:  # noqa: C901
+    subsets = [s.strip() for s in args.subsets.split(",") if s.strip()]
+    if not subsets:
+        raise BenchmarkError("No subsets selected")
+
+    tokenizer = None
+    buckets = parse_bucket_lengths(args.bucket_lengths)
+    if buckets:
+        try:
+            from transformers import AutoTokenizer
+        except ImportError as exc:  # pragma: no cover - depends on remote env
+            raise BenchmarkError("transformers is required for length buckets") from exc
+        tokenizer_name = args.tokenizer or args.model
+        log(f"Loading tokenizer for length buckets: {tokenizer_name}")
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+
+    rng = random.Random(args.seed)
+    grouped: dict[str, list[PromptRecord]] = {}
+
+    for subset in subsets:
+        prompts = load_jsonl_prompts_from_hf(
+            repo=args.dataset_repo, subset=subset, cache_dir=args.hf_cache_dir
+        )
+        rng.shuffle(prompts)
+        if buckets:
+            for prompt in prompts:
+                assert tokenizer is not None
+                prompt_len = len(tokenizer(prompt, add_special_tokens=False).input_ids)
+                for bucket_name, lo, hi in buckets:
+                    if lo <= prompt_len <= hi:
+                        grouped.setdefault(bucket_name, []).append(
+                            PromptRecord(
+                                group=bucket_name,
+                                subset=subset,
+                                prompt=prompt,
+                                prompt_len=prompt_len,
+                            )
+                        )
+                        break
+        else:
+            take = prompts[: args.samples_per_subset]
+            grouped.setdefault(subset, [])
+            grouped[subset].extend(
+                PromptRecord(group=subset, subset=subset, prompt=prompt)
+                for prompt in take
+            )
+
+    selected: list[PromptRecord] = []
+    if buckets:
+        for bucket_name, _lo, _hi in buckets:
+            records = grouped.get(bucket_name, [])
+            rng.shuffle(records)
+            take = records[: args.samples_per_bucket]
+            if not take:
+                log(f"WARNING: bucket {bucket_name} has no prompts")
+                continue
+            lengths = [r.prompt_len for r in take if r.prompt_len is not None]
+            log(
+                f"bucket={bucket_name} prompts={len(take)} "
+                f"avg_len={sum(lengths) / len(lengths):.1f} "
+                f"min={min(lengths)} max={max(lengths)}"
+            )
+            selected.extend(take)
+    else:
+        for subset in subsets:
+            records = grouped.get(subset, [])
+            if not records:
+                log(f"WARNING: subset {subset} has no prompts")
+                continue
+            selected.extend(records[: args.samples_per_subset])
+            log(f"subset={subset} prompts={len(records[: args.samples_per_subset])}")
+
+    if not selected:
+        raise BenchmarkError("No prompts selected")
+    return selected
+
+
+def http_get_json(url: str, timeout_s: float = 10) -> Any:
+    with urllib.request.urlopen(url, timeout=timeout_s) as response:  # noqa: S310
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_server(base_url: str, process: subprocess.Popen[Any], timeout_s: int) -> None:
+    deadline = time.time() + timeout_s
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        if process.poll() is not None:
+            raise BenchmarkError(f"vLLM server exited early with rc={process.returncode}")
+        try:
+            http_get_json(f"{base_url}/v1/models", timeout_s=5)
+            return
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            last_error = exc
+            time.sleep(2)
+    raise BenchmarkError(f"Timed out waiting for {base_url}: {last_error}")
+
+
+def parse_prometheus_metrics(text: str) -> dict[str, Any]:
+    values = dict.fromkeys(SPEC_METRIC_NAMES, 0.0)
+    per_pos: dict[int, float] = {}
+
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        match = re.match(r"([^\s{]+)(?:\{([^}]*)\})?\s+([-+0-9.eE]+)", line)
+        if not match:
+            continue
+        name, labels, value_s = match.groups()
+        labels = labels or ""
+        try:
+            value = float(value_s)
+        except ValueError:
+            continue
+
+        # Prometheus counters are exported as *_total, while vLLM source names omit
+        # the suffix. Normalize so this script works across vLLM versions.
+        base_name = name[:-6] if name.endswith("_total") else name
+        if base_name in values:
+            values[base_name] += value
+
+        if "spec_decode" in name and "per_pos" in name:
+            pos_match = re.search(r'(?:pos|position|index)="?(\d+)"?', labels)
+            if pos_match:
+                pos = int(pos_match.group(1))
+                per_pos[pos] = per_pos.get(pos, 0.0) + value
+
+    values["per_pos"] = per_pos
+    return values
+
+
+def fetch_metrics(base_url: str) -> dict[str, Any]:
+    with urllib.request.urlopen(f"{base_url}/metrics", timeout=10) as response:  # noqa: S310
+        return parse_prometheus_metrics(response.read().decode("utf-8"))
+
+
+def metric_diff(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    diff = {name: after.get(name, 0.0) - before.get(name, 0.0) for name in SPEC_METRIC_NAMES}
+    before_pos = before.get("per_pos", {})
+    after_pos = after.get("per_pos", {})
+    diff["per_pos"] = {
+        pos: after_pos.get(pos, 0.0) - before_pos.get(pos, 0.0)
+        for pos in set(before_pos) | set(after_pos)
+    }
+    return diff
+
+
+def request_completion(
+    *,
+    base_url: str,
+    model_name: str,
+    prompt: PromptRecord,
+    max_tokens: int,
+    request_timeout_s: int,
+) -> dict[str, Any]:
+    body = json.dumps(
+        {
+            "model": model_name,
+            "prompt": prompt.prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0,
+            "stream": False,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}/v1/completions",
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    start = time.time()
+    with urllib.request.urlopen(request, timeout=request_timeout_s) as response:  # noqa: S310
+        data = json.loads(response.read().decode("utf-8"))
+    usage = data.get("usage", {})
+    choice = data.get("choices", [{}])[0]
+    return {
+        "group": prompt.group,
+        "subset": prompt.subset,
+        "prompt_len": prompt.prompt_len,
+        "elapsed_s": time.time() - start,
+        "completion_tokens": usage.get("completion_tokens") or 0,
+        "prompt_tokens": usage.get("prompt_tokens") or 0,
+        "finish_reason": choice.get("finish_reason"),
+    }
+
+
+def summarize_group(
+    *,
+    case: CaseConfig,
+    group: str,
+    records: list[PromptRecord],
+    results: list[dict[str, Any]],
+    elapsed_s: float,
+    metrics: dict[str, Any],
+    max_tokens: int,
+    concurrency: int,
+) -> dict[str, Any]:
+    completion_tokens = sum(int(r["completion_tokens"]) for r in results)
+    prompt_tokens = sum(int(r["prompt_tokens"]) for r in results)
+    total_tokens = completion_tokens + prompt_tokens
+    drafts = float(metrics.get("vllm:spec_decode_num_drafts", 0.0))
+    draft_tokens = float(metrics.get("vllm:spec_decode_num_draft_tokens", 0.0))
+    accepted_tokens = float(metrics.get("vllm:spec_decode_num_accepted_tokens", 0.0))
+    per_pos = metrics.get("per_pos", {})
+
+    lengths = [r.prompt_len for r in records if r.prompt_len is not None]
+    finish_counts: dict[str, int] = {}
+    for result in results:
+        key = str(result.get("finish_reason"))
+        finish_counts[key] = finish_counts.get(key, 0) + 1
+
+    return {
+        "case": case.name,
+        "group": group,
+        "mining": case.mining,
+        "spec_k": case.spec_k,
+        "num_requests": len(records),
+        "avg_prompt_len": (sum(lengths) / len(lengths)) if lengths else None,
+        "min_prompt_len": min(lengths) if lengths else None,
+        "max_prompt_len": max(lengths) if lengths else None,
+        "elapsed_s": elapsed_s,
+        "requests_per_second": len(records) / elapsed_s,
+        "output_tokens_per_second": completion_tokens / elapsed_s,
+        "total_tokens_per_second": total_tokens / elapsed_s,
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": prompt_tokens,
+        "max_tokens": max_tokens,
+        "concurrency": concurrency,
+        "num_drafts": drafts,
+        "num_draft_tokens": draft_tokens,
+        "num_accepted_tokens": accepted_tokens,
+        "acceptance_length": 1 + accepted_tokens / drafts if drafts > 0 else None,
+        "avg_draft_acceptance_rate": accepted_tokens / draft_tokens
+        if draft_tokens > 0
+        else None,
+        "acceptance_at_pos": {
+            str(pos): count / drafts for pos, count in sorted(per_pos.items())
+        }
+        if drafts > 0
+        else {},
+        "raw_metrics_diff": metrics,
+        "finish_counts": finish_counts,
+    }
+
+
+def build_server_command(args: argparse.Namespace, case: CaseConfig, port: int) -> list[str]:
+    command = [
+        args.vllm_bin,
+        "serve",
+        args.model,
+        "--served-model-name",
+        args.served_model_name,
+        "--host",
+        args.host,
+        "--port",
+        str(port),
+        "--max-model-len",
+        str(args.max_model_len),
+        "--gpu-memory-utilization",
+        str(args.gpu_memory_utilization),
+    ]
+    if args.enforce_eager:
+        command.append("--enforce-eager")
+    if args.disable_prefix_caching:
+        command.append("--no-enable-prefix-caching")
+    if case.spec_k > 0:
+        if not args.eagle_checkpoint:
+            raise BenchmarkError(f"{case.name} requires --eagle-checkpoint")
+        command.extend(
+            [
+                "--speculative-config",
+                json.dumps(
+                    {
+                        "method": args.eagle_method,
+                        "model": args.eagle_checkpoint,
+                        "num_speculative_tokens": case.spec_k,
+                    },
+                    separators=(",", ":"),
+                ),
+            ]
+        )
+    return command
+
+
+def run_case(
+    *,
+    args: argparse.Namespace,
+    case: CaseConfig,
+    prompts_by_group: dict[str, list[PromptRecord]],
+    port: int,
+) -> dict[str, Any]:
+    case_dir = Path(args.output_dir) / case.name
+    case_dir.mkdir(parents=True, exist_ok=True)
+    server_log_path = case_dir / "server.log"
+    base_url = f"http://{args.host}:{port}"
+
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+    if args.miner_no_gateway:
+        env["MINER_NO_GATEWAY"] = "1"
+    if args.skip_block_submission:
+        env["MINER_SKIP_BLOCK_SUBMISSION"] = "1"
+    if case.mining:
+        env.pop("MINER_NO_MINING", None)
+    else:
+        env["MINER_NO_MINING"] = "1"
+
+    command = build_server_command(args, case, port)
+    log(f"case={case.name} starting vLLM on gpu={args.gpu} port={port}")
+    log("server command: " + " ".join(command))
+    with server_log_path.open("w", encoding="utf-8") as server_log:
+        process = subprocess.Popen(  # noqa: S603 - benchmark harness starts vLLM intentionally
+            command,
+            stdout=server_log,
+            stderr=subprocess.STDOUT,
+            env=env,
+            text=True,
+        )
+        try:
+            wait_for_server(base_url, process, args.server_timeout_s)
+            log(f"case={case.name} server ready")
+
+            group_summaries: dict[str, dict[str, Any]] = {}
+            all_results: list[dict[str, Any]] = []
+            for group, records in prompts_by_group.items():
+                before = fetch_metrics(base_url)
+                start = time.time()
+                workers = min(args.concurrency, len(records))
+                with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+                    futures = [
+                        pool.submit(
+                            request_completion,
+                            base_url=base_url,
+                            model_name=args.served_model_name,
+                            prompt=record,
+                            max_tokens=args.max_tokens,
+                            request_timeout_s=args.request_timeout_s,
+                        )
+                        for record in records
+                    ]
+                    results = [future.result() for future in futures]
+                elapsed_s = time.time() - start
+                after = fetch_metrics(base_url)
+                metrics = metric_diff(before, after)
+                summary = summarize_group(
+                    case=case,
+                    group=group,
+                    records=records,
+                    results=results,
+                    elapsed_s=elapsed_s,
+                    metrics=metrics,
+                    max_tokens=args.max_tokens,
+                    concurrency=workers,
+                )
+                group_summaries[group] = summary
+                all_results.extend(results)
+                log(
+                    f"case={case.name} group={group} "
+                    f"req/s={summary['requests_per_second']:.3f} "
+                    f"out_tok/s={summary['output_tokens_per_second']:.1f} "
+                    f"acc_len={summary['acceptance_length']}"
+                )
+
+            (case_dir / "summary.json").write_text(
+                json.dumps(
+                    {
+                        "case": asdict(case),
+                        "groups": group_summaries,
+                        "results": all_results,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            return group_summaries
+        finally:
+            log(f"case={case.name} stopping vLLM")
+            process.terminate()
+            try:
+                process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=20)
+
+
+def _pct_delta(value: float | None, baseline: float | None) -> float | None:
+    if value is None or baseline in (None, 0):
+        return None
+    return (value / baseline - 1) * 100
+
+
+def add_primary_baseline_deltas(
+    all_summaries: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Add deltas against the primary production baseline: vanilla no-mining.
+
+    The PR claim is not "EAGLE beats mining". Vanilla mining is included to
+    show the mining tax. The primary comparison is EAGLE+mining vs vanilla
+    no-mining, because a win there means mining work is effectively hidden from
+    the serving-throughput perspective.
+    """
+    enriched = json.loads(json.dumps(all_summaries))
+    baseline_groups = enriched.get("vanilla_no_mining", {})
+    for case_groups in enriched.values():
+        for group, summary in case_groups.items():
+            baseline = baseline_groups.get(group)
+            if not baseline:
+                continue
+            summary["primary_baseline_case"] = "vanilla_no_mining"
+            summary["requests_vs_vanilla_no_mining_pct"] = _pct_delta(
+                summary.get("requests_per_second"), baseline.get("requests_per_second")
+            )
+            summary["output_tokens_vs_vanilla_no_mining_pct"] = _pct_delta(
+                summary.get("output_tokens_per_second"),
+                baseline.get("output_tokens_per_second"),
+            )
+            summary["total_tokens_vs_vanilla_no_mining_pct"] = _pct_delta(
+                summary.get("total_tokens_per_second"),
+                baseline.get("total_tokens_per_second"),
+            )
+    return enriched
+
+
+def write_combined_outputs(output_dir: Path, all_summaries: dict[str, dict[str, Any]]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    enriched = add_primary_baseline_deltas(all_summaries)
+    (output_dir / "combined_summary.json").write_text(
+        json.dumps(enriched, indent=2), encoding="utf-8"
+    )
+
+    fieldnames = [
+        "case",
+        "group",
+        "mining",
+        "spec_k",
+        "num_requests",
+        "avg_prompt_len",
+        "requests_per_second",
+        "output_tokens_per_second",
+        "total_tokens_per_second",
+        "primary_baseline_case",
+        "requests_vs_vanilla_no_mining_pct",
+        "output_tokens_vs_vanilla_no_mining_pct",
+        "total_tokens_vs_vanilla_no_mining_pct",
+        "acceptance_length",
+        "avg_draft_acceptance_rate",
+        "acceptance_at_pos_0",
+        "acceptance_at_pos_1",
+        "acceptance_at_pos_2",
+        "acceptance_at_pos_3",
+    ]
+    with (output_dir / "combined_summary.csv").open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for case_groups in enriched.values():
+            for summary in case_groups.values():
+                row = {key: summary.get(key) for key in fieldnames}
+                acceptance_at_pos = summary.get("acceptance_at_pos", {})
+                for pos in range(4):
+                    row[f"acceptance_at_pos_{pos}"] = acceptance_at_pos.get(str(pos))
+                writer.writerow(row)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Real-prompt vLLM speculative decoding throughput benchmark"
+    )
+    parser.add_argument("--model", required=True, help="Target model name/path for vLLM")
+    parser.add_argument("--served-model-name", default="pearl")
+    parser.add_argument("--eagle-checkpoint", default=None, help="EAGLE checkpoint path")
+    parser.add_argument("--eagle-method", default="eagle3")
+    parser.add_argument("--vllm-bin", default="vllm")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--dataset-repo", default="RedHatAI/speculator_benchmarks")
+    parser.add_argument("--subsets", default=DEFAULT_SUBSETS)
+    parser.add_argument("--hf-cache-dir", default=None)
+    parser.add_argument("--tokenizer", default=None)
+    parser.add_argument("--bucket-lengths", default=None)
+    parser.add_argument("--samples-per-subset", type=int, default=24)
+    parser.add_argument("--samples-per-bucket", type=int, default=64)
+    parser.add_argument("--max-tokens", type=int, default=96)
+    parser.add_argument("--concurrency", type=int, default=32)
+    parser.add_argument("--cases", default=DEFAULT_CASES)
+    parser.add_argument("--gpu", default="0")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port-base", type=int, default=8130)
+    parser.add_argument("--max-model-len", type=int, default=4096)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.88)
+    parser.add_argument("--server-timeout-s", type=int, default=180)
+    parser.add_argument("--request-timeout-s", type=int, default=240)
+    parser.add_argument("--seed", type=int, default=20260617)
+    parser.add_argument("--enforce-eager", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument(
+        "--disable-prefix-caching", action=argparse.BooleanOptionalAction, default=True
+    )
+    parser.add_argument(
+        "--miner-no-gateway",
+        dest="miner_no_gateway",
+        action="store_true",
+        default=True,
+        help="Set MINER_NO_GATEWAY=1 while serving benchmark cases (default)",
+    )
+    parser.add_argument(
+        "--with-gateway",
+        dest="miner_no_gateway",
+        action="store_false",
+        help="Do not set MINER_NO_GATEWAY; use the configured mining gateway",
+    )
+    parser.add_argument(
+        "--skip-block-submission", action=argparse.BooleanOptionalAction, default=True
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only load/sample prompts and write prompt_manifest.json",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cases = [parse_case(case) for case in args.cases.split(",") if case.strip()]
+    prompts = load_prompt_records(args)
+    prompts_by_group: dict[str, list[PromptRecord]] = {}
+    for prompt in prompts:
+        prompts_by_group.setdefault(prompt.group, []).append(prompt)
+
+    (output_dir / "prompt_manifest.json").write_text(
+        json.dumps([asdict(prompt) for prompt in prompts], indent=2),
+        encoding="utf-8",
+    )
+    log(
+        f"selected prompts={len(prompts)} groups="
+        + ",".join(f"{group}:{len(rows)}" for group, rows in prompts_by_group.items())
+    )
+    if args.dry_run:
+        log("dry run complete")
+        return 0
+
+    all_summaries: dict[str, dict[str, Any]] = {}
+    for idx, case in enumerate(cases, start=1):
+        port = args.port_base + idx
+        summaries = run_case(
+            args=args, case=case, prompts_by_group=prompts_by_group, port=port
+        )
+        all_summaries[case.name] = summaries
+        write_combined_outputs(output_dir, all_summaries)
+
+    log("combined results (primary comparator: vanilla_no_mining):")
+    enriched = add_primary_baseline_deltas(all_summaries)
+    for case_name, groups in enriched.items():
+        for group, summary in groups.items():
+            vs_no_mining = summary.get("requests_vs_vanilla_no_mining_pct")
+            vs_text = "n/a" if vs_no_mining is None else f"{vs_no_mining:+.1f}%"
+            log(
+                f"{case_name}/{group}: req/s={summary['requests_per_second']:.3f} "
+                f"vs_no_mining={vs_text} "
+                f"out_tok/s={summary['output_tokens_per_second']:.1f} "
+                f"acc_len={summary['acceptance_length']} "
+                f"draft_accept={summary['avg_draft_acceptance_rate']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a focused real-prompt benchmark harness and evidence doc for Pearl-specific EAGLE speculative decoding as a mining enabler.

This PR does **not** change production serving/mining code. It adds only:

- `scripts/benchmarks/real_prompt_spec_decode_bench.py`
- `docs/pearl-eagle-real-prompt-benchmark.md`

Primary comparator is **vanilla no-mining**. `vanilla_mining` is kept as a diagnostic to show the old mining tax.

## Novelty: EAGLE changes where noise is paid

The real mechanism is not just "lower the prompt threshold". The novelty is that EAGLE changes **where the noisy mining work is paid** in the serving path.

Vanilla mining pays noisy GEMM as a pure tax in the normal target-model path. Pearl-specific EAGLE puts the mining-capable target work behind the speculative decode / verification loop: a target pass can validate multiple drafted tokens, and accepted draft tokens amortize the noisy target work. That is why `EAGLE + mining` can beat `vanilla no-mining`, not only `vanilla mining`.

This is **not** a prefill trick and not a change to the GEMM shape threshold. The existing noisy-GEMM gate remains at `min_m/min_n/min_k = 1024`. The benchmark shows that, when the noisy target path is used inside speculative decoding, the noise is paid in a different part of the generation loop and becomes hidden/net-positive in the validated regimes.

## Main result

At canonical C=32, EAGLE+mining beats vanilla no-mining from ~128 prompt tokens onward.

In serving-throughput terms, mining becomes free from ~128 tokens onward: the mined path is faster than the no-mining path, so the mined work is not paid for by lower serving throughput.

Conservative headline:

```text
old throughput-positive mining bound: ~1024 prompt tokens
new throughput-positive EAGLE+mining bound at C32: ~128 prompt tokens
```

Above ~1024 tokens, it is not just free — it is materially faster:

```text
best EAGLE+mining, 1025–2048 bucket, C32 R1–R3:
+22.3% vs vanilla no-mining
+34.2% vs vanilla mining
```

## Canonical C32 numbers

Three C32 repeats, mean best EAGLE delta by prompt bucket:

| avg prompt len | best EAGLE vs vanilla no-mining | best EAGLE vs vanilla mining |
|---:|---:|---:|
| 49.8 | -2.3% | +0.6% |
| 186.6 | +25.4% | +28.3% |
| 350.0 | +14.9% | +20.8% |
| 708.3 | +4.5% | +12.3% |
| 1331.3 | +22.3% | +34.2% |

The `<128` bucket is noisy at C32, so the PR does **not** claim no threshold. It claims the throughput-positive bound moves from ~1024 to ~128 at the canonical C32 load.

## Concurrency sweep

Best EAGLE+mining delta vs vanilla no-mining:

| C | avg prompt len | best EAGLE delta | best K |
|---:|---:|---:|---|
| 1 | 49.8 | +43.4% | K3 |
| 1 | 186.6 | +62.3% | K3 |
| 1 | 350.0 | +61.8% | K3 |
| 1 | 708.3 | +63.3% | K3 |
| 1 | 1331.3 | +53.7% | K3 |
| 4 | 49.8 | +32.7% | K4 |
| 4 | 186.6 | +43.8% | K4 |
| 4 | 350.0 | +44.5% | K4 |
| 4 | 708.3 | +49.0% | K4 |
| 4 | 1331.3 | +29.9% | K4 |
| 16 | 49.8 | +6.9% | K3 |
| 16 | 186.6 | +23.8% | K2 |
| 16 | 350.0 | +15.3% | K2 |
| 16 | 708.3 | +13.7% | K3 |
| 16 | 1331.3 | +3.6% | K3 |
| 32 | 49.8 | -4.1% | K3 |
| 32 | 186.6 | +30.3% | K3 |
| 32 | 350.0 | +14.7% | K2 |
| 32 | 708.3 | +7.0% | K3 |
| 32 | 1331.3 | +24.0% | K3 |
| 64 | 49.8 | -14.3% | K3 |
| 64 | 186.6 | +5.3% | K2 |
| 64 | 350.0 | +6.2% | K2 |
| 64 | 708.3 | -8.7% | K3 |
| 64 | 1331.3 | -2.9% | K3 |

Interpretation:

- C1/C4/C16/C32: best EAGLE+mining is free-or-better vs no-mining in the relevant buckets.
- C64: mixed vs no-mining; still better than vanilla mining in long buckets.
  - 513–1024: K3 is +3.5% vs vanilla mining, -8.7% vs no-mining.
  - 1025–2048: K3 is +12.3% vs vanilla mining, -2.9% vs no-mining.

## Optimization headroom

These results use a small, early Pearl-specific EAGLE draft head trained for 5 epochs. Treat the benchmark as evidence that the current head already makes mining serving-throughput-free in the validated regimes, not as an upper bound. A larger/better-trained head and policy tuning should have additional headroom.

## Mining-path validation

A temporary process-local trace wrapper around `pearl_gemm_noisy()` verified the benchmark mining cases enter the actual noisy-GEMM mining path.

Trace summary:

```text
640 calls into pearl_gemm_noisy()
2 EngineCore worker PIDs
example shapes:
  m=1927, n=4096,  k=4096
  m=1927, n=28672, k=4096
  m=1927, n=6144,  k=4096
```

`submit_block=false` is expected: the benchmark uses:

```text
MINER_SKIP_BLOCK_SUBMISSION=1
MINER_NO_GATEWAY=1
```

so it measures noisy-GEMM / noise-generation compute-path overhead without gateway or block-submission/network overhead.

## Scope / caveats

- Real prompts only; random-token benches are treated as stress tests, not primary evidence.
- Primary metric is request throughput (`req/s`).
- Setup: greedy decoding, `max_tokens=96`, stated client concurrency.
- This measures net `EAGLE + mining` vs `vanilla no-mining`; it does not decompose EAGLE-only speedup from mining-only overhead.
- This is not a full end-to-end mining economics benchmark because gateway/submission is disabled.
- No unconditional no-threshold / all-concurrency claim.

## Validation

Local checks:

```text
python3 -m py_compile scripts/benchmarks/real_prompt_spec_decode_bench.py
.venv/bin/ruff check scripts/benchmarks/real_prompt_spec_decode_bench.py
git diff --check
python3 scripts/benchmarks/real_prompt_spec_decode_bench.py --help
```

All passed.


