### PR TITLE
perf(miner): skip cold MoE expert mining on f8 path

### DIFF
--- a/miner/miner-base/src/miner_base/async_loop_manager.py
+++ b/miner/miner-base/src/miner_base/async_loop_manager.py
@@ -233,6 +233,10 @@ class AsyncLoopManager:
             while not item.cuda_event.query():
                 await asyncio.sleep(0.01)
 
+            # Ensure host-pinned writes performed before the event are visible to
+            # the CPU thread before the callback reads the signal header.
+            item.cuda_event.synchronize()
+
             # callback should be fast (setup and call `handle_submit_block`)
             try:
                 item.callback(self.handle_submit_block)

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -115,12 +115,40 @@ def _offsets_hash(
     return _hash_2d(offsets_bytes.reshape(1, -1), key_tensor, device)
 
 
+def build_moe_routing_layout(topk_ids: torch.Tensor, num_experts: int) -> MoERoutingLayout:
+    """Build canonical routing data without committing or generating noise."""
+    top_k = topk_ids.shape[1]
+    num_routed_slots = topk_ids.shape[0] * top_k
+    device = topk_ids.device
+
+    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
+    routing_scratchpad = torch.empty(
+        get_build_routing_data_scratchpad_bytes(num_routed_slots),
+        dtype=torch.uint8,
+        device=device,
+    )
+    build_routing_data(
+        topk_ids.to(torch.int32).contiguous(),
+        routing_data,
+        slot_indices,
+        routing_offsets,
+        routing_scratchpad,
+        num_experts,
+    )
+    return MoERoutingLayout.from_kernel_outputs(
+        routing_data, slot_indices, routing_offsets, num_experts, top_k
+    )
+
+
 def prepare_moe_noising(
     A_q: torch.Tensor,
     A_scales: torch.Tensor,
     topk_ids: torch.Tensor,
     B_stacked: torch.Tensor,
     num_experts: int,
+    routing_layout: MoERoutingLayout | None = None,
 ) -> MoENoiseContext:
     """Compute hashes, MoE commitment, routing, and noise factors for one pass."""
 
@@ -150,26 +178,10 @@ def prepare_moe_noising(
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
     B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
 
-    num_routed_slots = num_tokens * top_k
-    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
-    routing_scratchpad = torch.empty(
-        get_build_routing_data_scratchpad_bytes(num_routed_slots),
-        dtype=torch.uint8,
-        device=device,
-    )
-    build_routing_data(
-        topk_ids.to(torch.int32).contiguous(),
-        routing_data,
-        slot_indices,
-        routing_offsets,
-        routing_scratchpad,
-        num_experts,
-    )
-    routing_layout = MoERoutingLayout.from_kernel_outputs(
-        routing_data, slot_indices, routing_offsets, num_experts, top_k
-    )
+    if routing_layout is None:
+        routing_layout = build_moe_routing_layout(topk_ids, num_experts)
+    routing_data = routing_layout.token_indices
+    routing_offsets = routing_layout.routing_offsets
     routing_hash = _routing_hash(routing_data, key_tensor, device)
 
     offsets_hash = _offsets_hash(routing_offsets, key_tensor, device)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import torch
@@ -26,8 +27,11 @@ from vllm.platforms import current_platform
 
 from .callbacks import MoEStatusCheckCallback
 from .config import config as pearl_config
+from .gemm_operators import pearl_gemm_vanilla
 from .mining_state import get_async_manager, get_pinned_pool
 from .moe_gemm_operators import (
+    MoERoutingLayout,
+    build_moe_routing_layout,
     pearl_moe_expert_gemm,
     permute_a_side_to_expert_order,
     prepare_moe_noising,
@@ -55,6 +59,11 @@ _TORCH_TO_TRITON_DTYPE: dict[torch.dtype, tl.dtype] = {
     torch.float16: tl.float16,
     torch.float32: tl.float32,
 }
+
+
+def _use_expert_local_mining_threshold() -> bool:
+    value = os.getenv("MINER_MOE_EXPERT_LOCAL_MINING", "1").lower()
+    return value not in {"0", "false", "no", "off"}
 
 
 def _torch_dtype_to_triton_compute_type(dtype: torch.dtype) -> tl.dtype:
@@ -154,6 +163,13 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         smooth = w13_smooth[:K] if w13_smooth is not None else None
         return quant_7bit(hidden_states, smooth_scale=smooth)
 
+    @staticmethod
+    def _expert_mining_mask(layout: MoERoutingLayout, n: int, k: int) -> list[bool]:
+        return [
+            pearl_config.should_use_noisy_gemm(layout.expert_slice(expert_index)[1], n, k)
+            for expert_index in range(layout.num_experts)
+        ]
+
     def apply(
         self,
         output: torch.Tensor,
@@ -179,7 +195,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         if global_num_experts == GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS:
             global_num_experts = E
 
-        should_mine = (
+        should_try_mining = (
             not get_async_manager()._conf.no_mining
         ) and pearl_config.should_use_noisy_gemm(num_tokens, N, K)
 
@@ -200,7 +216,20 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         )
 
         gemm1_compute_type = _torch_dtype_to_triton_compute_type(hidden_states.dtype)
+        routing_layout = None
+        mine_expert_mask = None
+        should_mine = False
+        if should_try_mining:
+            routing_layout = build_moe_routing_layout(topk_ids, E)
+            if _use_expert_local_mining_threshold():
+                mine_expert_mask = self._expert_mining_mask(routing_layout, N, K)
+            else:
+                mine_expert_mask = [True] * E
+            should_mine = any(mine_expert_mask)
+
         if should_mine:
+            assert routing_layout is not None
+            assert mine_expert_mask is not None
             self._apply_per_expert_gemm1(
                 A_q=A_q,
                 A_scales=A_scales,
@@ -214,6 +243,8 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                 num_tokens=num_tokens,
                 top_k_num=top_k_num,
                 apply_router_weight_on_input=apply_router_weight_on_input,
+                routing_layout=routing_layout,
+                mine_expert_mask=mine_expert_mask,
             )
         else:
             # Vanilla int8 grouped GEMM1 (no mining / no denoise).
@@ -268,10 +299,19 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         num_tokens: int,
         top_k_num: int,
         apply_router_weight_on_input: bool,
+        routing_layout: MoERoutingLayout,
+        mine_expert_mask: list[bool],
     ) -> None:
-        """GEMM1: per-expert ``noisy_gemm`` with PoW extraction"""
+        """GEMM1: per-expert noisy GEMM for hot experts, vanilla for smaller ones."""
         B_stacked = w1.reshape(E * N, K)
-        ctx = prepare_moe_noising(A_q, A_scales, topk_ids, B_stacked, E)
+        ctx = prepare_moe_noising(
+            A_q,
+            A_scales,
+            topk_ids,
+            B_stacked,
+            E,
+            routing_layout=routing_layout,
+        )
         layout = ctx.routing_layout
 
         (
@@ -303,34 +343,45 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                     continue
                 expert_weight_start = expert_index * N
                 expert_weight_end = expert_weight_start + N
-                expert_output = gemm1_output_by_slot[:expert_slot_count]
+                A_q_e = A_q_by_expert[routing_start : routing_start + expert_slot_count]
+                A_scales_e = A_scales_by_expert[routing_start : routing_start + expert_slot_count]
+                B_e = B_stacked[expert_weight_start:expert_weight_end]
+                B_scales_e = self.w1_scale[expert_index]
 
-                pearl_moe_expert_gemm(
-                    A_q_e=A_q_by_expert[routing_start : routing_start + expert_slot_count],
-                    B_e=B_stacked[expert_weight_start:expert_weight_end],
-                    A_scales_e=A_scales_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    B_scales_e=self.w1_scale[expert_index],
-                    EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
-                    EAL_fp16_e=EAL_fp16_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
-                    EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
-                    EAR_R_major=ctx.EAR_R_major,
-                    EBL_R_major=ctx.EBL_R_major,
-                    EAR_K_major=ctx.EAR_K_major,
-                    EBL_K_major=ctx.EBL_K_major,
-                    C_e=expert_output,
-                    host_signal_header_pinned=pow_headers[expert_index],
-                    host_signal_sync=host_signal_sync,
-                    pow_target=ctx.pow_target,
-                    pow_key=ctx.pow_key,
-                    tile_size_m=tile_m,
-                    tile_size_n=tile_n,
-                    tile_size_k=tile_k,
-                )
+                if mine_expert_mask[expert_index]:
+                    expert_output = gemm1_output_by_slot[:expert_slot_count]
+                    pearl_moe_expert_gemm(
+                        A_q_e=A_q_e,
+                        B_e=B_e,
+                        A_scales_e=A_scales_e,
+                        B_scales_e=B_scales_e,
+                        EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
+                        EAL_fp16_e=EAL_fp16_by_expert[
+                            routing_start : routing_start + expert_slot_count
+                        ],
+                        EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
+                        EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
+                        EAR_R_major=ctx.EAR_R_major,
+                        EBL_R_major=ctx.EBL_R_major,
+                        EAR_K_major=ctx.EAR_K_major,
+                        EBL_K_major=ctx.EBL_K_major,
+                        C_e=expert_output,
+                        host_signal_header_pinned=pow_headers[expert_index],
+                        host_signal_sync=host_signal_sync,
+                        pow_target=ctx.pow_target,
+                        pow_key=ctx.pow_key,
+                        tile_size_m=tile_m,
+                        tile_size_n=tile_n,
+                        tile_size_k=tile_k,
+                    )
+                else:
+                    expert_output = pearl_gemm_vanilla(
+                        A_q_e.contiguous(),
+                        B_e.contiguous(),
+                        scale_a=A_scales_e.squeeze(-1).contiguous(),
+                        scale_b=B_scales_e.squeeze(-1).contiguous(),
+                        out_dtype=out_dtype,
+                    )
 
                 expert_slot_indices = layout.slot_indices[
                     routing_start : routing_start + expert_slot_count

--- a/miner/vllm-miner/tests/test_moe_block_submission.py
+++ b/miner/vllm-miner/tests/test_moe_block_submission.py
@@ -7,7 +7,9 @@ from miner_base.gpu_matmul_config import GPUMatmulConfigFactory
 from miner_base.settings import MinerSettings
 from miner_utils import get_logger
 from moe_testing_helpers import make_moe_tensors
+from pearl_gateway.comm.dataclasses import MiningJob
 from pearl_gateway.comm.mining_configuration import MoEConfig
+from pearl_mining import IncompleteBlockHeader
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
@@ -37,7 +39,24 @@ _HIDDEN_SIZE = 2048
 _INTERMEDIATE_SIZE = 1024
 _NUM_TOKENS = 2048
 _TOP_K = 2
-_EASY_TARGET = 2**242
+_EASY_NBITS = 0x207FFFFF
+_EASY_TARGET = 2**256 - 1
+
+
+def _with_header_nbits(mining_job: MiningJob, nbits: int) -> MiningJob:
+    header = IncompleteBlockHeader.from_bytes(mining_job.incomplete_header_bytes)
+    easy_header = IncompleteBlockHeader(
+        header.version,
+        header.prev_block,
+        header.merkle_root,
+        header.timestamp,
+        nbits,
+    )
+    return MiningJob(
+        incomplete_header_bytes=easy_header.to_bytes(),
+        target=mining_job.target,
+        cert_version=mining_job.cert_version,
+    )
 
 
 @pytest.fixture
@@ -116,22 +135,44 @@ def test_block_found_and_proof_verifies(pearl_moe_layer, get_mining_job, async_m
     matmul_config = GPUMatmulConfigFactory.create(
         k=k, noise_rank=noise_rank, moe=MoEConfig(e=_NUM_EXPERTS, top_k=_TOP_K)
     )
-    mining_job = get_mining_job(mining_config=matmul_config.mining_config, target=_EASY_TARGET)
+    mining_job = _with_header_nbits(
+        get_mining_job(mining_config=matmul_config.mining_config, target=_EASY_TARGET),
+        _EASY_NBITS,
+    )
 
     with patch.object(am, "_client") as mock_mining_client:
         mock_mining_client.get_mining_info.return_value = mining_job
         am._mining_job = am._client.get_mining_info()
 
-        moe_method.apply(
-            layer,
-            tensors.hidden_states,
-            tensors.topk_weights,
-            tensors.topk_ids,
-            None,
-        )
+        hot_experts = torch.arange(_TOP_K, dtype=torch.int32, device="cuda").expand(_NUM_TOKENS, -1)
+        tensors.topk_ids.copy_(hot_experts)
 
-        am.wait_until_done_submitting_blocks()
-        assert am.blocks_submitted == 1
+        start_time = time.time()
+        forward_count = 0
+        while am.blocks_submitted == 0:
+            if time.time() - start_time > _MINING_LOOP_TIMEOUT_SECONDS:
+                pytest.fail(
+                    f"Timeout ({_MINING_LOOP_TIMEOUT_SECONDS}s) waiting for block. "
+                    f"Performed {forward_count} forwards, "
+                    f"blocks_submitted={am.blocks_submitted}"
+                )
+
+            hidden_states = (
+                tensors.hidden_states
+                if forward_count == 0
+                else torch.randn_like(tensors.hidden_states)
+            )
+            moe_method.apply(
+                layer,
+                hidden_states,
+                tensors.topk_weights,
+                tensors.topk_ids,
+                None,
+            )
+            forward_count += 1
+            am.wait_until_done_submitting_blocks()
+
+        assert am.blocks_submitted >= 1
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Draft port of #198's expert-local MoE mining threshold onto `moe_f8_down_proj`.

This keeps the f8 branch's GEMM2/down-projection path intact and ports only the GEMM1 mining behavior:

- global prefill threshold still gates whether mining is considered
- per-expert routed token counts decide which experts actually run noisy GEMM
- cold experts use vanilla int8 GEMM for GEMM1
- if no expert crosses the local threshold, GEMM1 stays on the existing grouped int8 MoE path
- `MINER_MOE_EXPERT_LOCAL_MINING=0` restores the old global-threshold behavior

## Draft status

This is a code port, not yet a ready PR. The v1/all-int7 implementation has H100 smoke and serving evidence in #198. This f8 port still needs an H100 smoke and a serving benchmark on an fp8-down-compatible checkpoint.

The open performance question is mining density versus serving throughput: how many routed expert slots still get mined under expert-local threshold, and how that compares to the throughput lift. I am measuring that on the v1 benchmark path first, then we should repeat it on the f8 target once the right model/checkpoint is settled.

## Local validation

- `uv run --project miner/vllm-miner python -m py_compile miner/miner-base/src/miner_base/async_loop_manager.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/tests/test_moe_block_submission.py`
- `uvx ruff check miner/miner-base/src/miner_base/async_loop_manager.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/tests/test_moe_block_submission.py`
- `uvx ruff format --check --diff miner/miner-base/src/miner_base/async_loop_manager.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/tests/test_moe_block_submission.py`
- `git diff --cached --check`
