### PR TITLE
Gate MoE mining per active expert

### DIFF
--- a/miner/vllm-miner/benchmarks/bench_moe_expert_gate.py
+++ b/miner/vllm-miner/benchmarks/bench_moe_expert_gate.py
@@ -1,0 +1,342 @@
+"""Benchmark MoE expert-local mining gate break-even on a RunPod H100.
+
+Example:
+    uv run --package vllm-miner python \
+        miner/vllm-miner/benchmarks/bench_moe_expert_gate.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import torch
+from compressed_tensors.quantization import QuantizationArgs
+from miner_base.settings import MinerSettings
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.v1.worker.workspace import init_workspace_manager, is_workspace_manager_initialized
+from vllm_miner.config import config as pearl_config
+from vllm_miner.mining_state import delete_state, init_async_manager, init_pinned_pool
+from vllm_miner.pearl_moe_experts import (
+    _EXPERT_LOCAL_MIN_M_ENV,
+    _EXPERT_LOCAL_MINING_ENV,
+)
+from vllm_miner.pearl_moe_method import PearlMoEMethod
+
+_DOWN_WEIGHT_QUANT = QuantizationArgs(
+    num_bits=8,
+    type="float",
+    strategy="block",
+    block_structure=[128, 128],
+    symmetric=True,
+    dynamic=False,
+)
+_DOWN_INPUT_QUANT = QuantizationArgs(
+    num_bits=8,
+    type="float",
+    strategy="group",
+    group_size=128,
+    dynamic=True,
+    symmetric=True,
+)
+
+
+@contextmanager
+def _temporary_env(name: str, value: str | None) -> Iterator[None]:
+    old_value = os.environ.get(name)
+    if value is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = value
+    try:
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = old_value
+
+
+def _global_min_m() -> int:
+    return int(pearl_config.matrix_multiplication_config["use_simplified_gemm"]["min_m"])
+
+
+def _make_topk_ids_from_counts(
+    counts: list[int],
+    top_k: int,
+    device: torch.device,
+) -> torch.Tensor:
+    total_slots = sum(counts)
+    if total_slots % top_k != 0:
+        raise ValueError(f"sum(counts)={total_slots} must be divisible by top_k={top_k}")
+    flat = torch.cat(
+        [
+            torch.full((count,), expert_id, dtype=torch.int32, device=device)
+            for expert_id, count in enumerate(counts)
+        ]
+    )
+    return flat.reshape(total_slots // top_k, top_k).contiguous()
+
+
+def _make_cases(num_experts: int, min_m: int, top_k: int) -> list[tuple[str, list[int]]]:
+    cold = min_m - 1
+
+    def counts_with(hot_counts: list[int]) -> list[int]:
+        counts = [cold] * num_experts
+        for expert_id, count in enumerate(hot_counts):
+            if expert_id >= num_experts:
+                raise ValueError(f"num_experts={num_experts} is too small for benchmark cases")
+            counts[expert_id] = count
+        remainder = sum(counts) % top_k
+        if remainder:
+            counts[-1] -= remainder
+            if counts[-1] < 0:
+                raise ValueError(f"top_k={top_k} is too large for generated counts")
+        return counts
+
+    return [
+        ("0-hot-all-cold", counts_with([])),
+        ("1-hot-exact", counts_with([min_m])),
+        ("2-hot-exact", counts_with([min_m, min_m])),
+        ("several-hot-mixed", counts_with([min_m - 1, min_m, min_m + 1, min_m * 2])),
+        ("below-above-edge", counts_with([min_m - 1, min_m + 1])),
+    ]
+
+
+def _build_layer(
+    *,
+    num_experts: int,
+    hidden_size: int,
+    intermediate_size: int,
+    top_k: int,
+    device: torch.device,
+) -> tuple[PearlMoEMethod, torch.nn.Module]:
+    if not is_workspace_manager_initialized():
+        init_workspace_manager(device)
+
+    moe_config = FusedMoEConfig(
+        num_experts=num_experts,
+        experts_per_token=top_k,
+        hidden_dim=hidden_size,
+        intermediate_size_per_partition=intermediate_size,
+        num_local_experts=num_experts,
+        num_logical_experts=num_experts,
+        activation=MoEActivation.SILU,
+        device=str(device),
+        routing_method=RoutingMethodType.Default,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        in_dtype=torch.bfloat16,
+    )
+    moe_method = PearlMoEMethod(moe_config, _DOWN_WEIGHT_QUANT, _DOWN_INPUT_QUANT)
+    layer = torch.nn.Module()
+    moe_method.create_weights(
+        layer,
+        num_experts=num_experts,
+        hidden_size=hidden_size,
+        intermediate_size_per_partition=intermediate_size,
+        params_dtype=torch.bfloat16,
+    )
+
+    weight_scale = 1.0 / 64.0
+    layer.w13_weight.data.copy_(
+        torch.randint(
+            -63,
+            64,
+            (num_experts, 2 * intermediate_size, hidden_size),
+            dtype=torch.int8,
+            device=device,
+        )
+    )
+    layer.w2_weight.data.copy_(
+        (torch.randn(num_experts, hidden_size, intermediate_size, device=device) * weight_scale).to(
+            torch.float8_e4m3fn
+        )
+    )
+    layer.w13_weight_scale.data.fill_(weight_scale)
+    layer.w2_weight_scale.data.fill_(1.0)
+
+    layer.to(device)
+    init_pinned_pool()
+    moe_method.process_weights_after_loading(layer)
+    layer.activation = MoEActivation.SILU
+    layer.global_num_experts = num_experts
+    layer.apply_router_weight_on_input = False
+    layer.expert_map = None
+    return moe_method, layer
+
+
+def _reset_mining_state(no_mining: bool) -> None:
+    delete_state()
+    init_async_manager(
+        MinerSettings(no_gateway=True, no_mining=no_mining, skip_block_submission=True)
+    )
+    init_pinned_pool()
+
+
+def _time_case(
+    moe_method: PearlMoEMethod,
+    layer: torch.nn.Module,
+    counts: list[int],
+    *,
+    top_k: int,
+    hidden_size: int,
+    warmup: int,
+    iterations: int,
+    device: torch.device,
+) -> float:
+    topk_ids = _make_topk_ids_from_counts(counts, top_k, device)
+    num_tokens = topk_ids.shape[0]
+    hidden_states = torch.randn(num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
+    topk_weights = torch.full((num_tokens, top_k), 1.0 / top_k, dtype=torch.float32, device=device)
+
+    for _ in range(warmup):
+        moe_method.apply(layer, hidden_states, topk_weights, topk_ids, None)
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        moe_method.apply(layer, hidden_states, topk_weights, topk_ids, None)
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def _run_mode(
+    mode: str,
+    no_mining: bool,
+    expert_local_env: str | None,
+    moe_method: PearlMoEMethod,
+    layer: torch.nn.Module,
+    cases: list[tuple[str, list[int]]],
+    args: argparse.Namespace,
+    device: torch.device,
+) -> list[dict[str, float | int | str]]:
+    rows = []
+    _reset_mining_state(no_mining=no_mining)
+    with _temporary_env(_EXPERT_LOCAL_MINING_ENV, expert_local_env):
+        for case_name, counts in cases:
+            samples = [
+                _time_case(
+                    moe_method,
+                    layer,
+                    counts,
+                    top_k=args.top_k,
+                    hidden_size=args.hidden_size,
+                    warmup=args.warmup,
+                    iterations=args.iterations,
+                    device=device,
+                )
+                for _ in range(args.repeats)
+            ]
+            avg_ms = statistics.mean(samples)
+            total_slots = sum(counts)
+            rows.append(
+                {
+                    "mode": mode,
+                    "case": case_name,
+                    "qualifying": sum(count >= args.min_m for count in counts),
+                    "slots": total_slots,
+                    "tokens": total_slots // args.top_k,
+                    "avg_ms": avg_ms,
+                    "slots_per_s": total_slots / (avg_ms / 1000.0),
+                }
+            )
+    return rows
+
+
+def _print_rows(rows: list[dict[str, float | int | str]]) -> None:
+    print(
+        "mode,case,qualifying_experts,routed_slots,tokens,avg_ms,slots_per_s",
+        flush=True,
+    )
+    for row in rows:
+        print(
+            f"{row['mode']},{row['case']},{row['qualifying']},{row['slots']},"
+            f"{row['tokens']},{row['avg_ms']:.3f},{row['slots_per_s']:.1f}",
+            flush=True,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-experts", type=int, default=8)
+    parser.add_argument("--hidden-size", type=int, default=2048)
+    parser.add_argument("--intermediate-size", type=int, default=1024)
+    parser.add_argument("--top-k", type=int, default=1)
+    parser.add_argument("--min-m", type=int, default=_global_min_m())
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--allow-non-h100", action="store_true")
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda")
+    device_name = torch.cuda.get_device_name(device)
+    if "H100" not in device_name and not args.allow_non_h100:
+        raise RuntimeError(f"Expected H100 for this benchmark, got {device_name!r}")
+
+    with _temporary_env(_EXPERT_LOCAL_MIN_M_ENV, str(args.min_m)):
+        _reset_mining_state(no_mining=True)
+        moe_method, layer = _build_layer(
+            num_experts=args.num_experts,
+            hidden_size=args.hidden_size,
+            intermediate_size=args.intermediate_size,
+            top_k=args.top_k,
+            device=device,
+        )
+        cases = _make_cases(args.num_experts, args.min_m, args.top_k)
+        rows = []
+        rows.extend(
+            _run_mode(
+                "grouped-vanilla",
+                True,
+                None,
+                moe_method,
+                layer,
+                cases,
+                args,
+                device,
+            )
+        )
+        rows.extend(
+            _run_mode(
+                "mine-all-active",
+                False,
+                "0",
+                moe_method,
+                layer,
+                cases,
+                args,
+                device,
+            )
+        )
+        rows.extend(
+            _run_mode(
+                "expert-local-gate",
+                False,
+                None,
+                moe_method,
+                layer,
+                cases,
+                args,
+                device,
+            )
+        )
+        _print_rows(rows)
+    delete_state()
+
+
+if __name__ == "__main__":
+    main()

--- a/miner/vllm-miner/benchmarks/bench_moe_expert_gate.py
+++ b/miner/vllm-miner/benchmarks/bench_moe_expert_gate.py
@@ -240,15 +240,23 @@ def _run_mode(
             ]
             avg_ms = statistics.mean(samples)
             total_slots = sum(counts)
+            if no_mining:
+                mined_slots = 0
+            elif expert_local_env == "0":
+                mined_slots = sum(count for count in counts if count > 0)
+            else:
+                mined_slots = sum(count for count in counts if count >= args.min_m)
             rows.append(
                 {
                     "mode": mode,
                     "case": case_name,
                     "qualifying": sum(count >= args.min_m for count in counts),
                     "slots": total_slots,
+                    "mined_slots": mined_slots,
                     "tokens": total_slots // args.top_k,
                     "avg_ms": avg_ms,
                     "slots_per_s": total_slots / (avg_ms / 1000.0),
+                    "mined_slots_per_s": mined_slots / (avg_ms / 1000.0),
                 }
             )
     return rows
@@ -256,13 +264,15 @@ def _run_mode(
 
 def _print_rows(rows: list[dict[str, float | int | str]]) -> None:
     print(
-        "mode,case,qualifying_experts,routed_slots,tokens,avg_ms,slots_per_s",
+        "mode,case,qualifying_experts,routed_slots,mined_slots,tokens,"
+        "avg_ms,slots_per_s,mined_slots_per_s",
         flush=True,
     )
     for row in rows:
         print(
             f"{row['mode']},{row['case']},{row['qualifying']},{row['slots']},"
-            f"{row['tokens']},{row['avg_ms']:.3f},{row['slots_per_s']:.1f}",
+            f"{row['mined_slots']},{row['tokens']},{row['avg_ms']:.3f},"
+            f"{row['slots_per_s']:.1f},{row['mined_slots_per_s']:.1f}",
             flush=True,
         )
 

--- a/miner/vllm-miner/src/vllm_miner/callbacks.py
+++ b/miner/vllm-miner/src/vllm_miner/callbacks.py
@@ -66,17 +66,17 @@ class StatusCheckCallback:
 
 @dataclass
 class MoEStatusCheckCallback:
-    """Check PoW results across all MoE expert headers for one forward pass.
+    """Check PoW results across mined MoE expert headers for one forward pass.
 
-    Headers are acquired from the global pinned pool in ``PearlMoEExperts.apply``
-    (one per expert) and released back here in the ``finally`` block. On a hit,
-    the expert-local (inner) row indices are mapped to global outer token indices
-    via ``routing_data`` so the proof can be built against the full activation.
-    The routing hash tensor is retained for lifetime symmetry with the scheduled
-    GPU work even though the CPU callback does not inspect it directly.
+    Headers are acquired from the global pinned pool only for experts that run a
+    mined GEMM and released back here in the ``finally`` block. On a hit, the
+    expert-local (inner) row indices are mapped to global outer token indices via
+    ``routing_data`` so the proof can be built against the full activation. The
+    routing hash tensor is retained for lifetime symmetry with the scheduled GPU
+    work even though the CPU callback does not inspect it directly.
     """
 
-    pow_headers: list[torch.Tensor]
+    pow_headers: list[tuple[int, torch.Tensor]]
     commitment_hash_A_tensor: torch.Tensor
     commitment_hash_B_tensor: torch.Tensor
     A_q: torch.Tensor  # (m, k) int8, original token order (non-noised)
@@ -93,8 +93,8 @@ class MoEStatusCheckCallback:
     def __call__(self, handle_submit_block) -> None:
         """Submit the first triggered expert block and release all pinned headers."""
         try:
-            for expert_index in range(self.num_experts):
-                header = get_host_signal_header(self.pow_headers[expert_index])
+            for expert_index, header_tensor in self.pow_headers:
+                header = get_host_signal_header(header_tensor)
                 if header.status != HostSignalStatus.kSignalTriggered:
                     continue
 
@@ -150,7 +150,7 @@ class MoEStatusCheckCallback:
                 handle_submit_block(opened_block_info, self.mining_job)
                 break
         finally:
-            for header_tensor in self.pow_headers:
+            for _, header_tensor in self.pow_headers:
                 get_pinned_pool().release(header_tensor)
             self.pow_headers = []
             del self.commitment_hash_A_tensor

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -115,12 +115,40 @@ def _offsets_hash(
     return _hash_2d(offsets_bytes.reshape(1, -1), key_tensor, device)
 
 
+def build_moe_routing_layout(topk_ids: torch.Tensor, num_experts: int) -> MoERoutingLayout:
+    """Build canonical routing data without committing or generating noise."""
+    top_k = topk_ids.shape[1]
+    num_routed_slots = topk_ids.shape[0] * top_k
+    device = topk_ids.device
+
+    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
+    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
+    routing_scratchpad = torch.empty(
+        get_build_routing_data_scratchpad_bytes(num_routed_slots),
+        dtype=torch.uint8,
+        device=device,
+    )
+    build_routing_data(
+        topk_ids.to(torch.int32).contiguous(),
+        routing_data,
+        slot_indices,
+        routing_offsets,
+        routing_scratchpad,
+        num_experts,
+    )
+    return MoERoutingLayout.from_kernel_outputs(
+        routing_data, slot_indices, routing_offsets, num_experts, top_k
+    )
+
+
 def prepare_moe_noising(
     A_q: torch.Tensor,
     A_scales: torch.Tensor,
     topk_ids: torch.Tensor,
     B_stacked: torch.Tensor,
     num_experts: int,
+    routing_layout: MoERoutingLayout | None = None,
 ) -> MoENoiseContext:
     """Compute hashes, MoE commitment, routing, and noise factors for one pass."""
 
@@ -150,26 +178,10 @@ def prepare_moe_noising(
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
     B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
 
-    num_routed_slots = num_tokens * top_k
-    routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
-    routing_offsets = torch.empty(num_experts, dtype=torch.int32, device=device)
-    routing_scratchpad = torch.empty(
-        get_build_routing_data_scratchpad_bytes(num_routed_slots),
-        dtype=torch.uint8,
-        device=device,
-    )
-    build_routing_data(
-        topk_ids.to(torch.int32).contiguous(),
-        routing_data,
-        slot_indices,
-        routing_offsets,
-        routing_scratchpad,
-        num_experts,
-    )
-    routing_layout = MoERoutingLayout.from_kernel_outputs(
-        routing_data, slot_indices, routing_offsets, num_experts, top_k
-    )
+    if routing_layout is None:
+        routing_layout = build_moe_routing_layout(topk_ids, num_experts)
+    routing_data = routing_layout.token_indices
+    routing_offsets = routing_layout.routing_offsets
     routing_hash = _routing_hash(routing_data, key_tensor, device)
 
     offsets_hash = _offsets_hash(routing_offsets, key_tensor, device)

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -202,6 +202,16 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         min_m = _expert_local_min_m()
         return [layout.expert_slice(i)[1] >= min_m for i in range(layout.num_experts)]
 
+    @staticmethod
+    def _active_expert_mask(layout: MoERoutingLayout) -> list[bool]:
+        return [layout.expert_slice(i)[1] > 0 for i in range(layout.num_experts)]
+
+    @classmethod
+    def _forward_mining_mask(cls, layout: MoERoutingLayout, n: int, k: int) -> list[bool]:
+        if _use_expert_local_mining_threshold():
+            return cls._expert_mining_mask(layout, n, k)
+        return cls._active_expert_mask(layout)
+
     def apply(
         self,
         output: torch.Tensor,
@@ -253,10 +263,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         should_mine = False
         if should_try_mining:
             routing_layout = build_moe_routing_layout(topk_ids, E)
-            if _use_expert_local_mining_threshold():
-                mine_expert_mask = self._expert_mining_mask(routing_layout, N, K)
-            else:
-                mine_expert_mask = [True] * E
+            mine_expert_mask = self._forward_mining_mask(routing_layout, N, K)
             should_mine = any(mine_expert_mask)
 
         if should_mine:
@@ -362,7 +369,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         )
 
         submit = not get_async_manager()._conf.skip_block_submission
-        pow_headers = [get_pinned_pool().acquire() for _ in range(E)]
+        pow_headers: list[tuple[int, torch.Tensor]] = []
 
         tile_m = pearl_config.settings.tile_size_m
         tile_n = pearl_config.settings.tile_size_n
@@ -381,6 +388,8 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                 B_scales_e = self.w1_scale[expert_index]
 
                 if mine_expert_mask[expert_index]:
+                    pow_header = get_pinned_pool().acquire()
+                    pow_headers.append((expert_index, pow_header))
                     expert_output = gemm1_output_by_slot[:expert_slot_count]
                     pearl_moe_expert_gemm(
                         A_q_e=A_q_e,
@@ -398,7 +407,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                         EAR_K_major=ctx.EAR_K_major,
                         EBL_K_major=ctx.EBL_K_major,
                         C_e=expert_output,
-                        host_signal_header_pinned=pow_headers[expert_index],
+                        host_signal_header_pinned=pow_header,
                         host_signal_sync=host_signal_sync,
                         pow_target=ctx.pow_target,
                         pow_key=ctx.pow_key,
@@ -423,12 +432,12 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                     expert_output = expert_output * expert_weights.unsqueeze(-1)
                 cache_flat[expert_slot_indices] = expert_output
         except Exception:
-            for header_tensor in pow_headers:
+            for _, header_tensor in pow_headers:
                 get_pinned_pool().release(header_tensor)
             raise
 
         if not submit:
-            for header_tensor in pow_headers:
+            for _, header_tensor in pow_headers:
                 get_pinned_pool().release(header_tensor)
             return
 

--- a/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
+++ b/miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py
@@ -1,3 +1,4 @@
+import os
 from typing import Any
 
 import torch
@@ -26,8 +27,11 @@ from vllm.platforms import current_platform
 
 from .callbacks import MoEStatusCheckCallback
 from .config import config as pearl_config
+from .gemm_operators import pearl_gemm_vanilla
 from .mining_state import get_async_manager, get_pinned_pool
 from .moe_gemm_operators import (
+    MoERoutingLayout,
+    build_moe_routing_layout,
     pearl_moe_expert_gemm,
     permute_a_side_to_expert_order,
     prepare_moe_noising,
@@ -40,6 +44,8 @@ _GEMM2_QUANT_SCHEME = "fp8_w8a8"
 _MIN_COMPUTE_CAPABILITY_MAJOR = 9
 # vLLM sentinel meaning "infer expert count from the weight tensor".
 GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS = -1
+_EXPERT_LOCAL_MINING_ENV = "MINER_MOE_EXPERT_LOCAL_MINING"
+_EXPERT_LOCAL_MIN_M_ENV = "MINER_MOE_EXPERT_LOCAL_MIN_M"
 
 _SUPPORTED_ACTIVATIONS = frozenset(
     {
@@ -55,6 +61,33 @@ _TORCH_TO_TRITON_DTYPE: dict[torch.dtype, tl.dtype] = {
     torch.float16: tl.float16,
     torch.float32: tl.float32,
 }
+
+
+def _use_expert_local_mining_threshold() -> bool:
+    value = os.getenv(_EXPERT_LOCAL_MINING_ENV, "1").lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _expert_local_min_m() -> int:
+    gemm_config = pearl_config.matrix_multiplication_config["use_simplified_gemm"]
+    global_min_m = int(gemm_config["min_m"])
+    value = os.getenv(_EXPERT_LOCAL_MIN_M_ENV)
+    if value is None or value == "":
+        return global_min_m
+
+    try:
+        min_m = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be an integer") from exc
+
+    if min_m < global_min_m:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be >= {global_min_m}")
+
+    tile_size_m = int(pearl_config.settings.tile_size_m)
+    if min_m % tile_size_m != 0:
+        raise ValueError(f"{_EXPERT_LOCAL_MIN_M_ENV} must be a multiple of {tile_size_m}")
+
+    return min_m
 
 
 def _torch_dtype_to_triton_compute_type(dtype: torch.dtype) -> tl.dtype:
@@ -158,6 +191,17 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         smooth = w13_smooth[:K] if w13_smooth is not None else None
         return quant_7bit(hidden_states, smooth_scale=smooth)
 
+    @staticmethod
+    def _expert_mining_mask(layout: MoERoutingLayout, n: int, k: int) -> list[bool]:
+        gemm_config = pearl_config.matrix_multiplication_config["use_simplified_gemm"]
+        min_n = int(gemm_config["min_n"])
+        min_k = int(gemm_config["min_k"])
+        if (n == 1) or (k == 1) or (n < min_n) or (k < min_k):
+            return [False] * layout.num_experts
+
+        min_m = _expert_local_min_m()
+        return [layout.expert_slice(i)[1] >= min_m for i in range(layout.num_experts)]
+
     def apply(
         self,
         output: torch.Tensor,
@@ -183,7 +227,7 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         if global_num_experts == GLOBAL_NUM_EXPERTS_INFER_FROM_WEIGHTS:
             global_num_experts = E
 
-        should_mine = (
+        should_try_mining = (
             not get_async_manager()._conf.no_mining
         ) and pearl_config.should_use_noisy_gemm(num_tokens, N, K)
 
@@ -204,7 +248,20 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         )
 
         gemm1_compute_type = _torch_dtype_to_triton_compute_type(hidden_states.dtype)
+        routing_layout = None
+        mine_expert_mask = None
+        should_mine = False
+        if should_try_mining:
+            routing_layout = build_moe_routing_layout(topk_ids, E)
+            if _use_expert_local_mining_threshold():
+                mine_expert_mask = self._expert_mining_mask(routing_layout, N, K)
+            else:
+                mine_expert_mask = [True] * E
+            should_mine = any(mine_expert_mask)
+
         if should_mine:
+            assert routing_layout is not None
+            assert mine_expert_mask is not None
             self._apply_per_expert_gemm1(
                 A_q=A_q,
                 A_scales=A_scales,
@@ -218,6 +275,8 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                 num_tokens=num_tokens,
                 top_k_num=top_k_num,
                 apply_router_weight_on_input=apply_router_weight_on_input,
+                routing_layout=routing_layout,
+                mine_expert_mask=mine_expert_mask,
             )
         else:
             # Vanilla int8 grouped GEMM1 (no mining / no denoise).
@@ -272,10 +331,19 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
         num_tokens: int,
         top_k_num: int,
         apply_router_weight_on_input: bool,
+        routing_layout: MoERoutingLayout,
+        mine_expert_mask: list[bool],
     ) -> None:
-        """GEMM1: per-expert ``noisy_gemm`` with PoW extraction"""
+        """GEMM1: per-expert noisy GEMM for hot experts, vanilla for smaller ones."""
         B_stacked = w1.reshape(E * N, K)
-        ctx = prepare_moe_noising(A_q, A_scales, topk_ids, B_stacked, E)
+        ctx = prepare_moe_noising(
+            A_q,
+            A_scales,
+            topk_ids,
+            B_stacked,
+            E,
+            routing_layout=routing_layout,
+        )
         layout = ctx.routing_layout
 
         (
@@ -307,34 +375,45 @@ class PearlMoEExperts(mk.FusedMoEExpertsModular):
                     continue
                 expert_weight_start = expert_index * N
                 expert_weight_end = expert_weight_start + N
-                expert_output = gemm1_output_by_slot[:expert_slot_count]
+                A_q_e = A_q_by_expert[routing_start : routing_start + expert_slot_count]
+                A_scales_e = A_scales_by_expert[routing_start : routing_start + expert_slot_count]
+                B_e = B_stacked[expert_weight_start:expert_weight_end]
+                B_scales_e = self.w1_scale[expert_index]
 
-                pearl_moe_expert_gemm(
-                    A_q_e=A_q_by_expert[routing_start : routing_start + expert_slot_count],
-                    B_e=B_stacked[expert_weight_start:expert_weight_end],
-                    A_scales_e=A_scales_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    B_scales_e=self.w1_scale[expert_index],
-                    EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
-                    EAL_fp16_e=EAL_fp16_by_expert[
-                        routing_start : routing_start + expert_slot_count
-                    ],
-                    EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
-                    EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
-                    EAR_R_major=ctx.EAR_R_major,
-                    EBL_R_major=ctx.EBL_R_major,
-                    EAR_K_major=ctx.EAR_K_major,
-                    EBL_K_major=ctx.EBL_K_major,
-                    C_e=expert_output,
-                    host_signal_header_pinned=pow_headers[expert_index],
-                    host_signal_sync=host_signal_sync,
-                    pow_target=ctx.pow_target,
-                    pow_key=ctx.pow_key,
-                    tile_size_m=tile_m,
-                    tile_size_n=tile_n,
-                    tile_size_k=tile_k,
-                )
+                if mine_expert_mask[expert_index]:
+                    expert_output = gemm1_output_by_slot[:expert_slot_count]
+                    pearl_moe_expert_gemm(
+                        A_q_e=A_q_e,
+                        B_e=B_e,
+                        A_scales_e=A_scales_e,
+                        B_scales_e=B_scales_e,
+                        EAL_e=EAL_by_expert[routing_start : routing_start + expert_slot_count],
+                        EAL_fp16_e=EAL_fp16_by_expert[
+                            routing_start : routing_start + expert_slot_count
+                        ],
+                        EBR_e=ctx.EBR[expert_weight_start:expert_weight_end],
+                        EBR_fp16_e=ctx.EBR_fp16[expert_weight_start:expert_weight_end],
+                        EAR_R_major=ctx.EAR_R_major,
+                        EBL_R_major=ctx.EBL_R_major,
+                        EAR_K_major=ctx.EAR_K_major,
+                        EBL_K_major=ctx.EBL_K_major,
+                        C_e=expert_output,
+                        host_signal_header_pinned=pow_headers[expert_index],
+                        host_signal_sync=host_signal_sync,
+                        pow_target=ctx.pow_target,
+                        pow_key=ctx.pow_key,
+                        tile_size_m=tile_m,
+                        tile_size_n=tile_n,
+                        tile_size_k=tile_k,
+                    )
+                else:
+                    expert_output = pearl_gemm_vanilla(
+                        A_q_e.contiguous(),
+                        B_e.contiguous(),
+                        scale_a=A_scales_e.squeeze(-1).contiguous(),
+                        scale_b=B_scales_e.squeeze(-1).contiguous(),
+                        out_dtype=out_dtype,
+                    )
 
                 expert_slot_indices = layout.slot_indices[
                     routing_start : routing_start + expert_slot_count

--- a/miner/vllm-miner/tests/test_moe_block_submission.py
+++ b/miner/vllm-miner/tests/test_moe_block_submission.py
@@ -140,16 +140,35 @@ def test_block_found_and_proof_verifies(pearl_moe_layer, get_mining_job, async_m
         mock_mining_client.get_mining_info.return_value = mining_job
         am._mining_job = am._client.get_mining_info()
 
-        moe_method.apply(
-            layer,
-            tensors.hidden_states,
-            tensors.topk_weights,
-            tensors.topk_ids,
-            None,
-        )
+        hot_experts = torch.arange(_TOP_K, dtype=torch.int32, device="cuda").expand(_NUM_TOKENS, -1)
+        tensors.topk_ids.copy_(hot_experts)
 
-        am.wait_until_done_submitting_blocks()
-        assert am.blocks_submitted == 1
+        start_time = time.time()
+        forward_count = 0
+        while am.blocks_submitted == 0:
+            if time.time() - start_time > _MINING_LOOP_TIMEOUT_SECONDS:
+                pytest.fail(
+                    f"Timeout ({_MINING_LOOP_TIMEOUT_SECONDS}s) waiting for block. "
+                    f"Performed {forward_count} forwards, "
+                    f"blocks_submitted={am.blocks_submitted}"
+                )
+
+            hidden_states = (
+                tensors.hidden_states
+                if forward_count == 0
+                else torch.randn_like(tensors.hidden_states)
+            )
+            moe_method.apply(
+                layer,
+                hidden_states,
+                tensors.topk_weights,
+                tensors.topk_ids,
+                None,
+            )
+            forward_count += 1
+            am.wait_until_done_submitting_blocks()
+
+        assert am.blocks_submitted >= 1
 
 
 @pytest.fixture

--- a/miner/vllm-miner/tests/test_moe_expert_threshold.py
+++ b/miner/vllm-miner/tests/test_moe_expert_threshold.py
@@ -1,4 +1,9 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
+import torch
+import vllm_miner.pearl_moe_experts as moe_experts
 from vllm_miner.config import config as pearl_config
 from vllm_miner.pearl_moe_experts import (
     _EXPERT_LOCAL_MIN_M_ENV,
@@ -18,6 +23,10 @@ class _FakeRoutingLayout:
         return sum(self._expert_counts[:expert_index]), self._expert_counts[expert_index]
 
 
+def _global_min_m() -> int:
+    return int(pearl_config.matrix_multiplication_config["use_simplified_gemm"]["min_m"])
+
+
 def test_expert_local_mining_threshold_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(_EXPERT_LOCAL_MINING_ENV, raising=False)
     assert _use_expert_local_mining_threshold() is True
@@ -35,8 +44,7 @@ def test_expert_local_min_m_defaults_to_global_threshold(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv(_EXPERT_LOCAL_MIN_M_ENV, raising=False)
-    global_min_m = pearl_config.matrix_multiplication_config["use_simplified_gemm"]["min_m"]
-    assert _expert_local_min_m() == global_min_m
+    assert _expert_local_min_m() == _global_min_m()
 
 
 def test_expert_local_min_m_accepts_tile_aligned_override(
@@ -55,15 +63,37 @@ def test_expert_local_min_m_rejects_invalid_override(
         _expert_local_min_m()
 
 
-def test_expert_mining_mask_uses_expert_local_min_m(
+@pytest.mark.parametrize(
+    ("expert_counts", "expected"),
+    [
+        pytest.param([0], [False], id="inactive"),
+        pytest.param([1023], [False], id="below-threshold"),
+        pytest.param([1024], [True], id="exactly-threshold"),
+        pytest.param([1025], [True], id="above-threshold"),
+        pytest.param([0, 1023, 1024, 2048], [False, False, True, True], id="mixed"),
+        pytest.param([1, 1023, 64], [False, False, False], id="all-cold"),
+    ],
+)
+def test_expert_mining_mask_gate_cases(
+    monkeypatch: pytest.MonkeyPatch,
+    expert_counts: list[int],
+    expected: list[bool],
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, str(_global_min_m()))
+    layout = _FakeRoutingLayout(expert_counts)
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1024) == expected
+
+
+def test_forward_mining_mask_can_mine_every_active_expert(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
-    layout = _FakeRoutingLayout([1024, 1535, 1536, 2048])
+    monkeypatch.setenv(_EXPERT_LOCAL_MINING_ENV, "0")
+    layout = _FakeRoutingLayout([0, 1, 1023, 1024])
 
-    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1024) == [
+    assert PearlMoEExperts._forward_mining_mask(layout, n=1024, k=1024) == [
         False,
-        False,
+        True,
         True,
         True,
     ]
@@ -77,3 +107,86 @@ def test_expert_mining_mask_keeps_global_nk_thresholds(
 
     assert PearlMoEExperts._expert_mining_mask(layout, n=1023, k=1024) == [False, False]
     assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1023) == [False, False]
+
+
+def test_all_cold_apply_uses_grouped_vanilla_without_preparing_noising(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MINING_ENV, raising=False)
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, str(_global_min_m()))
+    layout = _FakeRoutingLayout([_global_min_m() - 1, 0])
+
+    grouped_gemm = Mock()
+    prepare_noising = Mock(side_effect=AssertionError("all-cold gate prepared MoE noising"))
+    apply_per_expert = Mock(side_effect=AssertionError("all-cold gate used per-expert GEMM"))
+
+    monkeypatch.setattr(
+        moe_experts,
+        "get_async_manager",
+        lambda: SimpleNamespace(_conf=SimpleNamespace(no_mining=False)),
+    )
+    monkeypatch.setattr(moe_experts.pearl_config, "should_use_noisy_gemm", lambda m, n, k: True)
+    monkeypatch.setattr(moe_experts, "build_moe_routing_layout", lambda topk_ids, e: layout)
+    monkeypatch.setattr(moe_experts, "prepare_moe_noising", prepare_noising)
+    monkeypatch.setattr(moe_experts, "invoke_fused_moe_triton_kernel", grouped_gemm)
+    monkeypatch.setattr(
+        moe_experts,
+        "try_get_optimal_moe_config",
+        lambda *args, **kwargs: {"BLOCK_SIZE_M": 128},
+    )
+    monkeypatch.setattr(
+        moe_experts,
+        "moe_align_block_size",
+        lambda *args, **kwargs: (
+            torch.zeros(1, dtype=torch.int32),
+            torch.zeros(1, dtype=torch.int32),
+            torch.ones(1, dtype=torch.int32),
+        ),
+    )
+
+    fake_experts = SimpleNamespace(
+        moe_problem_size=lambda hidden_states, w1, w2, topk_ids: (
+            layout.num_experts,
+            1,
+            1024,
+            1024,
+            1,
+        ),
+        _quant_a_7bit=lambda hidden_states, k: (
+            torch.zeros((1, k), dtype=torch.int8),
+            torch.ones((1, 1), dtype=torch.float32),
+            None,
+        ),
+        adjust_N_for_activation=lambda n, activation: n,
+        _forward_mining_mask=PearlMoEExperts._forward_mining_mask,
+        _apply_per_expert_gemm1=apply_per_expert,
+        _int8_w8a8_triton_kwargs=lambda: {},
+        activation=lambda activation, intermediate_cache2, intermediate_cache1: None,
+        _gemm2_triton=lambda **kwargs: None,
+        w1_scale=torch.ones((layout.num_experts, 1024, 1), dtype=torch.float32),
+        w2_scale=torch.ones((layout.num_experts, 8, 8), dtype=torch.float32),
+        per_act_token_quant=True,
+    )
+
+    PearlMoEExperts.apply(
+        fake_experts,
+        output=torch.empty((1, 1024), dtype=torch.float32),
+        hidden_states=torch.empty((1, 1024), dtype=torch.float32),
+        w1=torch.empty((layout.num_experts, 1024, 1024), dtype=torch.int8),
+        w2=torch.empty((layout.num_experts, 1024, 1024), dtype=torch.float32),
+        topk_weights=torch.ones((1, 1), dtype=torch.float32),
+        topk_ids=torch.zeros((1, 1), dtype=torch.int32),
+        activation=None,
+        global_num_experts=layout.num_experts,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=torch.empty((1, 1, 1024), dtype=torch.float32),
+        workspace2=torch.empty((1, 1, 1024), dtype=torch.float32),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    grouped_gemm.assert_called_once()
+    apply_per_expert.assert_not_called()
+    prepare_noising.assert_not_called()

--- a/miner/vllm-miner/tests/test_moe_expert_threshold.py
+++ b/miner/vllm-miner/tests/test_moe_expert_threshold.py
@@ -1,0 +1,79 @@
+import pytest
+from vllm_miner.config import config as pearl_config
+from vllm_miner.pearl_moe_experts import (
+    _EXPERT_LOCAL_MIN_M_ENV,
+    _EXPERT_LOCAL_MINING_ENV,
+    PearlMoEExperts,
+    _expert_local_min_m,
+    _use_expert_local_mining_threshold,
+)
+
+
+class _FakeRoutingLayout:
+    def __init__(self, expert_counts: list[int]) -> None:
+        self._expert_counts = expert_counts
+        self.num_experts = len(expert_counts)
+
+    def expert_slice(self, expert_index: int) -> tuple[int, int]:
+        return sum(self._expert_counts[:expert_index]), self._expert_counts[expert_index]
+
+
+def test_expert_local_mining_threshold_defaults_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MINING_ENV, raising=False)
+    assert _use_expert_local_mining_threshold() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off"])
+def test_expert_local_mining_threshold_can_opt_out(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MINING_ENV, value)
+    assert _use_expert_local_mining_threshold() is False
+
+
+def test_expert_local_min_m_defaults_to_global_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(_EXPERT_LOCAL_MIN_M_ENV, raising=False)
+    global_min_m = pearl_config.matrix_multiplication_config["use_simplified_gemm"]["min_m"]
+    assert _expert_local_min_m() == global_min_m
+
+
+def test_expert_local_min_m_accepts_tile_aligned_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
+    assert _expert_local_min_m() == 1536
+
+
+@pytest.mark.parametrize("value", ["1023", "1153", "not-an-int"])
+def test_expert_local_min_m_rejects_invalid_override(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, value)
+    with pytest.raises(ValueError, match=_EXPERT_LOCAL_MIN_M_ENV):
+        _expert_local_min_m()
+
+
+def test_expert_mining_mask_uses_expert_local_min_m(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1536")
+    layout = _FakeRoutingLayout([1024, 1535, 1536, 2048])
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1024) == [
+        False,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_expert_mining_mask_keeps_global_nk_thresholds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_EXPERT_LOCAL_MIN_M_ENV, "1024")
+    layout = _FakeRoutingLayout([2048, 2048])
+
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1023, k=1024) == [False, False]
+    assert PearlMoEExperts._expert_mining_mask(layout, n=1024, k=1023) == [False, False]

--- a/miner/vllm-miner/tests/test_moe_per_expert.py
+++ b/miner/vllm-miner/tests/test_moe_per_expert.py
@@ -99,7 +99,7 @@ class TestMoEStatusCheckCallbackRelease:
         delete_state()
 
     @staticmethod
-    def _make_callback(headers: list[torch.Tensor]) -> MoEStatusCheckCallback:
+    def _make_callback(headers: list[tuple[int, torch.Tensor]]) -> MoEStatusCheckCallback:
         device = "cuda"
         return MoEStatusCheckCallback(
             pow_headers=headers,
@@ -119,10 +119,10 @@ class TestMoEStatusCheckCallbackRelease:
 
     def test_releases_all_headers_to_pool(self) -> None:
         pool = get_pinned_pool()
-        headers = [pool.acquire() for _ in range(_NUM_EXPERTS)]
-        assert len(pool._used_buffers) == _NUM_EXPERTS
+        mined_expert_headers = [(1, pool.acquire()), (4, pool.acquire()), (7, pool.acquire())]
+        assert len(pool._used_buffers) == len(mined_expert_headers)
 
-        callback = self._make_callback(headers)
-        # No expert triggered (zeroed headers): callback must still release them.
+        callback = self._make_callback(mined_expert_headers)
+        # No expert triggered (zeroed headers): callback must still release sparse headers.
         callback(lambda opened_block_info, mining_job: None)
         assert len(pool._used_buffers) == 0


### PR DESCRIPTION
Rebased on `master` after #188 landed. This replaces #203, which GitHub closed when the stacked base branch `moe_f8_down_proj` was deleted.

This changes MoE GEMM1 mining so the global mining gate still decides whether a forward is eligible, but each routed expert is mined only when that expert has enough routed slots. Cold experts fall back to the vanilla Pearl int8 GEMM path. The second MoE GEMM keeps the v2 fp8-down-proj path unchanged.

Controls:
- `MINER_MOE_EXPERT_LOCAL_MINING=0` opts out and restores the old mine-all-active-experts behavior after the global gate.
- `MINER_MOE_EXPERT_LOCAL_MIN_M` can raise the per-expert M threshold. It defaults to the existing global `min_m` and must be tile-aligned.

One subtlety from the profiles: the existing threshold is on the batched GEMM M, not per-request input length. For example, `input_len=512, prompts=4` still crosses the old global gate because the batch has 2048 tokens.

Benchmarks on H100 80GB with the updated v2 model `pearl-ai/Qwen3-30B-A3B-Instruct-2507-pearl`, `vllm bench throughput`, eager mode, prefix caching disabled, 2 repeats for throughput rows:

| case | old/global req/s | expert-local req/s | delta | expert-local mined slots vs old |
| --- | ---: | ---: | ---: | ---: |
| input 1024, output 1, prompts 80 | 17.58 | 24.37 | +38.63% | 88.41% |
| input 2048, output 1, prompts 80 | 9.35 | 12.02 | +28.54% | 87.77% |
| input 3072, output 1, prompts 40 | 5.93 | 7.62 | +28.47% | 88.18% |
| input 2048, output 128, prompts 40 | 3.91 | 4.35 | +11.26% | 88.88% |

Additional profile rows around the threshold:

| case | expert-local mined slots vs old |
| --- | ---: |
| input 512, output 1, prompts 4 | 96.56% |
| input 1024, output 1, prompts 4 | 92.46% |
| input 1025, output 1, prompts 4 | 93.53% |
| input 2048, output 1, prompts 4 | 92.93% |

Focused gate benchmark on a RunPod H100 SXM, synthetic routing through `PearlMoEExperts` (commit `bf9d8250`). This isolates the gate tradeoff; it is not an end-to-end serving benchmark:

| case | grouped vanilla ms | mine-all-active ms | expert-local ms | expert-local mined slots | expert-local mined slots/s |
| --- | ---: | ---: | ---: | ---: | ---: |
| all cold | 0.475 | 1.998 | 0.624 | 0 | 0 |
| 1 hot exact | 0.473 | 1.845 | 1.534 | 1,024 | 667,586 |
| 2 hot exact | 0.473 | 1.894 | 1.589 | 2,048 | 1,289,012 |
| several mixed | 0.536 | 1.956 | 1.682 | 4,097 | 2,435,915 |
| below/above edge | 0.473 | 1.861 | 1.548 | 1,025 | 661,946 |

Interpretation: expert-local gating is a selective mining policy, not a universal MoE latency optimization. It reduces wall time versus mining every active expert in the focused benchmark, especially all-cold, but it intentionally mines fewer slots and loses grouped-GEMM efficiency versus vanilla once any expert qualifies. Operators that want the old maximum-mined-work behavior can set `MINER_MOE_EXPERT_LOCAL_MINING=0`.

Verification:
- after rebase: `python3 -m py_compile miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_block_submission.py`
- before rebase: `uvx ruff check miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_block_submission.py`
- before rebase: `python3 -m py_compile miner/vllm-miner/src/vllm_miner/pearl_moe_experts.py miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_block_submission.py`
- H100 before rebase: `MINER_NO_GATEWAY=1 uv run --package vllm-miner pytest miner/vllm-miner/tests/test_moe_expert_threshold.py miner/vllm-miner/tests/test_moe_per_expert.py miner/vllm-miner/tests/test_moe_block_submission.py::test_block_found_and_proof_verifies -q` -> 16 passed.


## Current-master reconciliation (2026-09-14)

V3 salted dimensions are preserved while expert-local gating reuses the routed layout.

Merged upstream master b713614301c42bfc3ea7c35e92917b7f4b161d8b. 23 isolated host logic tests passed with CPU tensors and CUDA/vLLM imports stubbed; protocol mutation checks reject dropping salts or routing V3 through the legacy cache. Python compilation/lint and affected C++ formatting passed. These are host logic checks, not CUDA integration proof.

Historical H100 timings above remain measurements of their recorded old commits. They do not qualify this current merge, and no V3 cache speedup is claimed. The repository-pinned Python/Torch/vLLM/CUDA correctness and proof-validation run remains required on the supported GPU before merge, along with maintainer review.
