### PR TITLE
ci: add GHCR release workflow for vLLM miner image

### DIFF
--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -2,6 +2,10 @@ name: Release Miner Docker Image
 on:
   workflow_dispatch:
     inputs:
+      node_major_version:
+        description: "Compatible node major version to stamp on the image (e.g. 1)"
+        required: true
+        type: string
       image_tag:
         description: "Extra image tag to publish (e.g. v0.1.0). Leave empty to tag by commit sha only."
         required: false
@@ -37,20 +41,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # The miner targets a specific node protocol; surface the compatible node
-      # major version (from the canonical version/version.go) so it can be
-      # stamped onto the image as a label.
-      - name: Resolve compatible node major version
-        id: node_version
-        run: |
-          MAJOR=$(grep -E '^[[:space:]]*Major[[:space:]]+uint' version/version.go | grep -oE '[0-9]+' | head -n1)
-          if [ -z "$MAJOR" ]; then
-            echo "::error::Could not parse Major from version/version.go"
-            exit 1
-          fi
-          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
-          echo "Compatible node major version: $MAJOR"
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -68,7 +58,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           labels: |
-            ai.pearlresearch.node.compatible-major-version=${{ steps.node_version.outputs.major }}
+            ai.pearlresearch.node.compatible-major-version=${{ inputs.node_major_version }}
           tags: |
             type=sha
             type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}

--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -6,6 +6,11 @@ on:
         description: "Extra image tag to publish (e.g. v0.1.0). Leave empty to tag by commit sha only."
         required: false
         type: string
+      mark_latest:
+        description: "Also tag this image as :latest"
+        required: false
+        type: boolean
+        default: false
       push:
         description: "Push to GHCR (uncheck to only build, e.g. to validate the Dockerfile)"
         required: false
@@ -56,6 +61,7 @@ jobs:
           tags: |
             type=sha
             type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
+            type=raw,value=latest,enable=${{ inputs.mark_latest }}
 
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0

--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -27,6 +27,7 @@ jobs:
   build-and-push:
     name: Build & Push vLLM Miner Image
     runs-on: large-runner
+    environment: release
     permissions:
       contents: read
       packages: write
@@ -35,6 +36,20 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+
+      # The miner targets a specific node protocol; surface the compatible node
+      # major version (from the canonical version/version.go) so it can be
+      # stamped onto the image as a label.
+      - name: Resolve compatible node major version
+        id: node_version
+        run: |
+          MAJOR=$(grep -E '^[[:space:]]*Major[[:space:]]+uint' version/version.go | grep -oE '[0-9]+' | head -n1)
+          if [ -z "$MAJOR" ]; then
+            echo "::error::Could not parse Major from version/version.go"
+            exit 1
+          fi
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "Compatible node major version: $MAJOR"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -52,6 +67,8 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            ai.pearlresearch.node.compatible-major-version=${{ steps.node_version.outputs.major }}
           tags: |
             type=sha
             type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}

--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -2,10 +2,6 @@ name: Release Miner Docker Image
 on:
   workflow_dispatch:
     inputs:
-      node_major_version:
-        description: "Compatible node major version to stamp on the image (e.g. 1)"
-        required: true
-        type: string
       image_tag:
         description: "Extra image tag to publish (e.g. v0.1.0). Leave empty to tag by commit sha only."
         required: false
@@ -50,15 +46,13 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.RELEASE_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract image metadata (tags & labels)
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          labels: |
-            ai.pearlresearch.node.compatible-major-version=${{ inputs.node_major_version }}
           tags: |
             type=sha
             type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}

--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Extract image metadata (tags & labels)
         id: meta

--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -1,0 +1,69 @@
+name: Release Miner Docker Image
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Extra image tag to publish (e.g. v0.1.0). Leave empty to tag by commit sha only."
+        required: false
+        type: string
+      push:
+        description: "Push to GHCR (uncheck to only build, e.g. to validate the Dockerfile)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/vllm-miner
+
+jobs:
+  build-and-push:
+    name: Build & Push vLLM Miner Image
+    runs-on: large-runner
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        if: ${{ inputs.push }}
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata (tags & labels)
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha
+            type=raw,value=${{ inputs.image_tag }},enable=${{ inputs.image_tag != '' }}
+
+      - name: Build and push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ./miner/vllm-miner/Dockerfile
+          platforms: linux/amd64
+          push: ${{ inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds a manually triggered GitHub Actions workflow that builds the vLLM miner Docker image and publishes it to the GitHub Container Registry (GHCR).

## Type

ci

## Scope

miner

## Changes

- New `.github/workflows/miner_docker_release.yml`, triggered via `workflow_dispatch` (manual) only.
- Builds `miner/vllm-miner/Dockerfile` on `large-runner` and pushes to `ghcr.io/<owner>/<repo>/vllm-miner` using the built-in `GITHUB_TOKEN` (`packages: write`, no new secrets).
- Tags images by commit `sha` plus an optional `image_tag` input; the `push` toggle can be unchecked to dry-run the Dockerfile build.
- All actions pinned to commit SHAs, matching the repo's existing convention.

## Test plan

- Workflow YAML validated and all action SHAs resolve to their tagged releases.
- No application code changed, so `task test` is not applicable; the Dockerfile this workflow builds is already exercised on PRs by `miner_heavy_ci.yml`.
- The publish path runs only on manual `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
