### PR TITLE
fix(gateway): refresh same-tip mining templates

### DIFF
--- a/miner/pearl-gateway/src/pearl_gateway/work_cache.py
+++ b/miner/pearl-gateway/src/pearl_gateway/work_cache.py
@@ -1,11 +1,38 @@
 import asyncio
 import time
+from typing import NamedTuple
 
 from miner_utils import get_logger
 
 from pearl_gateway.comm.dataclasses import BlockTemplate, MiningJob, MiningPausedError
 
 logger = get_logger(__name__)
+
+
+class _TemplateIdentity(NamedTuple):
+    height: int
+    version: int
+    previous_block_hash: bytes
+    merkle_root: bytes
+    target_bits: int
+    required_cert_version: int
+
+
+def _template_identity(template: BlockTemplate) -> _TemplateIdentity:
+    """Fields that make cached miner work materially different.
+
+    Timestamp is omitted because the node refreshes it without regenerating a
+    block template, and updating on every tick would reject in-flight proofs.
+    """
+    header = template.header
+    return _TemplateIdentity(
+        height=template.height,
+        version=header.version,
+        previous_block_hash=header.previous_block_hash,
+        merkle_root=header.merkle_root,
+        target_bits=header.target_bits,
+        required_cert_version=int(template.required_cert_version),
+    )
 
 
 class WorkCache:
@@ -25,11 +52,11 @@ class WorkCache:
         Returns True if template was updated, False if unchanged.
         """
         async with self.lock:
-            is_new = (
-                self.current_template is None
-                or template.header.previous_block_hash
-                != self.current_template.header.previous_block_hash
-            )
+            current_template = self.current_template
+            if current_template is None:
+                is_new = True
+            else:
+                is_new = _template_identity(template) != _template_identity(current_template)
 
             if is_new:
                 logger.info(f"Updating block template to height {template.height}")

--- a/miner/pearl-gateway/tests/test_work_cache.py
+++ b/miner/pearl-gateway/tests/test_work_cache.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from bitcoinutils.transactions import Transaction
 from pearl_gateway.blockchain_utils.pearl_header import PearlHeader
+from pearl_gateway.blockchain_utils.zk_certificate import CertificateVersion
 from pearl_gateway.comm.dataclasses import BlockTemplate, MiningJob, MiningPausedError
 from pearl_gateway.work_cache import WorkCache
 from pearl_mining import IncompleteBlockHeader
@@ -18,6 +19,32 @@ from pearl_mining import IncompleteBlockHeader
 def work_cache():
     """Create a WorkCache instance for testing."""
     return WorkCache()
+
+
+def _template_with_header(
+    template: BlockTemplate,
+    *,
+    version: int | None = None,
+    merkle_root: bytes | None = None,
+    timestamp: int | None = None,
+    target_bits: int | None = None,
+    required_cert_version: CertificateVersion | None = None,
+) -> BlockTemplate:
+    return BlockTemplate(
+        header=PearlHeader(
+            incomplete_header=IncompleteBlockHeader(
+                version=version if version is not None else template.header.version,
+                prev_block=template.header.previous_block_hash,
+                merkle_root=merkle_root if merkle_root is not None else template.header.merkle_root,
+                timestamp=timestamp if timestamp is not None else template.header.timestamp,
+                nbits=target_bits if target_bits is not None else template.header.target_bits,
+            ),
+        ),
+        height=template.height,
+        coinbase_tx=template.coinbase_tx,
+        raw_transactions=list(template.raw_transactions),
+        required_cert_version=required_cert_version or template.required_cert_version,
+    )
 
 
 @pytest.fixture
@@ -83,6 +110,87 @@ class TestTemplateUpdate:
 
         assert result is True
         assert work_cache.current_template == different_block_template
+        assert work_cache.last_update_time == 1010.0
+
+    @pytest.mark.asyncio
+    async def test_update_template_same_tip_different_merkle_root(
+        self, work_cache, sample_block_template
+    ):
+        """Same previous block can still be a new mining template."""
+        updated_template = _template_with_header(
+            sample_block_template,
+            merkle_root=bytes.fromhex("22" * 32),
+        )
+
+        with patch("time.time", return_value=1000.0):
+            await work_cache.update_template(sample_block_template)
+
+        with patch("time.time", return_value=1010.0):
+            result = await work_cache.update_template(updated_template)
+
+        assert result is True
+        assert work_cache.current_template == updated_template
+        assert work_cache.last_update_time == 1010.0
+
+    @pytest.mark.asyncio
+    async def test_update_template_ignores_timestamp_only_refresh(
+        self, work_cache, sample_block_template
+    ):
+        """Do not invalidate in-flight miner jobs for node timestamp churn."""
+        updated_template = _template_with_header(
+            sample_block_template,
+            timestamp=sample_block_template.header.timestamp + 1,
+        )
+
+        with patch("time.time", return_value=1000.0):
+            await work_cache.update_template(sample_block_template)
+
+        with patch("time.time", return_value=1010.0):
+            result = await work_cache.update_template(updated_template)
+
+        assert result is False
+        assert work_cache.current_template == sample_block_template
+        assert work_cache.last_update_time == 1000.0
+
+    @pytest.mark.asyncio
+    async def test_update_template_same_tip_different_target_bits(
+        self, work_cache, sample_block_template
+    ):
+        """Difficulty changes alter the miner target even on the same tip."""
+        updated_template = _template_with_header(
+            sample_block_template,
+            target_bits=sample_block_template.header.target_bits + 1,
+            timestamp=sample_block_template.header.timestamp + 1,
+        )
+
+        with patch("time.time", return_value=1000.0):
+            await work_cache.update_template(sample_block_template)
+
+        with patch("time.time", return_value=1010.0):
+            result = await work_cache.update_template(updated_template)
+
+        assert result is True
+        assert work_cache.current_template == updated_template
+        assert work_cache.last_update_time == 1010.0
+
+    @pytest.mark.asyncio
+    async def test_update_template_same_header_different_cert_version(
+        self, work_cache, sample_block_template
+    ):
+        """Certificate version is part of the mining job contract."""
+        updated_template = _template_with_header(
+            sample_block_template,
+            required_cert_version=CertificateVersion.ZK_DENSE,
+        )
+
+        with patch("time.time", return_value=1000.0):
+            await work_cache.update_template(sample_block_template)
+
+        with patch("time.time", return_value=1010.0):
+            result = await work_cache.update_template(updated_template)
+
+        assert result is True
+        assert work_cache.current_template == updated_template
         assert work_cache.last_update_time == 1010.0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace the WorkCache prev-hash-only check with a mining-template identity: height, version, prev hash, merkle root, target bits, and cert version
- intentionally ignore timestamp-only node refreshes so in-flight proofs are not rejected on every time tick
- add regression coverage for same-tip merkle, target-bits, cert-version, and timestamp-only refresh behavior

## Root cause
The node can return a newer getblocktemplate result on the same previous block hash when the mempool changes and the template regenerates. The old WorkCache treated same prev hash as unchanged, so miners could keep receiving stale same-tip work.

## Validation
- reproduced the stale same-tip bug with the new merkle-root regression before the fix
- `CUDA_VISIBLE_DEVICES= uv run --package pearl-gateway pytest -q miner/pearl-gateway/tests/test_work_cache.py` -> 16 passed
- `CUDA_VISIBLE_DEVICES= uv run --package pearl-gateway pytest -q miner/pearl-gateway/tests` -> 150 passed
- `uv run --package pearl-gateway ruff check miner/pearl-gateway/src/pearl_gateway/work_cache.py miner/pearl-gateway/tests/test_work_cache.py`
- `uv run --package pearl-gateway ruff format --check miner/pearl-gateway/src/pearl_gateway/work_cache.py miner/pearl-gateway/tests/test_work_cache.py`
