### PR TITLE
perf(vllm-miner): cache job-bound B-side mining state

### DIFF
--- a/miner/miner-base/src/miner_base/settings.py
+++ b/miner/miner-base/src/miner_base/settings.py
@@ -25,6 +25,7 @@ class MinerSettings(BaseSettings):
     # fmt: on
 
     pinned_pool_size: int = 128
+    prepared_b_cache_bytes: int = 1 << 30
 
     debug: bool = False
     print_header_hash: bool = False

--- a/miner/pearl-gemm/csrc/gemm/pearl_gemm_api.cpp
+++ b/miner/pearl-gemm/csrc/gemm/pearl_gemm_api.cpp
@@ -1077,6 +1077,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         py::arg("B_merkle_root"), py::arg("key"), py::arg("A_commitment_hash"),
         py::arg("B_commitment_hash"), py::arg("routing_root") = py::none(),
         py::arg("offsets_hash") = py::none());
+  m.def("commitment_hash_from_b_commitment",
+        &run_commitment_hash_from_b_commitment,
+        "Commitment hash A from Merkle root A and cached commitment B",
+        py::arg("A_merkle_root"), py::arg("B_commitment_hash"),
+        py::arg("A_commitment_hash"), py::arg("routing_root") = py::none(),
+        py::arg("offsets_hash") = py::none());
   m.def("get_host_signal_header_size", &get_host_signal_header_size,
         "Calculate host signal header buffer size");
   m.def("get_host_signal_sync_size", &get_host_signal_sync_size,
@@ -1298,6 +1304,14 @@ TORCH_LIBRARY(pearl_gemm, m) {
       "    Tensor? offsets_hash=None"
       ") -> ()");
   m.def(
+      "commitment_hash_from_b_commitment("
+      "    Tensor A_merkle_root, "
+      "    Tensor B_commitment_hash, "
+      "    Tensor(A_commitment_hash!) A_commitment_hash, "
+      "    Tensor? routing_root=None, "
+      "    Tensor? offsets_hash=None"
+      ") -> ()");
+  m.def(
       "build_routing_data("
       "    Tensor topk_ids, "
       "    Tensor(routing_data!) routing_data, "
@@ -1320,5 +1334,7 @@ TORCH_LIBRARY_IMPL(pearl_gemm, CUDA, m) {
   m.impl("tensor_hash", &run_tensor_hash);
   m.impl("commitment_hash_from_merkle_roots",
          &run_commitment_hash_from_merkle_roots);
+  m.impl("commitment_hash_from_b_commitment",
+         &run_commitment_hash_from_b_commitment);
   m.impl("build_routing_data", &build_routing_data);
 }

--- a/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_b_commitment_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_b_commitment_kernel.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "blake3/blake3.cuh"
+
+namespace pearl {
+
+class CommitmentHashFromBCommitmentKernel {
+ public:
+  using Element = uint8_t;
+  static constexpr uint32_t MaxThreadsPerBlock = 1;
+  static constexpr uint32_t MinBlocksPerMultiprocessor = 1;
+  static constexpr int SharedStorageSize = 0;
+
+  using RmemChainingValueLayout =
+      Layout<Shape<Int<blake3::CHAINING_VALUE_SIZE_U32>>>;
+  using RmemBlockLayout = Layout<Shape<Int<blake3::MSG_BLOCK_SIZE_U32>>>;
+
+  struct Arguments {
+    Element const* const ptr_A_merkle_root;
+    Element const* const ptr_B_commitment_hash;
+    Element* const ptr_A_commitment_hash;
+    Element const* const ptr_routing_root;
+    Element const* const ptr_offsets_hash;
+  };
+
+  struct Params {
+    Element const* const ptr_A_merkle_root;
+    Element const* const ptr_B_commitment_hash;
+    Element* const ptr_A_commitment_hash;
+    Element const* const ptr_routing_root;
+    Element const* const ptr_offsets_hash;
+  };
+
+  static Params to_underlying_arguments(Arguments const& args) {
+    return {args.ptr_A_merkle_root,
+            args.ptr_B_commitment_hash,
+            args.ptr_A_commitment_hash,
+            args.ptr_routing_root,
+            args.ptr_offsets_hash};
+  }
+
+  static dim3 get_grid_shape(Params const& params) { return dim3(1); }
+
+  static dim3 get_block_shape() { return dim3(1); }
+
+  CUTLASS_DEVICE
+  void operator()(Params const& params, char* smem_buf) {
+    static constexpr blake3::CompressParams single_block_params = {
+        .counter = 0,
+        .block_len = blake3::MSG_BLOCK_SIZE,
+        .flags = blake3::CHUNK_START | blake3::CHUNK_END | blake3::ROOT,
+    };
+
+    Tensor rARoot = make_tensor<uint32_t>(RmemChainingValueLayout{});
+    uint32_t const* A_merkle_root_u32 =
+        reinterpret_cast<uint32_t const*>(params.ptr_A_merkle_root);
+
+    if (params.ptr_routing_root != nullptr) {
+      uint32_t const* routing_root_u32 =
+          reinterpret_cast<uint32_t const*>(params.ptr_routing_root);
+      uint32_t const* offsets_hash_u32 =
+          reinterpret_cast<uint32_t const*>(params.ptr_offsets_hash);
+
+      Tensor rBlockRouting = make_tensor<uint32_t>(RmemBlockLayout{});
+      Tensor rHashRouting = make_tensor<uint32_t>(RmemChainingValueLayout{});
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+        rBlockRouting(i) = routing_root_u32[i];
+        rBlockRouting(i + blake3::CHAINING_VALUE_SIZE_U32) =
+            offsets_hash_u32[i];
+        rHashRouting(i) = blake3::IV[i];
+      }
+      blake3::compress_msg_block_u32(rBlockRouting, rHashRouting,
+                                     single_block_params);
+
+      Tensor rBlockActivations = make_tensor<uint32_t>(RmemBlockLayout{});
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+        rBlockActivations(i) = A_merkle_root_u32[i];
+        rBlockActivations(i + blake3::CHAINING_VALUE_SIZE_U32) =
+            rHashRouting(i);
+        rARoot(i) = blake3::IV[i];
+      }
+      blake3::compress_msg_block_u32(rBlockActivations, rARoot,
+                                     single_block_params);
+    } else {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+        rARoot(i) = A_merkle_root_u32[i];
+      }
+    }
+
+    Tensor rBlockA = make_tensor<uint32_t>(RmemBlockLayout{});
+    Tensor rChainingValueA = make_tensor<uint32_t>(RmemChainingValueLayout{});
+    uint32_t const* B_commitment_hash_u32 =
+        reinterpret_cast<uint32_t const*>(params.ptr_B_commitment_hash);
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+      rBlockA(i) = B_commitment_hash_u32[i];
+      rBlockA(i + blake3::CHAINING_VALUE_SIZE_U32) = rARoot(i);
+      rChainingValueA(i) = blake3::IV[i];
+    }
+    blake3::compress_msg_block_u32(rBlockA, rChainingValueA,
+                                   single_block_params);
+
+    uint32_t* A_commitment_hash_u32 =
+        reinterpret_cast<uint32_t*>(params.ptr_A_commitment_hash);
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+      A_commitment_hash_u32[i] = rChainingValueA(i);
+    }
+  }
+};
+
+}  // namespace pearl

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -196,5 +196,67 @@ void run_commitment_hash_from_merkle_roots(
       *dprops, stream);
 }
 
+void run_commitment_hash_from_b_commitment(
+    at::Tensor& A_merkle_root, at::Tensor& B_commitment_hash,
+    at::Tensor& A_commitment_hash,
+    std::optional<at::Tensor> routing_root = std::nullopt,
+    std::optional<at::Tensor> offsets_hash = std::nullopt) {
+  CHECK_DEVICE(A_merkle_root);
+  CHECK_DEVICE(B_commitment_hash);
+  CHECK_DEVICE(A_commitment_hash);
+  CHECK_CONTIGUOUS(A_merkle_root);
+  CHECK_CONTIGUOUS(B_commitment_hash);
+  CHECK_CONTIGUOUS(A_commitment_hash);
+
+  TORCH_CHECK(A_merkle_root.dtype() == at::kByte,
+              "A_merkle_root must be uint8");
+  TORCH_CHECK(B_commitment_hash.dtype() == at::kByte,
+              "B_commitment_hash must be uint8");
+  TORCH_CHECK(A_commitment_hash.dtype() == at::kByte,
+              "A_commitment_hash must be uint8");
+  TORCH_CHECK(A_merkle_root.numel() == blake3::CHAINING_VALUE_SIZE,
+              "A_merkle_root must have exactly", blake3::CHAINING_VALUE_SIZE,
+              "bytes");
+  TORCH_CHECK(B_commitment_hash.numel() == blake3::CHAINING_VALUE_SIZE,
+              "B_commitment_hash must have exactly",
+              blake3::CHAINING_VALUE_SIZE, "bytes");
+  TORCH_CHECK(A_commitment_hash.numel() == blake3::CHAINING_VALUE_SIZE,
+              "A_commitment_hash must have exactly",
+              blake3::CHAINING_VALUE_SIZE, "bytes");
+  TORCH_CHECK(routing_root.has_value() == offsets_hash.has_value(),
+              "routing_root and offsets_hash must be provided together");
+
+  const uint8_t* routing_root_ptr = nullptr;
+  const uint8_t* offsets_hash_ptr = nullptr;
+  if (routing_root.has_value()) {
+    auto& routing_root_tensor = routing_root.value();
+    auto& offsets_hash_tensor = offsets_hash.value();
+    CHECK_DEVICE(routing_root_tensor);
+    CHECK_DEVICE(offsets_hash_tensor);
+    CHECK_CONTIGUOUS(routing_root_tensor);
+    CHECK_CONTIGUOUS(offsets_hash_tensor);
+    TORCH_CHECK(routing_root_tensor.dtype() == at::kByte,
+                "routing_root must be uint8");
+    TORCH_CHECK(offsets_hash_tensor.dtype() == at::kByte,
+                "offsets_hash must be uint8");
+    TORCH_CHECK(routing_root_tensor.numel() == blake3::CHAINING_VALUE_SIZE,
+                "routing_root must have exactly", blake3::CHAINING_VALUE_SIZE,
+                "bytes");
+    TORCH_CHECK(offsets_hash_tensor.numel() == blake3::CHAINING_VALUE_SIZE,
+                "offsets_hash must have exactly", blake3::CHAINING_VALUE_SIZE,
+                "bytes");
+    routing_root_ptr = routing_root_tensor.data_ptr<uint8_t>();
+    offsets_hash_ptr = offsets_hash_tensor.data_ptr<uint8_t>();
+  }
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  auto dprops = at::cuda::getCurrentDeviceProperties();
+
+  commitment_hash_from_b_commitment(
+      A_merkle_root.data_ptr<uint8_t>(), B_commitment_hash.data_ptr<uint8_t>(),
+      A_commitment_hash.data_ptr<uint8_t>(), routing_root_ptr, offsets_hash_ptr,
+      *dprops, stream);
+}
+
 #undef CHECK_DEVICE
 #undef CHECK_CONTIGUOUS

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -54,6 +54,8 @@ void run_tensor_hash(
   TORCH_CHECK(key.dtype() == at::kByte, "key must be uint8");
   TORCH_CHECK(out.dtype() == at::kByte, "out must be uint8");
   TORCH_CHECK(roots.dtype() == at::kByte, "roots must be uint8");
+  TORCH_CHECK(data.dtype() == at::kByte || data.dtype() == at::kChar,
+              "data must be uint8 or int8");
   TORCH_CHECK(data.dim() == 2, "data must be 2D tensor");
   TORCH_CHECK(reinterpret_cast<uintptr_t>(data.data_ptr()) %
                       TMA_GLOBAL_ALIGNMENT_BYTES ==
@@ -103,8 +105,10 @@ void run_tensor_hash(
   auto stream = at::cuda::getCurrentCUDAStream();
   auto dprops = at::cuda::getCurrentDeviceProperties();
 
-  tensor_hash(data.data_ptr<uint8_t>(), data.numel(), out.data_ptr<uint8_t>(),
-              key.data_ptr<uint8_t>(), num_blocks,
+  // Hash the tensor storage bytes. int8 and uint8 are both one byte per
+  // element, so they must commit to identical roots for identical bit patterns.
+  tensor_hash(reinterpret_cast<uint8_t const*>(data.data_ptr()), data.numel(),
+              out.data_ptr<uint8_t>(), key.data_ptr<uint8_t>(), num_blocks,
               static_cast<uint32_t>(threads_per_block),
               static_cast<uint32_t>(num_stages),
               static_cast<uint32_t>(leaves_per_mt_block),

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_decl.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_decl.hpp
@@ -25,3 +25,8 @@ void commitment_hash_from_merkle_roots(
     const uint8_t* key, uint8_t* A_commitment_hash, uint8_t* B_commitment_hash,
     const uint8_t* routing_root, const uint8_t* offsets_hash,
     cudaDeviceProp& deviceProp, cudaStream_t stream);
+
+void commitment_hash_from_b_commitment(
+    const uint8_t* A_merkle_root, const uint8_t* B_commitment_hash,
+    uint8_t* A_commitment_hash, const uint8_t* routing_root,
+    const uint8_t* offsets_hash, cudaDeviceProp& deviceProp, cudaStream_t stream);

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_host.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_host.hpp
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "blake3/blake3_constants.hpp"
+#include "commitment_hash_from_b_commitment_kernel.hpp"
 #include "commitment_hash_from_merkle_roots_kernel.hpp"
 #include "compute_blake_mt_kernel.hpp"
 #include "gemm/error_check.hpp"
@@ -313,4 +314,36 @@ void commitment_hash_from_merkle_roots(
   dim3 block = dim3(1);
 
   kernel<<<grid, block, commitment_hash_smem_size, stream>>>(kernel_params);
+}
+
+void commitment_hash_from_b_commitment(
+    const uint8_t* A_merkle_root, const uint8_t* B_commitment_hash,
+    uint8_t* A_commitment_hash, const uint8_t* routing_root,
+    const uint8_t* offsets_hash, cudaDeviceProp& deviceProp, cudaStream_t stream) {
+
+  using CommitmentHashFromBCommitmentKernel =
+      pearl::CommitmentHashFromBCommitmentKernel;
+
+  typename CommitmentHashFromBCommitmentKernel::Arguments args{
+      static_cast<const uint8_t*>(A_merkle_root),
+      static_cast<const uint8_t*>(B_commitment_hash),
+      static_cast<uint8_t*>(A_commitment_hash),
+      static_cast<const uint8_t*>(routing_root),
+      static_cast<const uint8_t*>(offsets_hash)};
+
+  typename CommitmentHashFromBCommitmentKernel::Params kernel_params =
+      CommitmentHashFromBCommitmentKernel::to_underlying_arguments(args);
+
+  auto kernel = cutlass::device_kernel<CommitmentHashFromBCommitmentKernel>;
+
+  constexpr static int commitment_hash_smem_size =
+      CommitmentHashFromBCommitmentKernel::SharedStorageSize;
+
+  if (commitment_hash_smem_size >= 48 * 1024) {
+    gpuErrchk(cudaFuncSetAttribute(reinterpret_cast<const void*>(kernel),
+                                   cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                   commitment_hash_smem_size));
+  }
+
+  kernel<<<dim3(1), dim3(1), commitment_hash_smem_size, stream>>>(kernel_params);
 }

--- a/miner/pearl-gemm/src/pearl_gemm/__init__.py
+++ b/miner/pearl-gemm/src/pearl_gemm/__init__.py
@@ -23,6 +23,7 @@ from .helpers import (
     make_pow_target_tensor,
 )
 from .pearl_gemm_interface import (
+    commitment_hash_from_b_commitment,
     commitment_hash_from_merkle_roots,
     denoise_converter,
     gemm,
@@ -39,6 +40,7 @@ __all__ = [
     "HostSignalStatus",
     "ProofTileIndices",
     "commitment_hash_from_merkle_roots",
+    "commitment_hash_from_b_commitment",
     "denoise_converter",
     "extract_indices",
     "gemm",

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -602,6 +602,22 @@ def commitment_hash_from_merkle_roots(
     )
 
 
+def commitment_hash_from_b_commitment(
+    A_merkle_root,
+    B_commitment_hash,
+    A_commitment_hash,
+    routing_root=None,
+    offsets_hash=None,
+):
+    return pearl_gemm_cuda.commitment_hash_from_b_commitment(
+        A_merkle_root,
+        B_commitment_hash,
+        A_commitment_hash,
+        routing_root,
+        offsets_hash,
+    )
+
+
 @torch.library.register_fake("pearl_gemm::commitment_hash_from_merkle_roots")
 def _abstract_commitment_hash_from_merkle_roots(
     A_merkle_root,
@@ -609,6 +625,17 @@ def _abstract_commitment_hash_from_merkle_roots(
     key,
     A_commitment_hash,
     B_commitment_hash,
+    routing_root=None,
+    offsets_hash=None,
+):
+    return None
+
+
+@torch.library.register_fake("pearl_gemm::commitment_hash_from_b_commitment")
+def _abstract_commitment_hash_from_b_commitment(
+    A_merkle_root,
+    B_commitment_hash,
+    A_commitment_hash,
     routing_root=None,
     offsets_hash=None,
 ):

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -559,7 +559,8 @@ def tensor_hash(
     """Hash a tensor using a key with configurable kernel parameters.
 
     Args:
-        data (Tensor): Input tensor to hash
+        data (Tensor): 2D uint8 or int8 tensor to hash as raw storage bytes.
+            int8 and uint8 inputs with the same bit pattern produce the same root.
         key (Tensor): Key tensor used for hashing
         out (Tensor): Output tensor for hash result
         roots (Tensor): Scratchpad tensor for intermediate results

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -3,7 +3,12 @@ import torch
 from blake3 import blake3
 from miner_base.commitment_hash import CommitmentHasher
 from miner_base.matrix_merkle_tree import MatrixMerkleTree
-from pearl_gemm import commitment_hash_from_merkle_roots, get_required_scratchpad_bytes, tensor_hash
+from pearl_gemm import (
+    commitment_hash_from_b_commitment,
+    commitment_hash_from_merkle_roots,
+    get_required_scratchpad_bytes,
+    tensor_hash,
+)
 
 
 def hash_matrix(matrix: torch.Tensor, key: bytes) -> torch.Tensor:
@@ -193,6 +198,26 @@ class TestTensorHash:
         assert cuda_result_B.cpu().numpy().tobytes() == reference.noise_seed_B, (
             "MoE commitment hash mismatch: CUDA result doesn't match Python reference"
         )
+
+    def test_commitment_hash_from_b_commitment_matches_full_commitment(self):
+        """Warm-path A commitment matches the full A/B root commitment kernel."""
+        A_merkle_root = torch.randint(
+            0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda"
+        )
+        B_merkle_root = torch.randint(
+            0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda"
+        )
+        key = torch.randint(0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda")
+
+        full_A = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        full_B = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        commitment_hash_from_merkle_roots(A_merkle_root, B_merkle_root, key, full_A, full_B)
+
+        warm_A = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        commitment_hash_from_b_commitment(A_merkle_root, full_B, warm_A)
+        torch.cuda.synchronize()
+
+        assert torch.equal(warm_A, full_A)
 
     @pytest.mark.parametrize(
         "shape",

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -115,6 +115,40 @@ class TestTensorHash:
             "Commitment hash from merkle roots mismatch: CUDA result doesn't match Python reference"
         )
 
+    @pytest.mark.parametrize(
+        "shape",
+        [
+            (16, 16),
+            (257, 1024),
+            (1024, 1024),
+            (2048, 3072),
+        ],
+    )
+    def test_tensor_hash_int8_hashes_raw_bytes(self, shape):
+        """Dense mining hashes int8 A/B tensors directly without uint8 casts."""
+        matrix = torch.randint(-63, 64, shape, dtype=torch.int8, device="cuda")
+        scratchpad = torch.empty(
+            get_required_scratchpad_bytes(matrix.numel()),
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        direct_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        cast_result = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
+        key_tensor = torch.randint(0, 255, (blake3.digest_size,), dtype=torch.uint8, device="cuda")
+        key_bytes = key_tensor.cpu().numpy().tobytes()
+
+        tensor_hash(matrix, key_tensor, direct_result, scratchpad)
+        tensor_hash(matrix.to(torch.uint8), key_tensor, cast_result, scratchpad)
+        torch.cuda.synchronize()
+
+        python_result = hash_matrix(matrix.cpu(), key_bytes)
+        assert torch.equal(direct_result, python_result), (
+            f"tensor_hash must hash the raw int8 bytes used by MatrixMerkleTree for {shape}"
+        )
+        assert torch.equal(direct_result, cast_result), (
+            f"direct int8 hashing must match the previous uint8 cast path for {shape}"
+        )
+
     def test_commitment_hash_from_merkle_roots_moe(self):
         """MoE folding path matches the CommitmentHasher reference."""
         # Cumulative exclusive ends per expert; last == m * top_k.

--- a/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
+++ b/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
@@ -1,4 +1,4 @@
-"""Benchmark cold vs warm PreparedBMiningState for dense noisy GEMM.
+"""Benchmark dense noisy GEMM with and without PreparedBMiningState hits.
 
 Example:
     uv run --package vllm-miner python \
@@ -9,11 +9,19 @@ from __future__ import annotations
 
 import argparse
 import statistics
+import time
 
 import torch
 from miner_base.settings import MinerSettings
+from pearl_gateway.comm.dataclasses import MiningJob
+from vllm_miner.config import config
 from vllm_miner.gemm_operators import pearl_gemm_noisy
-from vllm_miner.mining_state import delete_state, init_async_manager, init_pinned_pool
+from vllm_miner.mining_state import (
+    delete_state,
+    get_async_manager,
+    init_async_manager,
+    init_pinned_pool,
+)
 from vllm_miner.prepared_b_mining_state import (
     clear_prepared_b_cache,
     prepared_b_cache_bytes,
@@ -25,16 +33,43 @@ from vllm_miner.prepared_b_mining_state import (
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Benchmark dense noisy GEMM with cold and warm PreparedBMiningState."
+        description="Benchmark dense noisy GEMM with disabled, cold, warm, and job-transition PreparedBMiningState."
     )
-    parser.add_argument("--m", type=int, default=1024)
+    parser.add_argument(
+        "--m-values",
+        type=str,
+        default="256,512,1024,2048",
+        help="Comma-separated M values. Use this to model batch/speculative-width pressure.",
+    )
     parser.add_argument("--n", type=int, default=28672)
     parser.add_argument("--k", type=int, default=4096)
-    parser.add_argument("--warmup", type=int, default=3)
-    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iterations", type=int, default=10)
     parser.add_argument("--cache-bytes", type=int, default=1 << 30)
+    parser.add_argument(
+        "--modes",
+        type=str,
+        default="disabled,cold,warm,job_transition",
+        help="Comma-separated modes: disabled,cold,warm,job_transition.",
+    )
     parser.add_argument("--allow-non-h100", action="store_true")
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.m_values = _parse_int_list(args.m_values, "--m-values")
+    args.modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
+    valid_modes = {"disabled", "cold", "warm", "job_transition"}
+    unknown_modes = set(args.modes) - valid_modes
+    if unknown_modes:
+        raise ValueError(f"unknown --modes entries: {sorted(unknown_modes)}")
+    return args
+
+
+def _parse_int_list(raw: str, flag_name: str) -> list[int]:
+    values = [int(value.strip()) for value in raw.split(",") if value.strip()]
+    if not values:
+        raise ValueError(f"{flag_name} must contain at least one integer")
+    if any(value <= 0 for value in values):
+        raise ValueError(f"{flag_name} must contain only positive integers")
+    return values
 
 
 def _require_gpu(allow_non_h100: bool) -> None:
@@ -45,13 +80,18 @@ def _require_gpu(allow_non_h100: bool) -> None:
         raise RuntimeError(f"Expected H100; got {name}. Pass --allow-non-h100 to override.")
 
 
-def _make_inputs(args: argparse.Namespace) -> tuple[torch.Tensor, ...]:
+def _make_inputs(m: int, args: argparse.Namespace) -> tuple[torch.Tensor, ...]:
     torch.manual_seed(0)
-    a = torch.randint(-63, 64, (args.m, args.k), dtype=torch.int8, device="cuda")
+    a = torch.randint(-63, 64, (m, args.k), dtype=torch.int8, device="cuda")
     b = torch.randint(-63, 64, (args.n, args.k), dtype=torch.int8, device="cuda")
-    scale_a = torch.ones((args.m,), dtype=torch.float32, device="cuda")
+    scale_a = torch.ones((m,), dtype=torch.float32, device="cuda")
     scale_b = torch.ones((args.n,), dtype=torch.float32, device="cuda")
     return a, b, scale_a, scale_b
+
+
+def _set_job(sequence: int) -> None:
+    header = sequence.to_bytes(8, byteorder="little", signed=False) * 4
+    get_async_manager()._mining_job = MiningJob(header, 1)
 
 
 def _one_call(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor) -> None:
@@ -60,27 +100,41 @@ def _one_call(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: 
     del out
 
 
-def _measure(
+def _measure(  # noqa: C901
     mode: str,
     args: argparse.Namespace,
+    m: int,
     a: torch.Tensor,
     b: torch.Tensor,
     scale_a: torch.Tensor,
     scale_b: torch.Tensor,
 ) -> dict[str, float | int | str]:
     clear_prepared_b_cache()
+    if mode == "disabled":
+        config.settings.prepared_b_cache_bytes = 0
+    else:
+        config.settings.prepared_b_cache_bytes = args.cache_bytes
 
     if mode == "warm":
+        _set_job(0)
         _one_call(a, b, scale_a, scale_b)
         torch.cuda.synchronize()
         reset_prepared_b_cache_stats()
-    elif mode != "cold":
+    elif mode not in {"disabled", "cold", "job_transition"}:
         raise ValueError(f"unknown mode: {mode}")
 
-    samples = []
-    for _ in range(args.warmup):
+    gpu_samples = []
+    wall_samples = []
+    sequence = 1
+
+    for idx in range(args.warmup):
         if mode == "cold":
             clear_prepared_b_cache(reset_stats=False)
+        if mode == "job_transition":
+            _set_job(sequence)
+            sequence += 1
+        elif mode != "warm":
+            _set_job(idx)
         _one_call(a, b, scale_a, scale_b)
     torch.cuda.synchronize()
 
@@ -89,41 +143,59 @@ def _measure(
     for _ in range(args.iterations):
         if mode == "cold":
             clear_prepared_b_cache(reset_stats=False)
+        if mode == "job_transition":
+            _set_job(sequence)
+            sequence += 1
         start.record()
+        wall_start = time.perf_counter()
         _one_call(a, b, scale_a, scale_b)
         end.record()
         torch.cuda.synchronize()
-        samples.append(start.elapsed_time(end))
+        wall_samples.append((time.perf_counter() - wall_start) * 1000)
+        gpu_samples.append(start.elapsed_time(end))
 
     stats = prepared_b_cache_stats()
+    cache_entries = prepared_b_cache_size()
+    cache_bytes = prepared_b_cache_bytes()
+    state_bytes = cache_bytes // cache_entries if cache_entries else 0
     return {
         "mode": mode,
-        "m": args.m,
+        "m": m,
         "n": args.n,
         "k": args.k,
-        "avg_ms": statistics.mean(samples),
-        "median_ms": statistics.median(samples),
-        "cache_entries": prepared_b_cache_size(),
-        "cache_bytes": prepared_b_cache_bytes(),
+        "avg_gpu_ms": statistics.mean(gpu_samples),
+        "median_gpu_ms": statistics.median(gpu_samples),
+        "avg_wall_ms": statistics.mean(wall_samples),
+        "median_wall_ms": statistics.median(wall_samples),
+        "cache_entries": cache_entries,
+        "cache_bytes": cache_bytes,
+        "b_state_bytes": state_bytes,
+        "avoided_b_state_bytes": stats.hits * state_bytes,
         "hits": stats.hits,
         "misses": stats.misses,
         "evictions": stats.evictions,
         "oversize": stats.oversize,
+        "disabled": stats.disabled,
+        "cache_budget_bytes": args.cache_bytes,
     }
 
 
 def _print_rows(rows: list[dict[str, float | int | str]]) -> None:
     print(
-        "mode,m,n,k,avg_ms,median_ms,cache_entries,cache_bytes,"
-        "hits,misses,evictions,oversize",
+        "mode,m,n,k,avg_gpu_ms,median_gpu_ms,avg_wall_ms,median_wall_ms,"
+        "cache_entries,cache_bytes,b_state_bytes,avoided_b_state_bytes,"
+        "hits,misses,evictions,oversize,disabled,cache_budget_bytes",
         flush=True,
     )
     for row in rows:
         print(
             f"{row['mode']},{row['m']},{row['n']},{row['k']},"
-            f"{row['avg_ms']:.3f},{row['median_ms']:.3f},"
-            f"{row['cache_entries']},{row['cache_bytes']},"
-            f"{row['hits']},{row['misses']},{row['evictions']},{row['oversize']}",
+            f"{row['avg_gpu_ms']:.3f},{row['median_gpu_ms']:.3f},"
+            f"{row['avg_wall_ms']:.3f},{row['median_wall_ms']:.3f},"
+            f"{row['cache_entries']},{row['cache_bytes']},{row['b_state_bytes']},"
+            f"{row['avoided_b_state_bytes']},{row['hits']},{row['misses']},"
+            f"{row['evictions']},{row['oversize']},{row['disabled']},"
+            f"{row['cache_budget_bytes']}",
             flush=True,
         )
 
@@ -139,11 +211,11 @@ def main() -> None:
     init_async_manager(settings)
     init_pinned_pool(settings.pinned_pool_size)
     try:
-        a, b, scale_a, scale_b = _make_inputs(args)
-        rows = [
-            _measure("cold", args, a, b, scale_a, scale_b),
-            _measure("warm", args, a, b, scale_a, scale_b),
-        ]
+        rows = []
+        for m in args.m_values:
+            a, b, scale_a, scale_b = _make_inputs(m, args)
+            for mode in args.modes:
+                rows.append(_measure(mode, args, m, a, b, scale_a, scale_b))
         _print_rows(rows)
     finally:
         clear_prepared_b_cache()

--- a/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
+++ b/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
@@ -151,10 +151,12 @@ def _measure(  # noqa: C901
             clear_prepared_b_cache(reset_stats=False)
         if mode == "vanilla":
             pass
+        elif mode == "warm":
+            _set_job(0)
         elif mode == "job_transition":
             _set_job(sequence)
             sequence += 1
-        elif mode != "warm":
+        else:
             _set_job(idx)
         _one_call(mode, a, b, scale_a, scale_b)
     torch.cuda.synchronize()
@@ -164,7 +166,9 @@ def _measure(  # noqa: C901
     for _ in range(args.iterations):
         if mode == "cold":
             clear_prepared_b_cache(reset_stats=False)
-        if mode == "job_transition":
+        if mode == "warm":
+            _set_job(0)
+        elif mode == "job_transition":
             _set_job(sequence)
             sequence += 1
         start.record()

--- a/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
+++ b/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
@@ -1,0 +1,154 @@
+"""Benchmark cold vs warm PreparedBMiningState for dense noisy GEMM.
+
+Example:
+    uv run --package vllm-miner python \
+        miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+
+import torch
+from miner_base.settings import MinerSettings
+from vllm_miner.gemm_operators import pearl_gemm_noisy
+from vllm_miner.mining_state import delete_state, init_async_manager, init_pinned_pool
+from vllm_miner.prepared_b_mining_state import (
+    clear_prepared_b_cache,
+    prepared_b_cache_bytes,
+    prepared_b_cache_size,
+    prepared_b_cache_stats,
+    reset_prepared_b_cache_stats,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark dense noisy GEMM with cold and warm PreparedBMiningState."
+    )
+    parser.add_argument("--m", type=int, default=1024)
+    parser.add_argument("--n", type=int, default=28672)
+    parser.add_argument("--k", type=int, default=4096)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--cache-bytes", type=int, default=1 << 30)
+    parser.add_argument("--allow-non-h100", action="store_true")
+    return parser.parse_args()
+
+
+def _require_gpu(allow_non_h100: bool) -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    name = torch.cuda.get_device_name(0)
+    if "H100" not in name and not allow_non_h100:
+        raise RuntimeError(f"Expected H100; got {name}. Pass --allow-non-h100 to override.")
+
+
+def _make_inputs(args: argparse.Namespace) -> tuple[torch.Tensor, ...]:
+    torch.manual_seed(0)
+    a = torch.randint(-63, 64, (args.m, args.k), dtype=torch.int8, device="cuda")
+    b = torch.randint(-63, 64, (args.n, args.k), dtype=torch.int8, device="cuda")
+    scale_a = torch.ones((args.m,), dtype=torch.float32, device="cuda")
+    scale_b = torch.ones((args.n,), dtype=torch.float32, device="cuda")
+    return a, b, scale_a, scale_b
+
+
+def _one_call(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor) -> None:
+    out = pearl_gemm_noisy(a, b, scale_a, scale_b, torch.bfloat16, submit_block=False)
+    # Keep the output live until after kernel launch.
+    del out
+
+
+def _measure(
+    mode: str,
+    args: argparse.Namespace,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale_a: torch.Tensor,
+    scale_b: torch.Tensor,
+) -> dict[str, float | int | str]:
+    clear_prepared_b_cache()
+
+    if mode == "warm":
+        _one_call(a, b, scale_a, scale_b)
+        torch.cuda.synchronize()
+        reset_prepared_b_cache_stats()
+    elif mode != "cold":
+        raise ValueError(f"unknown mode: {mode}")
+
+    samples = []
+    for _ in range(args.warmup):
+        if mode == "cold":
+            clear_prepared_b_cache(reset_stats=False)
+        _one_call(a, b, scale_a, scale_b)
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    for _ in range(args.iterations):
+        if mode == "cold":
+            clear_prepared_b_cache(reset_stats=False)
+        start.record()
+        _one_call(a, b, scale_a, scale_b)
+        end.record()
+        torch.cuda.synchronize()
+        samples.append(start.elapsed_time(end))
+
+    stats = prepared_b_cache_stats()
+    return {
+        "mode": mode,
+        "m": args.m,
+        "n": args.n,
+        "k": args.k,
+        "avg_ms": statistics.mean(samples),
+        "median_ms": statistics.median(samples),
+        "cache_entries": prepared_b_cache_size(),
+        "cache_bytes": prepared_b_cache_bytes(),
+        "hits": stats.hits,
+        "misses": stats.misses,
+        "evictions": stats.evictions,
+        "oversize": stats.oversize,
+    }
+
+
+def _print_rows(rows: list[dict[str, float | int | str]]) -> None:
+    print(
+        "mode,m,n,k,avg_ms,median_ms,cache_entries,cache_bytes,"
+        "hits,misses,evictions,oversize",
+        flush=True,
+    )
+    for row in rows:
+        print(
+            f"{row['mode']},{row['m']},{row['n']},{row['k']},"
+            f"{row['avg_ms']:.3f},{row['median_ms']:.3f},"
+            f"{row['cache_entries']},{row['cache_bytes']},"
+            f"{row['hits']},{row['misses']},{row['evictions']},{row['oversize']}",
+            flush=True,
+        )
+
+
+def main() -> None:
+    args = _parse_args()
+    _require_gpu(args.allow_non_h100)
+    settings = MinerSettings(
+        no_gateway=True,
+        skip_block_submission=True,
+        prepared_b_cache_bytes=args.cache_bytes,
+    )
+    init_async_manager(settings)
+    init_pinned_pool(settings.pinned_pool_size)
+    try:
+        a, b, scale_a, scale_b = _make_inputs(args)
+        rows = [
+            _measure("cold", args, a, b, scale_a, scale_b),
+            _measure("warm", args, a, b, scale_a, scale_b),
+        ]
+        _print_rows(rows)
+    finally:
+        clear_prepared_b_cache()
+        delete_state()
+
+
+if __name__ == "__main__":
+    main()

--- a/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
+++ b/miner/vllm-miner/benchmarks/bench_prepared_b_mining_state.py
@@ -15,7 +15,7 @@ import torch
 from miner_base.settings import MinerSettings
 from pearl_gateway.comm.dataclasses import MiningJob
 from vllm_miner.config import config
-from vllm_miner.gemm_operators import pearl_gemm_noisy
+from vllm_miner.gemm_operators import pearl_gemm_noisy, pearl_gemm_vanilla
 from vllm_miner.mining_state import (
     delete_state,
     get_async_manager,
@@ -33,7 +33,7 @@ from vllm_miner.prepared_b_mining_state import (
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Benchmark dense noisy GEMM with disabled, cold, warm, and job-transition PreparedBMiningState."
+        description="Benchmark dense GEMM with vanilla and noisy PreparedBMiningState modes."
     )
     parser.add_argument(
         "--m-values",
@@ -49,14 +49,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--modes",
         type=str,
-        default="disabled,cold,warm,job_transition",
-        help="Comma-separated modes: disabled,cold,warm,job_transition.",
+        default="vanilla,disabled,cold,warm,job_transition",
+        help="Comma-separated modes: vanilla,disabled,cold,warm,job_transition.",
     )
     parser.add_argument("--allow-non-h100", action="store_true")
     args = parser.parse_args()
     args.m_values = _parse_int_list(args.m_values, "--m-values")
     args.modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
-    valid_modes = {"disabled", "cold", "warm", "job_transition"}
+    valid_modes = {"vanilla", "disabled", "cold", "warm", "job_transition"}
     unknown_modes = set(args.modes) - valid_modes
     if unknown_modes:
         raise ValueError(f"unknown --modes entries: {sorted(unknown_modes)}")
@@ -94,10 +94,29 @@ def _set_job(sequence: int) -> None:
     get_async_manager()._mining_job = MiningJob(header, 1)
 
 
-def _one_call(a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor) -> None:
+def _one_noisy_call(
+    a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor
+) -> None:
     out = pearl_gemm_noisy(a, b, scale_a, scale_b, torch.bfloat16, submit_block=False)
     # Keep the output live until after kernel launch.
     del out
+
+
+def _one_vanilla_call(
+    a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor
+) -> None:
+    out = pearl_gemm_vanilla(a, b, scale_a, scale_b, torch.bfloat16)
+    # Keep the output live until after kernel launch.
+    del out
+
+
+def _one_call(
+    mode: str, a: torch.Tensor, b: torch.Tensor, scale_a: torch.Tensor, scale_b: torch.Tensor
+) -> None:
+    if mode == "vanilla":
+        _one_vanilla_call(a, b, scale_a, scale_b)
+        return
+    _one_noisy_call(a, b, scale_a, scale_b)
 
 
 def _measure(  # noqa: C901
@@ -110,17 +129,17 @@ def _measure(  # noqa: C901
     scale_b: torch.Tensor,
 ) -> dict[str, float | int | str]:
     clear_prepared_b_cache()
-    if mode == "disabled":
+    if mode in {"vanilla", "disabled"}:
         config.settings.prepared_b_cache_bytes = 0
     else:
         config.settings.prepared_b_cache_bytes = args.cache_bytes
 
     if mode == "warm":
         _set_job(0)
-        _one_call(a, b, scale_a, scale_b)
+        _one_call(mode, a, b, scale_a, scale_b)
         torch.cuda.synchronize()
         reset_prepared_b_cache_stats()
-    elif mode not in {"disabled", "cold", "job_transition"}:
+    elif mode not in {"vanilla", "disabled", "cold", "job_transition"}:
         raise ValueError(f"unknown mode: {mode}")
 
     gpu_samples = []
@@ -130,12 +149,14 @@ def _measure(  # noqa: C901
     for idx in range(args.warmup):
         if mode == "cold":
             clear_prepared_b_cache(reset_stats=False)
-        if mode == "job_transition":
+        if mode == "vanilla":
+            pass
+        elif mode == "job_transition":
             _set_job(sequence)
             sequence += 1
         elif mode != "warm":
             _set_job(idx)
-        _one_call(a, b, scale_a, scale_b)
+        _one_call(mode, a, b, scale_a, scale_b)
     torch.cuda.synchronize()
 
     start = torch.cuda.Event(enable_timing=True)
@@ -148,7 +169,7 @@ def _measure(  # noqa: C901
             sequence += 1
         start.record()
         wall_start = time.perf_counter()
-        _one_call(a, b, scale_a, scale_b)
+        _one_call(mode, a, b, scale_a, scale_b)
         end.record()
         torch.cuda.synchronize()
         wall_samples.append((time.perf_counter() - wall_start) * 1000)

--- a/miner/vllm-miner/src/vllm_miner/__init__.py
+++ b/miner/vllm-miner/src/vllm_miner/__init__.py
@@ -1,10 +1,29 @@
-from .gemm_operators import pearl_gemm_noisy, pearl_gemm_vanilla
-from .register import register_pearl_miner_layer
-from .vllm_kernels import PearlKernel
-
 __all__ = [
     "register_pearl_miner_layer",
     "PearlKernel",
     "pearl_gemm_vanilla",
     "pearl_gemm_noisy",
 ]
+
+
+def __getattr__(name: str):
+    if name in {"pearl_gemm_noisy", "pearl_gemm_vanilla"}:
+        from .gemm_operators import pearl_gemm_noisy, pearl_gemm_vanilla
+
+        return {
+            "pearl_gemm_noisy": pearl_gemm_noisy,
+            "pearl_gemm_vanilla": pearl_gemm_vanilla,
+        }[name]
+    if name == "register_pearl_miner_layer":
+        from .register import register_pearl_miner_layer
+
+        return register_pearl_miner_layer
+    if name == "PearlKernel":
+        from .vllm_kernels import PearlKernel
+
+        return PearlKernel
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -3,6 +3,7 @@ from miner_base.commitment_hash import CommitmentHasher
 from miner_base.gpu_matmul_config import GPUMatmulConfigFactory
 from miner_utils import get_logger
 from pearl_gemm import (
+    commitment_hash_from_b_commitment,
     commitment_hash_from_merkle_roots,
     gemm,
     get_host_signal_sync_size,
@@ -20,6 +21,10 @@ from .config import config
 from .mining_state import (
     get_async_manager,
     get_pinned_pool,
+)
+from .prepared_b_mining_state import (
+    PreparedBMiningState,
+    get_or_prepare_b_mining_state,
 )
 
 _LOGGER = get_logger("vllm.pearl_miner")
@@ -129,44 +134,57 @@ def pearl_gemm_noisy(
         tensor_hash_scratchpad,
     )
 
-    B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
-    tensor_hash(
+    def _prepare_b_state(
+        B: torch.Tensor = B,
+        key_tensor: torch.Tensor = key_tensor,
+        tensor_hash_scratchpad: torch.Tensor = tensor_hash_scratchpad,
+        n: int = n,
+        k: int = k,
+        r: int = r,
+        device: torch.device = a.device,
+    ) -> PreparedBMiningState:
+        return prepare_b_mining_state(
+            B,
+            key_tensor,
+            tensor_hash_scratchpad,
+            n,
+            k,
+            r,
+            device,
+        )
+
+    prepared_b_state = get_or_prepare_b_mining_state(
         B,
-        key_tensor,
-        B_tensor_hash,
-        tensor_hash_scratchpad,
+        hash_key,
+        r,
+        config.settings.prepared_b_cache_bytes,
+        _prepare_b_state,
     )
 
-    # Generate commitment hash for noise generation
     commitment_hash_A_tensor = torch.empty(32, device="cuda", dtype=torch.uint8)
-    commitment_hash_B_tensor = torch.empty(32, device="cuda", dtype=torch.uint8)
-    commitment_hash_from_merkle_roots(
+    commitment_hash_from_b_commitment(
         A_tensor_hash,
-        B_tensor_hash,
-        key_tensor,
+        prepared_b_state.commitment_b,
         commitment_hash_A_tensor,
-        commitment_hash_B_tensor,
     )
+    commitment_hash_B_tensor = prepared_b_state.commitment_b
 
-    # Generate noise factors from commitment hashes
     (
         EAL,
         EAR_R_major,
-        EBL_R_major,
         EAR_K_major,
-        EBL_K_major,
-        EBR,
         EAL_fp16,
-        EBR_fp16,
-    ) = generate_noise_factors(
+    ) = generate_a_noise_factors(
         m,
-        n,
         k,
         r,
         commitment_hash_A_tensor,
-        commitment_hash_B_tensor,
         a.device,
     )
+    EBL_R_major = prepared_b_state.ebl_r_major
+    EBL_K_major = prepared_b_state.ebl_k_major
+    EBR = prepared_b_state.ebr
+    EBR_fp16 = prepared_b_state.ebr_fp16
 
     # Always compute B noising (depends on A through EAR)
     BpEB = torch.empty((n, k), dtype=torch.int8, device=a.device)
@@ -256,11 +274,101 @@ def pearl_gemm_noisy(
     del EBR_fp16
     del key_tensor
     del A_tensor_hash
-    del B_tensor_hash
     del tensor_hash_scratchpad
     del host_signal_sync
     del EARxBpEB
     return C
+
+
+def prepare_b_mining_state(
+    B: torch.Tensor,
+    key_tensor: torch.Tensor,
+    tensor_hash_scratchpad: torch.Tensor,
+    n: int,
+    k: int,
+    r: int,
+    device: torch.device,
+) -> PreparedBMiningState:
+    B_tensor_hash = torch.empty(32, device=device, dtype=torch.uint8)
+    tensor_hash(
+        B,
+        key_tensor,
+        B_tensor_hash,
+        tensor_hash_scratchpad,
+    )
+
+    dummy_A_tensor_hash = torch.zeros(32, device=device, dtype=torch.uint8)
+    dummy_commitment_hash_A = torch.empty(32, device=device, dtype=torch.uint8)
+    commitment_hash_B_tensor = torch.empty(32, device=device, dtype=torch.uint8)
+    commitment_hash_from_merkle_roots(
+        dummy_A_tensor_hash,
+        B_tensor_hash,
+        key_tensor,
+        dummy_commitment_hash_A,
+        commitment_hash_B_tensor,
+    )
+
+    EBL_R_major, EBL_K_major, EBR, EBR_fp16 = generate_b_noise_factors(
+        n,
+        k,
+        r,
+        commitment_hash_B_tensor,
+        device,
+    )
+    return PreparedBMiningState(
+        b_hash=B_tensor_hash,
+        commitment_b=commitment_hash_B_tensor,
+        ebl_r_major=EBL_R_major,
+        ebl_k_major=EBL_K_major,
+        ebr=EBR,
+        ebr_fp16=EBR_fp16,
+    )
+
+
+def generate_a_noise_factors(
+    m: int,
+    k: int,
+    r: int,
+    commitment_hash_A: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    EAL = torch.empty((m, r), dtype=torch.int8, device=device)
+    EAR_R_major = torch.empty((k, r), dtype=torch.int8, device=device)
+    EAR_K_major = torch.empty((r, k), dtype=torch.int8, device=device)
+    EAL_fp16 = torch.empty((m, r), dtype=torch.float16, device=device)
+
+    noise_gen(
+        R=r,
+        EAL=EAL,
+        EAL_fp16=EAL_fp16,
+        EAR_R_major=EAR_R_major,
+        EAR_K_major=EAR_K_major,
+        key_A=commitment_hash_A,
+    )
+    return EAL, EAR_R_major, EAR_K_major, EAL_fp16
+
+
+def generate_b_noise_factors(
+    n: int,
+    k: int,
+    r: int,
+    commitment_hash_B: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    EBL_R_major = torch.empty((k, r), dtype=torch.int8, device=device)
+    EBL_K_major = torch.empty((r, k), dtype=torch.int8, device=device)
+    EBR = torch.empty((n, r), dtype=torch.int8, device=device)
+    EBR_fp16 = torch.empty((n, r), dtype=torch.float16, device=device)
+
+    noise_gen(
+        R=r,
+        EBL_R_major=EBL_R_major,
+        EBL_K_major=EBL_K_major,
+        EBR=EBR,
+        EBR_fp16=EBR_fp16,
+        key_B=commitment_hash_B,
+    )
+    return EBL_R_major, EBL_K_major, EBR, EBR_fp16
 
 
 def generate_noise_factors(
@@ -297,28 +405,19 @@ def generate_noise_factors(
     :return: Tuple of noise tensors (EAL, EAR_R_major, EBL_R_major,
              EAR_K_major, EBL_K_major, EBR, EAL_fp16, EBR_fp16)
     """
-    EAL = torch.empty((m, r), dtype=torch.int8, device=device)
-    EBR = torch.empty((n, r), dtype=torch.int8, device=device)
-
-    EAR_R_major = torch.empty((k, r), dtype=torch.int8, device=device)
-    EBL_R_major = torch.empty((k, r), dtype=torch.int8, device=device)
-    EAR_K_major = torch.empty((r, k), dtype=torch.int8, device=device)
-    EBL_K_major = torch.empty((r, k), dtype=torch.int8, device=device)
-    EAL_fp16 = torch.empty((m, r), dtype=torch.float16, device=device)
-    EBR_fp16 = torch.empty((n, r), dtype=torch.float16, device=device)
-
-    noise_gen(
-        R=r,
-        EAL=EAL,
-        EAL_fp16=EAL_fp16,
-        EAR_R_major=EAR_R_major,
-        EAR_K_major=EAR_K_major,
-        EBL_R_major=EBL_R_major,
-        EBL_K_major=EBL_K_major,
-        EBR=EBR,
-        EBR_fp16=EBR_fp16,
-        key_A=commitment_hash_A,
-        key_B=commitment_hash_B,
+    EAL, EAR_R_major, EAR_K_major, EAL_fp16 = generate_a_noise_factors(
+        m,
+        k,
+        r,
+        commitment_hash_A,
+        device,
+    )
+    EBL_R_major, EBL_K_major, EBR, EBR_fp16 = generate_b_noise_factors(
+        n,
+        k,
+        r,
+        commitment_hash_B,
+        device,
     )
     return (
         EAL,

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -123,7 +123,7 @@ def pearl_gemm_noisy(
 
     A_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        A.to(torch.uint8),
+        A,
         key_tensor,
         A_tensor_hash,
         tensor_hash_scratchpad,
@@ -131,7 +131,7 @@ def pearl_gemm_noisy(
 
     B_tensor_hash = torch.empty(32, device="cuda", dtype=torch.uint8)
     tensor_hash(
-        B.to(torch.uint8),
+        B,
         key_tensor,
         B_tensor_hash,
         tensor_hash_scratchpad,

--- a/miner/vllm-miner/src/vllm_miner/prepared_b_mining_state.py
+++ b/miner/vllm-miner/src/vllm_miner/prepared_b_mining_state.py
@@ -4,6 +4,7 @@ import weakref
 from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
+from threading import RLock
 
 import torch
 
@@ -50,6 +51,7 @@ class PreparedBCacheStats:
 _CACHE: OrderedDict[tuple, _CacheEntry] = OrderedDict()
 _STATS = PreparedBCacheStats()
 _CACHE_BYTES = 0
+_CACHE_LOCK = RLock()
 
 
 def _cache_key(weight: torch.Tensor, job_key_bytes: bytes, noise_rank: int) -> tuple:
@@ -65,7 +67,7 @@ def _cache_key(weight: torch.Tensor, job_key_bytes: bytes, noise_rank: int) -> t
     )
 
 
-def _evict_key(cache_key: tuple) -> None:
+def _evict_key_locked(cache_key: tuple) -> None:
     global _CACHE_BYTES
     entry = _CACHE.pop(cache_key, None)
     if entry is not None:
@@ -73,10 +75,10 @@ def _evict_key(cache_key: tuple) -> None:
         _STATS.evictions += 1
 
 
-def _evict_lru_until_fits(required_bytes: int, max_cache_bytes: int) -> None:
+def _evict_lru_until_fits_locked(required_bytes: int, max_cache_bytes: int) -> None:
     while _CACHE and _CACHE_BYTES + required_bytes > max_cache_bytes:
         cache_key, _ = next(iter(_CACHE.items()))
-        _evict_key(cache_key)
+        _evict_key_locked(cache_key)
 
 
 def get_or_prepare_b_mining_state(
@@ -88,68 +90,85 @@ def get_or_prepare_b_mining_state(
 ) -> PreparedBMiningState:
     """Return immutable B-side mining state for one exact weight/job/rank tuple."""
     if max_cache_bytes <= 0:
-        _STATS.disabled += 1
+        with _CACHE_LOCK:
+            _STATS.disabled += 1
         return prepare()
 
     cache_key = _cache_key(weight, job_key_bytes, noise_rank)
-    entry = _CACHE.get(cache_key)
-    if entry is not None:
-        if entry.weak_weight() is weight:
-            _CACHE.move_to_end(cache_key)
-            _STATS.hits += 1
-            return entry.state
-        _evict_key(cache_key)
+    with _CACHE_LOCK:
+        entry = _CACHE.get(cache_key)
+        if entry is not None:
+            if entry.weak_weight() is weight:
+                _CACHE.move_to_end(cache_key)
+                _STATS.hits += 1
+                return entry.state
+            _evict_key_locked(cache_key)
 
-    _STATS.misses += 1
+        _STATS.misses += 1
     state = prepare()
     state_bytes = state.nbytes
     if state_bytes > max_cache_bytes:
-        _STATS.oversize += 1
+        with _CACHE_LOCK:
+            _STATS.oversize += 1
         return state
 
     def _finalize(ref: weakref.ReferenceType[torch.Tensor], key: tuple = cache_key) -> None:
-        entry = _CACHE.get(key)
-        if entry is not None and entry.weak_weight is ref:
-            _evict_key(key)
+        with _CACHE_LOCK:
+            entry = _CACHE.get(key)
+            if entry is not None and entry.weak_weight is ref:
+                _evict_key_locked(key)
 
     try:
         weak_weight = weakref.ref(weight, _finalize)
     except TypeError:
         return state
 
-    _evict_lru_until_fits(state_bytes, max_cache_bytes)
-    global _CACHE_BYTES
-    _CACHE[cache_key] = _CacheEntry(weak_weight=weak_weight, state=state)
-    _CACHE_BYTES += state_bytes
+    with _CACHE_LOCK:
+        entry = _CACHE.get(cache_key)
+        if entry is not None:
+            if entry.weak_weight() is weight:
+                _CACHE.move_to_end(cache_key)
+                return entry.state
+            _evict_key_locked(cache_key)
+
+        _evict_lru_until_fits_locked(state_bytes, max_cache_bytes)
+        global _CACHE_BYTES
+        _CACHE[cache_key] = _CacheEntry(weak_weight=weak_weight, state=state)
+        _CACHE_BYTES += state_bytes
     return state
 
 
 def clear_prepared_b_cache(*, reset_stats: bool = True) -> None:
     global _CACHE_BYTES, _STATS
-    _CACHE.clear()
-    _CACHE_BYTES = 0
-    if reset_stats:
-        _STATS = PreparedBCacheStats()
+    with _CACHE_LOCK:
+        _CACHE.clear()
+        _CACHE_BYTES = 0
+        if reset_stats:
+            _STATS = PreparedBCacheStats()
 
 
 def reset_prepared_b_cache_stats() -> None:
     global _STATS
-    _STATS = PreparedBCacheStats()
+    with _CACHE_LOCK:
+        _STATS = PreparedBCacheStats()
 
 
 def prepared_b_cache_stats() -> PreparedBCacheStats:
-    return PreparedBCacheStats(
-        hits=_STATS.hits,
-        misses=_STATS.misses,
-        evictions=_STATS.evictions,
-        oversize=_STATS.oversize,
-        disabled=_STATS.disabled,
-    )
+    with _CACHE_LOCK:
+        return PreparedBCacheStats(
+            hits=_STATS.hits,
+            misses=_STATS.misses,
+            evictions=_STATS.evictions,
+            oversize=_STATS.oversize,
+            disabled=_STATS.disabled,
+        )
 
 
 def prepared_b_cache_size() -> int:
-    return len(_CACHE)
+    with _CACHE_LOCK:
+        return len(_CACHE)
 
 
 def prepared_b_cache_bytes() -> int:
-    return _CACHE_BYTES
+    with _CACHE_LOCK:
+        return _CACHE_BYTES

--- a/miner/vllm-miner/src/vllm_miner/prepared_b_mining_state.py
+++ b/miner/vllm-miner/src/vllm_miner/prepared_b_mining_state.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import weakref
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedBMiningState:
+    b_hash: torch.Tensor
+    commitment_b: torch.Tensor
+    ebl_r_major: torch.Tensor
+    ebl_k_major: torch.Tensor
+    ebr: torch.Tensor
+    ebr_fp16: torch.Tensor
+
+    @property
+    def nbytes(self) -> int:
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for tensor in (
+                self.b_hash,
+                self.commitment_b,
+                self.ebl_r_major,
+                self.ebl_k_major,
+                self.ebr,
+                self.ebr_fp16,
+            )
+        )
+
+
+@dataclass(slots=True)
+class _CacheEntry:
+    weak_weight: weakref.ReferenceType[torch.Tensor]
+    state: PreparedBMiningState
+
+
+@dataclass(slots=True)
+class PreparedBCacheStats:
+    hits: int = 0
+    misses: int = 0
+    evictions: int = 0
+    oversize: int = 0
+    disabled: int = 0
+
+
+_CACHE: OrderedDict[tuple, _CacheEntry] = OrderedDict()
+_STATS = PreparedBCacheStats()
+_CACHE_BYTES = 0
+
+
+def _cache_key(weight: torch.Tensor, job_key_bytes: bytes, noise_rank: int) -> tuple:
+    return (
+        weight.device.type,
+        weight.device.index,
+        weight.data_ptr(),
+        tuple(weight.shape),
+        tuple(weight.stride()),
+        weight.dtype,
+        bytes(job_key_bytes),
+        int(noise_rank),
+    )
+
+
+def _evict_key(cache_key: tuple) -> None:
+    global _CACHE_BYTES
+    entry = _CACHE.pop(cache_key, None)
+    if entry is not None:
+        _CACHE_BYTES -= entry.state.nbytes
+        _STATS.evictions += 1
+
+
+def _evict_lru_until_fits(required_bytes: int, max_cache_bytes: int) -> None:
+    while _CACHE and _CACHE_BYTES + required_bytes > max_cache_bytes:
+        cache_key, _ = next(iter(_CACHE.items()))
+        _evict_key(cache_key)
+
+
+def get_or_prepare_b_mining_state(
+    weight: torch.Tensor,
+    job_key_bytes: bytes,
+    noise_rank: int,
+    max_cache_bytes: int,
+    prepare: Callable[[], PreparedBMiningState],
+) -> PreparedBMiningState:
+    """Return immutable B-side mining state for one exact weight/job/rank tuple."""
+    if max_cache_bytes <= 0:
+        _STATS.disabled += 1
+        return prepare()
+
+    cache_key = _cache_key(weight, job_key_bytes, noise_rank)
+    entry = _CACHE.get(cache_key)
+    if entry is not None:
+        if entry.weak_weight() is weight:
+            _CACHE.move_to_end(cache_key)
+            _STATS.hits += 1
+            return entry.state
+        _evict_key(cache_key)
+
+    _STATS.misses += 1
+    state = prepare()
+    state_bytes = state.nbytes
+    if state_bytes > max_cache_bytes:
+        _STATS.oversize += 1
+        return state
+
+    def _finalize(ref: weakref.ReferenceType[torch.Tensor], key: tuple = cache_key) -> None:
+        entry = _CACHE.get(key)
+        if entry is not None and entry.weak_weight is ref:
+            _evict_key(key)
+
+    try:
+        weak_weight = weakref.ref(weight, _finalize)
+    except TypeError:
+        return state
+
+    _evict_lru_until_fits(state_bytes, max_cache_bytes)
+    global _CACHE_BYTES
+    _CACHE[cache_key] = _CacheEntry(weak_weight=weak_weight, state=state)
+    _CACHE_BYTES += state_bytes
+    return state
+
+
+def clear_prepared_b_cache(*, reset_stats: bool = True) -> None:
+    global _CACHE_BYTES, _STATS
+    _CACHE.clear()
+    _CACHE_BYTES = 0
+    if reset_stats:
+        _STATS = PreparedBCacheStats()
+
+
+def reset_prepared_b_cache_stats() -> None:
+    global _STATS
+    _STATS = PreparedBCacheStats()
+
+
+def prepared_b_cache_stats() -> PreparedBCacheStats:
+    return PreparedBCacheStats(
+        hits=_STATS.hits,
+        misses=_STATS.misses,
+        evictions=_STATS.evictions,
+        oversize=_STATS.oversize,
+        disabled=_STATS.disabled,
+    )
+
+
+def prepared_b_cache_size() -> int:
+    return len(_CACHE)
+
+
+def prepared_b_cache_bytes() -> int:
+    return _CACHE_BYTES

--- a/miner/vllm-miner/tests/test_prepared_b_mining_state.py
+++ b/miner/vllm-miner/tests/test_prepared_b_mining_state.py
@@ -1,0 +1,99 @@
+import torch
+from vllm_miner.prepared_b_mining_state import (
+    PreparedBMiningState,
+    clear_prepared_b_cache,
+    get_or_prepare_b_mining_state,
+    prepared_b_cache_bytes,
+    prepared_b_cache_size,
+    prepared_b_cache_stats,
+)
+
+
+def _state(fill: int, elems: int = 4) -> PreparedBMiningState:
+    def tensor(multiplier: int = 1) -> torch.Tensor:
+        return torch.full((elems * multiplier,), fill, dtype=torch.uint8)
+
+    return PreparedBMiningState(
+        b_hash=tensor(),
+        commitment_b=tensor(),
+        ebl_r_major=tensor(2),
+        ebl_k_major=tensor(2),
+        ebr=tensor(2),
+        ebr_fp16=torch.full((elems,), fill, dtype=torch.float16),
+    )
+
+
+def setup_function() -> None:
+    clear_prepared_b_cache()
+
+
+def teardown_function() -> None:
+    clear_prepared_b_cache()
+
+
+def test_prepared_b_cache_hits_exact_weight_job_and_rank() -> None:
+    weight = torch.empty((4, 4), dtype=torch.int8)
+    calls = 0
+
+    def prepare() -> PreparedBMiningState:
+        nonlocal calls
+        calls += 1
+        return _state(calls)
+
+    first = get_or_prepare_b_mining_state(weight, b"job-a", 128, 10_000, prepare)
+    second = get_or_prepare_b_mining_state(weight, b"job-a", 128, 10_000, prepare)
+
+    assert first is second
+    assert calls == 1
+    assert prepared_b_cache_size() == 1
+    stats = prepared_b_cache_stats()
+    assert stats.misses == 1
+    assert stats.hits == 1
+
+
+def test_prepared_b_cache_misses_on_job_rank_and_exact_identity() -> None:
+    weight = torch.empty((4, 4), dtype=torch.int8)
+    same_storage_view = weight.as_strided(weight.shape, weight.stride())
+    calls = 0
+
+    def prepare() -> PreparedBMiningState:
+        nonlocal calls
+        calls += 1
+        return _state(calls)
+
+    base = get_or_prepare_b_mining_state(weight, b"job-a", 128, 100_000, prepare)
+    new_job = get_or_prepare_b_mining_state(weight, b"job-b", 128, 100_000, prepare)
+    new_rank = get_or_prepare_b_mining_state(weight, b"job-a", 64, 100_000, prepare)
+    new_identity = get_or_prepare_b_mining_state(
+        same_storage_view, b"job-a", 128, 100_000, prepare
+    )
+
+    assert len({id(base), id(new_job), id(new_rank), id(new_identity)}) == 4
+    assert calls == 4
+    assert prepared_b_cache_stats().misses == 4
+
+
+def test_prepared_b_cache_enforces_byte_budget_with_lru_eviction() -> None:
+    weight_a = torch.empty((4, 4), dtype=torch.int8)
+    weight_b = torch.empty((4, 4), dtype=torch.int8)
+    one_entry_bytes = _state(1).nbytes
+
+    get_or_prepare_b_mining_state(weight_a, b"job", 128, one_entry_bytes + 1, lambda: _state(1))
+    get_or_prepare_b_mining_state(weight_b, b"job", 128, one_entry_bytes + 1, lambda: _state(2))
+
+    assert prepared_b_cache_size() == 1
+    assert prepared_b_cache_bytes() <= one_entry_bytes + 1
+    assert prepared_b_cache_stats().evictions == 1
+
+
+def test_prepared_b_cache_skips_oversize_and_disabled_entries() -> None:
+    weight = torch.empty((4, 4), dtype=torch.int8)
+    state = _state(1)
+
+    get_or_prepare_b_mining_state(weight, b"job", 128, state.nbytes - 1, lambda: state)
+    assert prepared_b_cache_size() == 0
+    assert prepared_b_cache_stats().oversize == 1
+
+    get_or_prepare_b_mining_state(weight, b"job", 128, 0, lambda: state)
+    assert prepared_b_cache_size() == 0
+    assert prepared_b_cache_stats().disabled == 1

--- a/miner/vllm-miner/tests/test_prepared_b_mining_state.py
+++ b/miner/vllm-miner/tests/test_prepared_b_mining_state.py
@@ -1,3 +1,5 @@
+import threading
+
 import torch
 from vllm_miner.prepared_b_mining_state import (
     PreparedBMiningState,
@@ -84,6 +86,50 @@ def test_prepared_b_cache_enforces_byte_budget_with_lru_eviction() -> None:
     assert prepared_b_cache_size() == 1
     assert prepared_b_cache_bytes() <= one_entry_bytes + 1
     assert prepared_b_cache_stats().evictions == 1
+
+
+def test_concurrent_same_key_misses_do_not_double_count_cache_bytes() -> None:
+    weight = torch.empty((4, 4), dtype=torch.int8)
+    barrier = threading.Barrier(2, timeout=5)
+    calls = 0
+    calls_lock = threading.Lock()
+    errors: list[BaseException] = []
+    results: list[PreparedBMiningState] = []
+    one_entry_bytes = _state(1).nbytes
+
+    def prepare() -> PreparedBMiningState:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            fill = calls
+        barrier.wait()
+        return _state(fill)
+
+    def worker() -> None:
+        try:
+            results.append(
+                get_or_prepare_b_mining_state(
+                    weight,
+                    b"job",
+                    128,
+                    100_000,
+                    prepare,
+                )
+            )
+        except BaseException as exc:  # pragma: no cover - surfaced by assertion below.
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    assert calls == 2
+    assert len(results) == 2
+    assert prepared_b_cache_size() == 1
+    assert prepared_b_cache_bytes() == one_entry_bytes
 
 
 def test_prepared_b_cache_skips_oversize_and_disabled_entries() -> None:

--- a/miner/vllm-miner/tests/test_reference_vs_kernels.py
+++ b/miner/vllm-miner/tests/test_reference_vs_kernels.py
@@ -77,8 +77,8 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Create random int8 tensor for MatrixMerkleTree
         matrix_int8 = torch.randint(-128, 127, (m, n), dtype=torch.int8)
 
-        # Convert to uint8 for tensor_hash (CUDA implementation expects uint8)
-        matrix_uint8 = matrix_int8.to(torch.uint8).cuda()
+        matrix_cuda = matrix_int8.cuda()
+        matrix_uint8 = matrix_cuda.to(torch.uint8)
 
         # Create key tensor for CUDA implementation
         key_tensor = _to_cuda_u8(test_noise_seed_A)
@@ -89,16 +89,19 @@ class TestMatrixMerkleTreeVsTensorHash:
 
         # Compute hash using tensor_hash (CUDA implementation)
         cuda_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
+        cast_result = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
         tensor_hash_scratchpad = torch.empty(
-            pearl_gemm.get_required_scratchpad_bytes(matrix_uint8.numel()),
+            pearl_gemm.get_required_scratchpad_bytes(matrix_cuda.numel()),
             device="cuda",
             dtype=torch.uint8,
         )
-        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_cuda, key_tensor, cuda_result, tensor_hash_scratchpad)
+        pearl_gemm.tensor_hash(matrix_uint8, key_tensor, cast_result, tensor_hash_scratchpad)
         torch.cuda.synchronize()
 
         # Convert CUDA result back to bytes for comparison
         cuda_root = cuda_result.cpu().numpy().tobytes()
+        cast_root = cast_result.cpu().numpy().tobytes()
 
         blake3_result = blake3(matrix_int8.cpu().numpy().tobytes(), key=test_noise_seed_A).digest()
 
@@ -109,6 +112,9 @@ class TestMatrixMerkleTreeVsTensorHash:
         # Compare results
         assert python_root == cuda_root, (
             f"Hash mismatch for shape {m, n}: MatrixMerkleTree root doesn't match tensor_hash result"
+        )
+        assert cuda_root == cast_root, (
+            f"Hash mismatch for shape {m, n}: direct int8 tensor_hash differs from uint8 cast path"
         )
 
     def test_commitment_hash_reference_vs_cuda(self, test_noise_seed_A):


### PR DESCRIPTION
Stack note: this is stacked on #193. After #193 lands I will rebase this on `master`; at that point the diff should be only the prepared-B cache work.

## Overview

This is the missing warm-path piece between #187 and #197.

B-side mining state is fixed for a given weight + mining job, but today we rebuild it before each GEMM. This PR caches that state for static dense weights.

On a cache hit, `pearl_gemm_noisy` still does the A-dependent work: A hash, `commitment_A`, `EAL`/`EAL_fp16`, and `EAR` layouts. It reuses the B-dependent work: `b_hash`, `commitment_b`, `EBL_R_major`, `EBL_K_major`, `EBR`, and `EBR_fp16`.

This does not cache `BpEB` or `EARxBpEB`. `EARxBpEB` depends on A, and #197 should own the fused / no-materialized-`BpEB` path.

## What changed

- Added `PreparedBMiningState` and a byte-budgeted cache keyed by exact weight identity, device, shape/stride/dtype, job-key bytes, and noise rank.
- Added a CUDA helper for deriving `commitment_A` from fresh A hash + cached `commitment_b`.
- Wired dense `pearl_gemm_noisy` through the cache. Cold calls and job transitions still prepare the B state normally.
- Added tests for cache behavior, concurrent same-key misses, and the new commitment helper.
- Added a focused H100 benchmark for vanilla, cold/no-cache mining, warm cached mining, and job transitions.

## H100 numbers

RunPod H100 80GB HBM3, Torch `2.11.0+cu130`, CUDA 13.0, bench commit `ba0d4d99`, stacked on #193. Current tip only adds the concurrent cache-accounting fix.

Shape: `N=28672`, `K=4096`, `R=128`, 5 warmups + 50 measured iterations.

| M | vanilla no-mining | cold/no-cache mining | warm cached mining | job transition | warm vs cold |
|---:|---:|---:|---:|---:|---:|
| 256 | 0.078 ms | 0.974 ms | 0.753 ms | 0.998 ms | **+22.7%** |
| 512 | 0.122 ms | 0.942 ms | 0.811 ms | 0.951 ms | **+13.9%** |
| 1024 | 0.205 ms | 1.062 ms | 0.905 ms | 1.057 ms | **+14.8%** |
| 2048 | 0.396 ms | 1.280 ms | 1.149 ms | 1.287 ms | **+10.2%** |

The comparison that matters is warm cached mining vs cold/no-cache mining. Vanilla no-mining is only there as the baseline sanity check; mining is not expected to beat no mining.

For this shape, one prepared-B entry is `12,058,688` bytes. Warm rows hit 55/55 calls and avoided `663,227,840` bytes of B-side state regeneration per row.

## Reviewer notes

- #187 is superseded for this direction. This caches the B hash and also the downstream B commitment/noise state.
- #193 is still needed. This branch depends on its direct-int8 tensor hashing.
- #197 should rebase on this and consume `PreparedBMiningState` instead of regenerating B hash, B commitment, or B factors.
- This PR is not trying to solve the remaining `BpEB` materialization. That is the next step in #197.

## Validation

- Local ruff, py_compile, prepared-B cache tests, and benchmark `--help`: passed.
- RunPod H100 prepared-B cache tests: 4 passed.
- RunPod H100 commitment helper test: 1 passed.
- RunPod H100 benchmark completed with the table above.


## Current-master reconciliation (2026-09-14)

The prepared-B cache applies only to unsalted V1/V2 jobs. V3 bypasses it and retains the full salted preparation from master. #193 remains an ancestor and an unmerged dependency.

Merged upstream master b713614301c42bfc3ea7c35e92917b7f4b161d8b. 7 isolated host logic tests passed with CPU tensors and CUDA/vLLM imports stubbed; protocol mutation checks reject dropping salts or routing V3 through the legacy cache. Python compilation/lint and affected C++ formatting passed. These are host logic checks, not CUDA integration proof.

Historical H100 timings above remain measurements of their recorded old commits. They do not qualify this current merge, and no V3 cache speedup is claimed. The repository-pinned Python/Torch/vLLM/CUDA correctness and proof-validation run remains required on the supported GPU before merge, along with maintainer review.
