### PR TITLE
ci: increase integration tests timeout to 60 min

### DIFF
--- a/.github/workflows/integration_tests_ci.yml
+++ b/.github/workflows/integration_tests_ci.yml
@@ -83,7 +83,7 @@ jobs:
     needs: [detect-changes, start-runner]
     if: always() && !cancelled() && needs.detect-changes.outputs.should_run == 'true'
     runs-on: ${{ needs.start-runner.outputs.label || 'h100-gpu' }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: public.ecr.aws/x5p2d7p8/pearl/ci-container:latest
       options: --gpus all --shm-size=16g --ipc=host


### PR DESCRIPTION
## Summary
- Bumps the `integration-tests` job `timeout-minutes` from 30 to 60 in `integration_tests_ci.yml`.

## Why this needs to land on `master`
The Integration Tests workflow is triggered via `pull_request_target`, which means GitHub **always reads the workflow definition from the base branch**, not from the PR branch. As a result, bumping the timeout on a feature branch has no effect on that PR's runs — the job keeps getting killed at the base branch's 30-minute limit. Merging this change to `master` makes the 60-minute timeout apply to all PRs.

## Test plan
- [ ] Confirm a subsequent PR's Integration Tests job shows a 60-minute timeout (no 30-minute cutoff).

Made with [Cursor](https://cursor.com)