### PR TITLE
perf(miner): skip cold MoE expert mining

### DIFF
--- a/miner/miner-base/src/miner_base/async_loop_manager.py
+++ b/miner/miner-base/src/miner_base/async_loop_manager.py
@@ -233,6 +233,10 @@ class AsyncLoopManager:
             while not item.cuda_event.query():
                 await asyncio.sleep(0.01)
 
+            # Ensure host-pinned writes performed before the event are visible to
+            # the CPU thread before the callback reads the signal header.
+            item.cuda_event.synchronize()
+
             # callback should be fast (setup and call `handle_submit_block`)
             try:
                 item.callback(self.handle_submit_block)

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -115,12 +115,40 @@ def _offsets_hash(
     return _hash_2d(offsets_bytes.reshape(1, -1), key_tensor, device)
 
 
+def build_moe_routing_layout(topk_ids: torch.Tensor, num_experts: int) -> MoERoutingLayout:
+    """Build canonical routing data without committing or generating noise."""
+    top_k = topk_ids.shape[1]
+    num_routed_slots = topk_ids.shape[0] * top_k
+    device = topk_ids.device
+
+    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
+    routing_scratchpad = torch.empty(
+        get_build_routing_data_scratchpad_bytes(num_routed_slots),
+        dtype=torch.uint8,
+        device=device,
+    )
+    build_routing_data(
+        topk_ids.to(torch.int32).contiguous(),
+        routing_data,
+        slot_indices,
+        routing_offsets,
+        routing_scratchpad,
+        num_experts,
+    )
+    return MoERoutingLayout.from_kernel_outputs(
+        routing_data, slot_indices, routing_offsets, num_experts, top_k
+    )
+
+
 def prepare_moe_noising(
     A_q: torch.Tensor,
     A_scales: torch.Tensor,
     topk_ids: torch.Tensor,
     B_stacked: torch.Tensor,
     num_experts: int,
+    routing_layout: MoERoutingLayout | None = None,
 ) -> MoENoiseContext:
     """Compute hashes, MoE commitment, routing, and noise factors for one pass."""
 
@@ -150,26 +178,10 @@ def prepare_moe_noising(
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
     B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
 
-    num_routed_slots = num_tokens * top_k
-    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
-    routing_scratchpad = torch.empty(
-        get_build_routing_data_scratchpad_bytes(num_routed_slots),
-        dtype=torch.uint8,
-        device=device,
-    )
-    build_routing_data(
-        topk_ids.to(torch.int32).contiguous(),
-        routing_data,
-        slot_indices,
-        routing_offsets,
-        routing_scratchpad,
-        num_experts,
-    )
-    routing_layout = MoERoutingLayout.from_kernel_outputs(
-        routing_data, slot_indices, routing_offsets, num_experts, top_k
-    )
+    if routing_layout is None:
+        routing_layout = build_moe_routing_layout(topk_ids, num_experts)
+    routing_data = routing_layout.token_indices
+    routing_offsets = routing_layout.routing_offsets
     routing_hash = _routing_hash(routing_data, key_tensor, device)
 
     offsets_hash = _offsets_hash(routing_offsets, key_tensor, device)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import torch
@@ -26,8 +27,11 @@ from vllm.platforms import current_platform
 
 from .callbacks import MoEStatusCheckCallback
 from .config import config as pearl_config
+from .gemm_operators import pearl_gemm_vanilla
 from .mining_state import get_async_manager, get_pinned_pool
 from .moe_gemm_operators import (
+    MoERoutingLayout,
+    build_moe_routing_layout,
     pearl_moe_expert_gemm,
     permute_a_side_to_expert_order,
     prepare_moe_noising,
@@ -55,6 +59,11 @@ _TORCH_TO_TRITON_DTYPE: dict[torch.dtype, tl.dtype] = {
     torch.float16: tl.float16,
     torch.float32: tl.float32,
 }
+
+
+def _use_expert_local_mining_threshold() -> bool:
+    value = os.getenv("MINER_MOE_EXPERT_LOCAL_MINING", "1").lower()
+    return value not in {"0", "false", "no", "off"}
 
 
 def _torch_dtype_to_triton_compute_type(dtype: torch.dtype) -> tl.dtype:
@@ -156,6 +165,13 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
             return quant_7bit_smooth(hidden_states, smooth_scale=smooth)
         return quant_7bit(hidden_states)
 
+    @staticmethod
+    def _expert_mining_mask(layout: MoERoutingLayout, n: int, k: int) -> list[bool]:
+        return [
+            pearl_config.should_use_noisy_gemm(layout.expert_slice(expert_index)[1], n, k)
+            for expert_index in range(layout.num_experts)
+        ]
+
     def apply(
         self,
         output: torch.Tensor,
@@ -181,7 +197,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         if global_num_experts == GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS:
             global_num_experts = E
 
-        should_mine = (
+        should_try_mining = (
             not get_async_manager()._conf.no_mining
         ) and pearl_config.should_use_noisy_gemm(num_tokens, N, K)
 
@@ -202,7 +218,20 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         )
 
         gemm1_compute_type = _torch_dtype_to_triton_compute_type(hidden_states.dtype)
+        routing_layout = None
+        mine_expert_mask = None
+        should_mine = False
+        if should_try_mining:
+            routing_layout = build_moe_routing_layout(topk_ids, E)
+            if _use_expert_local_mining_threshold():
+                mine_expert_mask = self._expert_mining_mask(routing_layout, N, K)
+            else:
+                mine_expert_mask = [True] * E
+            should_mine = any(mine_expert_mask)
+
         if should_mine:
+            assert routing_layout is not None
+            assert mine_expert_mask is not None
             self._apply_per_expert_gemm1(
                 A_q=A_q,
                 A_scales=A_scales,
@@ -216,6 +245,8 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                 num_tokens=num_tokens,
                 top_k_num=top_k_num,
                 apply_router_weight_on_input=apply_router_weight_on_input,
+                routing_layout=routing_layout,
+                mine_expert_mask=mine_expert_mask,
             )
         else:
             # Vanilla int8 grouped GEMM1 (no mining / no denoise).
@@ -276,10 +307,19 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         num_tokens: int,
         top_k_num: int,
         apply_router_weight_on_input: bool,
+        routing_layout: MoERoutingLayout,
+        mine_expert_mask: list[bool],
     ) -> None:
-        """GEMM1: per-expert ``noisy_gemm`` with PoW extraction"""
+        """GEMM1: per-expert noisy GEMM for hot experts, vanilla for smaller ones."""
         B_stacked = w1.reshape(E * N, K)
-        ctx = prepare_moe_noising(A_q, A_scales, topk_ids, B_stacked, E)
+        ctx = prepare_moe_noising(
+            A_q,
+            A_scales,
+            topk_ids,
+            B_stacked,
+            E,
+            routing_layout=routing_layout,
+        )
         layout = ctx.routing_layout
 
         (
@@ -311,34 +351,45 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                     continue
                 expert_weight_start = expert_index * N
                 expert_weight_end = expert_weight_start + N
-                expert_output = gemm1_output_by_slot[:expert_slot_count]
+                A_q_e = A_q_by_expert[routing_start : routing_start + expert_slot_count]
+                A_scales_e = A_scales_by_expert[routing_start : routing_start + expert_slot_count]
+                B_e = B_stacked[expert_weight_start:expert_weight_end]
+                B_scales_e = self.w1_scale[expert_index]
 
-                pearl_moe_expert_gemm(
-                    A_q_e=A_q_by_expert[routing_start : routing_start + expert_slot_count],
-                    B_e=B_stacked[expert_weight_start:expert_weight_end],
-                    A_scales_e=A_scales_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    B_scales_e=self.w1_scale[expert_index],
-                    EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
-                    EAL_fp16_e=EAL_fp16_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
-                    EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
-                    EAR_R_major=ctx.EAR_R_major,
-                    EBL_R_major=ctx.EBL_R_major,
-                    EAR_K_major=ctx.EAR_K_major,
-                    EBL_K_major=ctx.EBL_K_major,
-                    C_e=expert_output,
-                    host_signal_header_pinned=pow_headers[expert_index],
-                    host_signal_sync=host_signal_sync,
-                    pow_target=ctx.pow_target,
-                    pow_key=ctx.pow_key,
-                    tile_size_m=tile_m,
-                    tile_size_n=tile_n,
-                    tile_size_k=tile_k,
-                )
+                if mine_expert_mask[expert_index]:
+                    expert_output = gemm1_output_by_slot[:expert_slot_count]
+                    pearl_moe_expert_gemm(
+                        A_q_e=A_q_e,
+                        B_e=B_e,
+                        A_scales_e=A_scales_e,
+                        B_scales_e=B_scales_e,
+                        EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
+                        EAL_fp16_e=EAL_fp16_by_expert[
+                            routing_start : routing_start + expert_slot_count
+                        ],
+                        EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
+                        EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
+                        EAR_R_major=ctx.EAR_R_major,
+                        EBL_R_major=ctx.EBL_R_major,
+                        EAR_K_major=ctx.EAR_K_major,
+                        EBL_K_major=ctx.EBL_K_major,
+                        C_e=expert_output,
+                        host_signal_header_pinned=pow_headers[expert_index],
+                        host_signal_sync=host_signal_sync,
+                        pow_target=ctx.pow_target,
+                        pow_key=ctx.pow_key,
+                        tile_size_m=tile_m,
+                        tile_size_n=tile_n,
+                        tile_size_k=tile_k,
+                    )
+                else:
+                    expert_output = pearl_gemm_vanilla(
+                        A_q_e.contiguous(),
+                        B_e.contiguous(),
+                        scale_a=A_scales_e.squeeze(-1).contiguous(),
+                        scale_b=B_scales_e.squeeze(-1).contiguous(),
+                        out_dtype=out_dtype,
+                    )
 
                 expert_slot_indices = layout.slot_indices[
                     routing_start : routing_start + expert_slot_count

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -44,6 +44,8 @@ _GEMM2_TOP_K = 1
 _MIN_COMPUTE_CAPABILITY_MAJOR = 9
 # vLLM sentinel meaning "infer expert count from the weight tensor".
 GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS = -1
+_EXPERT_LOCAL_MINING_ENV = "MINER_MOE_EXPERT_LOCAL_MINING"
+_EXPERT_LOCAL_MIN_M_ENV = "MINER_MOE_EXPERT_LOCAL_MIN_M"
 
 _SUPPORTED_ACTIVATIONS = frozenset(
     {
@@ -62,8 +64,30 @@ _TORCH_TO_TRITON_DTYPE: dict[torch.dtype, tl.dtype] = {
 
 
 def _use_expert_local_mining_threshold() -> bool:
-    value = os.getenv("MINER_MOE_EXPERT_LOCAL_MINING", "1").lower()
+    value = os.getenv(_EXPERT_LOCAL_MINING_ENV, "1").lower()
     return value not in {"0", "false", "no", "off"}
+
+
+def _expert_local_min_m() -> int:
+    gemm_config = pearl_config.matrix_multiplication_config["use_simplified_gemm"]
+    global_min_m = int(gemm_config["min_m"])
+    value = os.getenv(_EXPERT_LOCAL_MIN_M_ENV)
+    if value is None or value == "":
+        return global_min_m
+
+    try:
+        min_m = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be an integer") from exc
+
+    if min_m < global_min_m:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be >= {global_min_m}")
+
+    tile_size_m = int(pearl_config.settings.tile_size_m)
+    if min_m % tile_size_m != 0:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be a multiple of {tile_size_m}")
+
+    return min_m
 
 
 def _torch_dtype_to_triton_compute_type(dtype: torch.dtype) -> tl.dtype:
@@ -167,10 +191,14 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _expert_mining_mask(layout: MoERoutingLayout, n: int, k: int) -> list[bool]:
-        return [
-            pearl_config.should_use_noisy_gemm(layout.expert_slice(expert_index)[1], n, k)
-            for expert_index in range(layout.num_experts)
-        ]
+        gemm_config = pearl_config.matrix_multiplication_config["use_simplified_gemm"]
+        min_n = int(gemm_config["min_n"])
+        min_k = int(gemm_config["min_k"])
+        if (n == 1) or (k == 1) or (n < min_n) or (k < min_k):
+            return [False] * layout.num_experts
+
+        min_m = _expert_local_min_m()
+        return [layout.expert_slice(i)[1] >= min_m for i in range(layout.num_experts)]
 
     def apply(
         self,

--- a/miner/vllm-miner/tests/test_moe_block_submission.py
+++ b/miner/vllm-miner/tests/test_moe_block_submission.py
@@ -7,7 +7,9 @@ from miner_base.gpu_matmul_config import GPUMatmulConfigFactory
 from miner_base.settings import MinerSettings
 from miner_utils import get_logger
 from moe_testing_helpers import make_moe_tensors
+from pearl_gateway.comm.dataclasses import MiningJob
 from pearl_gateway.comm.mining_configuration import MoEConfig
+from pearl_mining import IncompleteBlockHeader
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
@@ -37,7 +39,24 @@ _HIDDEN_SIZE = 2048
 _INTERMEDIATE_SIZE = 1024
 _NUM_TOKENS = 2048
 _TOP_K = 2
-_EASY_TARGET = 2**242
+_EASY_NBITS = 0x207FFFFF
+_EASY_TARGET = 2**256 - 1
+
+
+def _with_header_nbits(mining_job: MiningJob, nbits: int) -> MiningJob:
+    header = IncompleteBlockHeader.from_bytes(mining_job.incomplete_header_bytes)
+    easy_header = IncompleteBlockHeader(
+        header.version,
+        header.prev_block,
+        header.merkle_root,
+        header.timestamp,
+        nbits,
+    )
+    return MiningJob(
+        incomplete_header_bytes=easy_header.to_bytes(),
+        target=mining_job.target,
+        cert_version=mining_job.cert_version,
+    )
 
 
 @pytest.fixture
@@ -116,22 +135,44 @@ def test_block_found_and_proof_verifies(pearl_moe_layer, get_mining_job, async_m
     matmul_config = GPUMatmulConfigFactory.create(
         k=k, noise_rank=noise_rank, moe=MoEConfig(e=_NUM_EXPERTS, top_k=_TOP_K)
     )
-    mining_job = get_mining_job(mining_config=matmul_config.mining_config, target=_EASY_TARGET)
+    mining_job = _with_header_nbits(
+        get_mining_job(mining_config=matmul_config.mining_config, target=_EASY_TARGET),
+        _EASY_NBITS,
+    )
 
     with patch.object(am, "_client") as mock_mining_client:
         mock_mining_client.get_mining_info.return_value = mining_job
         am._mining_job = am._client.get_mining_info()
 
-        moe_method.apply(
-            layer,
-            tensors.hidden_states,
-            tensors.topk_weights,
-            tensors.topk_ids,
-            None,
-        )
+        hot_experts = torch.arange(_TOP_K, dtype=torch.int32, device="cuda").expand(_NUM_TOKENS, -1)
+        tensors.topk_ids.copy_(hot_experts)
 
-        am.wait_until_done_submitting_blocks()
-        assert am.blocks_submitted == 1
+        start_time = time.time()
+        forward_count = 0
+        while am.blocks_submitted == 0:
+            if time.time() - start_time > _MINING_LOOP_TIMEOUT_SECONDS:
+                pytest.fail(
+                    f"Timeout ({_MINING_LOOP_TIMEOUT_SECONDS}s) waiting for block. "
+                    f"Performed {forward_count} forwards, "
+                    f"blocks_submitted={am.blocks_submitted}"
+                )
+
+            hidden_states = (
+                tensors.hidden_states
+                if forward_count == 0
+                else torch.randn_like(tensors.hidden_states)
+            )
+            moe_method.apply(
+                layer,
+                hidden_states,
+                tensors.topk_weights,
+                tensors.topk_ids,
+                None,
+            )
+            forward_count += 1
+            am.wait_until_done_submitting_blocks()
+
+        assert am.blocks_submitted >= 1
 
 
 @pytest.fixture

--- a/miner/vllm-miner/tests/test_moe_expert_threshold.py
+++ b/miner/vllm-miner/tests/test_moe_expert_threshold.py
@@ -1,0 +1,79 @@
+import pytest
+from vllm_miner.config import config as pearl_config
+from vllm_miner.pearl_moe_experts import (
+    _EXPERT_LOCAL_MIN_M_ENV,
+    _EXPERT_LOCAL_MINING_ENV,
+    PearlMoEExperts,
+    _expert_local_min_m,
+    _use_expert_local_mining_threshold,
+)
+
+
+class _FakeRoutingLayout:
+    def __init__(self, expert_counts: list[int]) -> None:
+        self._expert_counts = expert_counts
+        self.num_experts = len(expert_counts)
+
+    def expert_slice(self, expert_index: int) -> tuple[int, int]:
+        return sum(self._expert_counts[:expert_index]), self._expert_counts[expert_index]
+
+
+def test_expert_local_mining_threshold_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MINING_ENV, raising=False)
+    assert _use_expert_local_mining_threshold() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+def test_expert_local_mining_threshold_can_opt_out(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MINING_ENV, value)
+    assert _use_expert_local_mining_threshold() is False
+
+
+def test_expert_local_min_m_defaults_to_global_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MIN_M_ENV, raising=False)
+    global_min_m = pearl_config.matrix_multiplication_config["use_simplified_gemm"]["min_m"]
+    assert _expert_local_min_m() == global_min_m
+
+
+def test_expert_local_min_m_accepts_tile_aligned_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
+    assert _expert_local_min_m() == 1536
+
+
+@pytest.mark.parametrize("value", ["1023", "1153", "not-an-int"])
+def test_expert_local_min_m_rejects_invalid_override(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, value)
+    with pytest.raises(ValueError, match=_EXPERT_LOCAL_MIN_M_ENV):
+        _expert_local_min_m()
+
+
+def test_expert_mining_mask_uses_expert_local_min_m(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
+    layout = _FakeRoutingLayout([1024, 1535, 1536, 2048])
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1024) == [
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_expert_mining_mask_keeps_global_nk_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1024")
+    layout = _FakeRoutingLayout([2048, 2048])
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1023, k=1024) == [False, False]
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1023) == [False, False]


### PR DESCRIPTION
## Summary

This is the v1 MoE expert-local mining path on top of #182.
For MoE v2 - non public models exists yet, hence cant prove efficiency - cant open followup pr.

- Keep the existing global mining gate unchanged: mining is only attempted when the full MoE forward already passes `should_use_noisy_gemm(num_tokens, N, K)`.
- When that global gate passes, mine only experts whose routed-token count is large enough; cold experts use the vanilla int8 GEMM1 path.
- Keep the feature default-on, with an opt-out: `MINER_MOE_EXPERT_LOCAL_MINING=0` restores the old all-experts behavior after the global gate passes.
- Add `MINER_MOE_EXPERT_LOCAL_MIN_M` for serving-biased threshold experiments. Default is the global noisy-GEMM `min_m` (`1024` today). The override is intentionally constrained to `>=1024` and a multiple of `tile_size_m` (`128` today), so this PR does not mine below the current valid boundary.

## Benchmark evidence

Bench setup: RunPod H100, `pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl`, branch commit `829b00a3` for the expert-local behavior, `MINER_SKIP_BLOCK_SUBMISSION=1`, eager execution, no prefix cache. The threshold sweep used the same code path plus the threshold override that is now in this PR.

Baseline is the old/global MoE mining behavior: once the global gate passes, every expert in GEMM1 is mined. `mined slots/sec` combines serving throughput with mined routed slots/request, so it is the honest mining-throughput number.

| Shape | Threshold | Req/s vs old | Mined slots/request vs old | Mined slots/sec vs old | Read |
| --- | ---: | ---: | ---: | ---: | --- |
| input 1024, output 1, prompts 80 | 1024 | +37.1% | 88.2% | +21.0% | positive |
| input 2048, output 1, prompts 80 | 1024 | +29.2% | 87.3% | +12.7% | positive |
| input 3072, output 1, prompts 40 | 1024 | +29.4% | 87.9% | +13.7% | positive |
| input 2048, output 128, prompts 40 | 1024 | +12.9% | 88.3% | -0.3% | neutral/flat |
| input 2048, output 128, prompts 40 | 2048 | +16.9% | 77.0% | -10.0% | mining-negative |

No measured shape had negative serving throughput. The negative case is mined slots/sec: longer-output traffic spends more wall time outside the prefill-heavy mining window, so raising the expert threshold buys request throughput while losing effective mining throughput.

Threshold sweep summary:

| Shape | Best measured mining threshold | Mined slots/sec at 1024 | Mined slots/sec at 2048 | Serving delta at 2048 |
| --- | ---: | ---: | ---: | ---: |
| input 1024, output 1, prompts 80 | 1024 | +21.0% | +9.4% | +42.5% |
| input 2048, output 1, prompts 80 | 1024 | +12.7% | +4.8% | +39.8% |
| input 3072, output 1, prompts 40 | 1024 | +13.7% | +3.7% | +36.6% |
| input 2048, output 128, prompts 40 | 1024 | -0.3% | -10.0% | +16.9% |

Recommendation from these numbers:

- Keep `MINER_MOE_EXPERT_LOCAL_MIN_M` at `1024` when the goal is mined slots/sec.
- Raise the threshold only when serving throughput is the priority and lower mined slots/sec is acceptable.
- **For Pearl's stated usage, mining during prefill above 1024**, expert-local routing suggests the MoE threshold is probably too conservative for a future config/protocol experiment. This PR does not lower below 1024, but the data argues that if a lower valid MoE threshold is introduced later, it should be evaluated seriously because expert-local mining makes small cold experts cheap to skip.

## Validation

- `uv run pytest miner/vllm-miner/tests/test_moe_expert_threshold.py -q` - 12 passed
- `uv run pytest miner/vllm-miner/tests/test_vllm_interface.py::TestNoisyGemmSelectionThresholds -q` - 6 passed
- `uv run ruff check miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/tests/test_moe_expert_threshold.py`
- `git diff --check`
