### PR TITLE
Gate MoE mining per active expert

### DIFF
--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -115,12 +115,40 @@ def _offsets_hash(
     return _hash_2d(offsets_bytes.reshape(1, -1), key_tensor, device)
 
 
+def build_moe_routing_layout(topk_ids: torch.Tensor, num_experts: int) -> MoERoutingLayout:
+    """Build canonical routing data without committing or generating noise."""
+    top_k = topk_ids.shape[1]
+    num_routed_slots = topk_ids.shape[0] * top_k
+    device = topk_ids.device
+
+    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
+    routing_scratchpad = torch.empty(
+        get_build_routing_data_scratchpad_bytes(num_routed_slots),
+        dtype=torch.uint8,
+        device=device,
+    )
+    build_routing_data(
+        topk_ids.to(torch.int32).contiguous(),
+        routing_data,
+        slot_indices,
+        routing_offsets,
+        routing_scratchpad,
+        num_experts,
+    )
+    return MoERoutingLayout.from_kernel_outputs(
+        routing_data, slot_indices, routing_offsets, num_experts, top_k
+    )
+
+
 def prepare_moe_noising(
     A_q: torch.Tensor,
     A_scales: torch.Tensor,
     topk_ids: torch.Tensor,
     B_stacked: torch.Tensor,
     num_experts: int,
+    routing_layout: MoERoutingLayout | None = None,
 ) -> MoENoiseContext:
     """Compute hashes, MoE commitment, routing, and noise factors for one pass."""
 
@@ -150,26 +178,10 @@ def prepare_moe_noising(
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
     B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
 
-    num_routed_slots = num_tokens * top_k
-    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
-    routing_scratchpad = torch.empty(
-        get_build_routing_data_scratchpad_bytes(num_routed_slots),
-        dtype=torch.uint8,
-        device=device,
-    )
-    build_routing_data(
-        topk_ids.to(torch.int32).contiguous(),
-        routing_data,
-        slot_indices,
-        routing_offsets,
-        routing_scratchpad,
-        num_experts,
-    )
-    routing_layout = MoERoutingLayout.from_kernel_outputs(
-        routing_data, slot_indices, routing_offsets, num_experts, top_k
-    )
+    if routing_layout is None:
+        routing_layout = build_moe_routing_layout(topk_ids, num_experts)
+    routing_data = routing_layout.token_indices
+    routing_offsets = routing_layout.routing_offsets
     routing_hash = _routing_hash(routing_data, key_tensor, device)
 
     offsets_hash = _offsets_hash(routing_offsets, key_tensor, device)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import torch
@@ -26,8 +27,11 @@ from vllm.platforms import current_platform
 
 from .callbacks import MoEStatusCheckCallback
 from .config import config as pearl_config
+from .gemm_operators import pearl_gemm_vanilla
 from .mining_state import get_async_manager, get_pinned_pool
 from .moe_gemm_operators import (
+    MoERoutingLayout,
+    build_moe_routing_layout,
     pearl_moe_expert_gemm,
     permute_a_side_to_expert_order,
     prepare_moe_noising,
@@ -40,6 +44,8 @@ _GEMM2_QUANT_SCHEME = "fp8_w8a8"
 _MIN_COMPUTE_CAPABILITY_MAJOR = 9
 # vLLM sentinel meaning "infer expert count from the weight tensor".
 GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS = -1
+_EXPERT_LOCAL_MINING_ENV = "MINER_MOE_EXPERT_LOCAL_MINING"
+_EXPERT_LOCAL_MIN_M_ENV = "MINER_MOE_EXPERT_LOCAL_MIN_M"
 
 _SUPPORTED_ACTIVATIONS = frozenset(
     {
@@ -55,6 +61,33 @@ _TORCH_TO_TRITON_DTYPE: dict[torch.dtype, tl.dtype] = {
     torch.float16: tl.float16,
     torch.float32: tl.float32,
 }
+
+
+def _use_expert_local_mining_threshold() -> bool:
+    value = os.getenv(_EXPERT_LOCAL_MINING_ENV, "1").lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _expert_local_min_m() -> int:
+    gemm_config = pearl_config.matrix_multiplication_config["use_simplified_gemm"]
+    global_min_m = int(gemm_config["min_m"])
+    value = os.getenv(_EXPERT_LOCAL_MIN_M_ENV)
+    if value is None or value == "":
+        return global_min_m
+
+    try:
+        min_m = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be an integer") from exc
+
+    if min_m < global_min_m:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be >= {global_min_m}")
+
+    tile_size_m = int(pearl_config.settings.tile_size_m)
+    if min_m % tile_size_m != 0:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be a multiple of {tile_size_m}")
+
+    return min_m
 
 
 def _torch_dtype_to_triton_compute_type(dtype: torch.dtype) -> tl.dtype:
@@ -158,6 +191,17 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         smooth = w13_smooth[:K] if w13_smooth is not None else None
         return quant_7bit(hidden_states, smooth_scale=smooth)
 
+    @staticmethod
+    def _expert_mining_mask(layout: MoERoutingLayout, n: int, k: int) -> list[bool]:
+        gemm_config = pearl_config.matrix_multiplication_config["use_simplified_gemm"]
+        min_n = int(gemm_config["min_n"])
+        min_k = int(gemm_config["min_k"])
+        if (n == 1) or (k == 1) or (n < min_n) or (k < min_k):
+            return [False] * layout.num_experts
+
+        min_m = _expert_local_min_m()
+        return [layout.expert_slice(i)[1] >= min_m for i in range(layout.num_experts)]
+
     def apply(
         self,
         output: torch.Tensor,
@@ -183,7 +227,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         if global_num_experts == GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS:
             global_num_experts = E
 
-        should_mine = (
+        should_try_mining = (
             not get_async_manager()._conf.no_mining
         ) and pearl_config.should_use_noisy_gemm(num_tokens, N, K)
 
@@ -204,7 +248,20 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         )
 
         gemm1_compute_type = _torch_dtype_to_triton_compute_type(hidden_states.dtype)
+        routing_layout = None
+        mine_expert_mask = None
+        should_mine = False
+        if should_try_mining:
+            routing_layout = build_moe_routing_layout(topk_ids, E)
+            if _use_expert_local_mining_threshold():
+                mine_expert_mask = self._expert_mining_mask(routing_layout, N, K)
+            else:
+                mine_expert_mask = [True] * E
+            should_mine = any(mine_expert_mask)
+
         if should_mine:
+            assert routing_layout is not None
+            assert mine_expert_mask is not None
             self._apply_per_expert_gemm1(
                 A_q=A_q,
                 A_scales=A_scales,
@@ -218,6 +275,8 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                 num_tokens=num_tokens,
                 top_k_num=top_k_num,
                 apply_router_weight_on_input=apply_router_weight_on_input,
+                routing_layout=routing_layout,
+                mine_expert_mask=mine_expert_mask,
             )
         else:
             # Vanilla int8 grouped GEMM1 (no mining / no denoise).
@@ -272,10 +331,19 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         num_tokens: int,
         top_k_num: int,
         apply_router_weight_on_input: bool,
+        routing_layout: MoERoutingLayout,
+        mine_expert_mask: list[bool],
     ) -> None:
-        """GEMM1: per-expert ``noisy_gemm`` with PoW extraction"""
+        """GEMM1: per-expert noisy GEMM for hot experts, vanilla for smaller ones."""
         B_stacked = w1.reshape(E * N, K)
-        ctx = prepare_moe_noising(A_q, A_scales, topk_ids, B_stacked, E)
+        ctx = prepare_moe_noising(
+            A_q,
+            A_scales,
+            topk_ids,
+            B_stacked,
+            E,
+            routing_layout=routing_layout,
+        )
         layout = ctx.routing_layout
 
         (
@@ -307,34 +375,45 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                     continue
                 expert_weight_start = expert_index * N
                 expert_weight_end = expert_weight_start + N
-                expert_output = gemm1_output_by_slot[:expert_slot_count]
+                A_q_e = A_q_by_expert[routing_start : routing_start + expert_slot_count]
+                A_scales_e = A_scales_by_expert[routing_start : routing_start + expert_slot_count]
+                B_e = B_stacked[expert_weight_start:expert_weight_end]
+                B_scales_e = self.w1_scale[expert_index]
 
-                pearl_moe_expert_gemm(
-                    A_q_e=A_q_by_expert[routing_start : routing_start + expert_slot_count],
-                    B_e=B_stacked[expert_weight_start:expert_weight_end],
-                    A_scales_e=A_scales_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    B_scales_e=self.w1_scale[expert_index],
-                    EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
-                    EAL_fp16_e=EAL_fp16_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
-                    EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
-                    EAR_R_major=ctx.EAR_R_major,
-                    EBL_R_major=ctx.EBL_R_major,
-                    EAR_K_major=ctx.EAR_K_major,
-                    EBL_K_major=ctx.EBL_K_major,
-                    C_e=expert_output,
-                    host_signal_header_pinned=pow_headers[expert_index],
-                    host_signal_sync=host_signal_sync,
-                    pow_target=ctx.pow_target,
-                    pow_key=ctx.pow_key,
-                    tile_size_m=tile_m,
-                    tile_size_n=tile_n,
-                    tile_size_k=tile_k,
-                )
+                if mine_expert_mask[expert_index]:
+                    expert_output = gemm1_output_by_slot[:expert_slot_count]
+                    pearl_moe_expert_gemm(
+                        A_q_e=A_q_e,
+                        B_e=B_e,
+                        A_scales_e=A_scales_e,
+                        B_scales_e=B_scales_e,
+                        EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
+                        EAL_fp16_e=EAL_fp16_by_expert[
+                            routing_start : routing_start + expert_slot_count
+                        ],
+                        EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
+                        EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
+                        EAR_R_major=ctx.EAR_R_major,
+                        EBL_R_major=ctx.EBL_R_major,
+                        EAR_K_major=ctx.EAR_K_major,
+                        EBL_K_major=ctx.EBL_K_major,
+                        C_e=expert_output,
+                        host_signal_header_pinned=pow_headers[expert_index],
+                        host_signal_sync=host_signal_sync,
+                        pow_target=ctx.pow_target,
+                        pow_key=ctx.pow_key,
+                        tile_size_m=tile_m,
+                        tile_size_n=tile_n,
+                        tile_size_k=tile_k,
+                    )
+                else:
+                    expert_output = pearl_gemm_vanilla(
+                        A_q_e.contiguous(),
+                        B_e.contiguous(),
+                        scale_a=A_scales_e.squeeze(-1).contiguous(),
+                        scale_b=B_scales_e.squeeze(-1).contiguous(),
+                        out_dtype=out_dtype,
+                    )
 
                 expert_slot_indices = layout.slot_indices[
                     routing_start : routing_start + expert_slot_count

--- a/miner/vllm-miner/tests/test_moe_block_submission.py
+++ b/miner/vllm-miner/tests/test_moe_block_submission.py
@@ -140,16 +140,35 @@ def test_block_found_and_proof_verifies(pearl_moe_layer, get_mining_job, async_m
         mock_mining_client.get_mining_info.return_value = mining_job
         am._mining_job = am._client.get_mining_info()
 
-        moe_method.apply(
-            layer,
-            tensors.hidden_states,
-            tensors.topk_weights,
-            tensors.topk_ids,
-            None,
-        )
+        hot_experts = torch.arange(_TOP_K, dtype=torch.int32, device="cuda").expand(_NUM_TOKENS, -1)
+        tensors.topk_ids.copy_(hot_experts)
 
-        am.wait_until_done_submitting_blocks()
-        assert am.blocks_submitted == 1
+        start_time = time.time()
+        forward_count = 0
+        while am.blocks_submitted == 0:
+            if time.time() - start_time > _MINING_LOOP_TIMEOUT_SECONDS:
+                pytest.fail(
+                    f"Timeout ({_MINING_LOOP_TIMEOUT_SECONDS}s) waiting for block. "
+                    f"Performed {forward_count} forwards, "
+                    f"blocks_submitted={am.blocks_submitted}"
+                )
+
+            hidden_states = (
+                tensors.hidden_states
+                if forward_count == 0
+                else torch.randn_like(tensors.hidden_states)
+            )
+            moe_method.apply(
+                layer,
+                hidden_states,
+                tensors.topk_weights,
+                tensors.topk_ids,
+                None,
+            )
+            forward_count += 1
+            am.wait_until_done_submitting_blocks()
+
+        assert am.blocks_submitted >= 1
 
 
 @pytest.fixture

--- a/miner/vllm-miner/tests/test_moe_expert_threshold.py
+++ b/miner/vllm-miner/tests/test_moe_expert_threshold.py
@@ -1,0 +1,79 @@
+import pytest
+from vllm_miner.config import config as pearl_config
+from vllm_miner.pearl_moe_experts import (
+    _EXPERT_LOCAL_MIN_M_ENV,
+    _EXPERT_LOCAL_MINING_ENV,
+    PearlMoEExperts,
+    _expert_local_min_m,
+    _use_expert_local_mining_threshold,
+)
+
+
+class _FakeRoutingLayout:
+    def __init__(self, expert_counts: list[int]) -> None:
+        self._expert_counts = expert_counts
+        self.num_experts = len(expert_counts)
+
+    def expert_slice(self, expert_index: int) -> tuple[int, int]:
+        return sum(self._expert_counts[:expert_index]), self._expert_counts[expert_index]
+
+
+def test_expert_local_mining_threshold_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MINING_ENV, raising=False)
+    assert _use_expert_local_mining_threshold() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+def test_expert_local_mining_threshold_can_opt_out(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MINING_ENV, value)
+    assert _use_expert_local_mining_threshold() is False
+
+
+def test_expert_local_min_m_defaults_to_global_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MIN_M_ENV, raising=False)
+    global_min_m = pearl_config.matrix_multiplication_config["use_simplified_gemm"]["min_m"]
+    assert _expert_local_min_m() == global_min_m
+
+
+def test_expert_local_min_m_accepts_tile_aligned_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
+    assert _expert_local_min_m() == 1536
+
+
+@pytest.mark.parametrize("value", ["1023", "1153", "not-an-int"])
+def test_expert_local_min_m_rejects_invalid_override(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, value)
+    with pytest.raises(ValueError, match=_EXPERT_LOCAL_MIN_M_ENV):
+        _expert_local_min_m()
+
+
+def test_expert_mining_mask_uses_expert_local_min_m(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
+    layout = _FakeRoutingLayout([1024, 1535, 1536, 2048])
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1024) == [
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_expert_mining_mask_keeps_global_nk_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1024")
+    layout = _FakeRoutingLayout([2048, 2048])
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1023, k=1024) == [False, False]
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1023) == [False, False]


### PR DESCRIPTION
Stacked on #188 (`moe_f8_down_proj`).

This changes MoE GEMM1 mining so the global mining gate still decides whether a forward is eligible, but each routed expert is mined only when that expert has enough routed slots. Cold experts fall back to the vanilla Pearl int8 GEMM path. The second MoE GEMM keeps the v2 fp8-down-proj path unchanged.

Controls:
- `MINER_MOE_EXPERT_LOCAL_MINING=0` opts out and restores the old mine-all-active-experts behavior after the global gate.
- `MINER_MOE_EXPERT_LOCAL_MIN_M` can raise the per-expert M threshold. It defaults to the existing global `min_m` and must be tile-aligned.

One subtlety from the profiles: the existing threshold is on the batched GEMM M, not per-request input length. For example, `input_len=512, prompts=4` still crosses the old global gate because the batch has 2048 tokens.

Benchmarks on H100 80GB with the updated v2 model `pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl`, `vllm bench throughput`, eager mode, prefix caching disabled, 2 repeats for throughput rows:

| case | old/global req/s | expert-local req/s | delta | expert-local mined slots vs old |
| --- | ---: | ---: | ---: | ---: |
| input 1024, output 1, prompts 80 | 17.58 | 24.37 | +38.63% | 88.41% |
| input 2048, output 1, prompts 80 | 9.35 | 12.02 | +28.54% | 87.77% |
| input 3072, output 1, prompts 40 | 5.93 | 7.62 | +28.47% | 88.18% |
| input 2048, output 128, prompts 40 | 3.91 | 4.35 | +11.26% | 88.88% |

Additional profile rows around the threshold:

| case | expert-local mined slots vs old |
| --- | ---: |
| input 512, output 1, prompts 4 | 96.56% |
| input 1024, output 1, prompts 4 | 92.46% |
| input 1025, output 1, prompts 4 | 93.53% |
| input 2048, output 1, prompts 4 | 92.93% |

Verification:
- `uvx ruff check miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_block_submission.py`
- `python3 -m py_compile miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_block_submission.py`
- H100: `MINER_NO_GATEWAY=1 uv run --package vllm-miner pytest miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_per_expert.py miner/vllm-miner/tests/test_moe_block_submission.py::test_block_found_and_proof_verifies -q` -> 16 passed.
