### PR TITLE
mempool: simplify and bound RBF conflict traversal

### DIFF
--- a/node/mempool/mempool.go
+++ b/node/mempool/mempool.go
@@ -7,7 +7,6 @@ package mempool
 import (
 	"container/list"
 	"fmt"
-	"maps"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -671,86 +670,44 @@ func (mp *TxPool) signalsReplacement(tx *btcutil.Tx,
 	return false
 }
 
-// txAncestors returns all of the unconfirmed ancestors of the given
-// transaction. Given transactions A, B, and C where C spends B and B spends A,
-// A and B are considered ancestors of C.
-//
-// The cache is optional and serves as an optimization to avoid visiting
-// transactions we've already determined ancestors of.
-//
-// This function MUST be called with the mempool lock held (for reads).
-func (mp *TxPool) txAncestors(tx *btcutil.Tx,
-	cache map[chainhash.Hash]map[chainhash.Hash]*btcutil.Tx) map[chainhash.Hash]*btcutil.Tx {
-
-	// If a cache was not provided, we'll initialize one now to use for the
-	// recursive calls.
-	if cache == nil {
-		cache = make(map[chainhash.Hash]map[chainhash.Hash]*btcutil.Tx)
-	}
-
-	ancestors := make(map[chainhash.Hash]*btcutil.Tx)
-	for _, txIn := range tx.MsgTx().TxIn {
-		parent, ok := mp.pool[txIn.PreviousOutPoint.Hash]
-		if !ok {
-			continue
-		}
-		ancestors[*parent.Tx.Hash()] = parent.Tx
-
-		// Determine if the ancestors of this ancestor have already been
-		// computed. If they haven't, we'll do so now and cache them to
-		// use them later on if necessary.
-		moreAncestors, ok := cache[*parent.Tx.Hash()]
-		if !ok {
-			moreAncestors = mp.txAncestors(parent.Tx, cache)
-			cache[*parent.Tx.Hash()] = moreAncestors
-		}
-
-		maps.Copy(ancestors, moreAncestors)
-	}
-
-	return ancestors
-}
-
 // txDescendants returns all of the unconfirmed descendants of the given
 // transaction. Given transactions A, B, and C where C spends B and B spends A,
-// B and C are considered descendants of A. A cache can be provided in order to
-// easily retrieve the descendants of transactions we've already determined the
-// descendants of.
+// B and C are considered descendants of A.
+//
+// Results accumulate into descendants; if nil a new map is allocated.
+// At most MaxReplacementEvictions entries are collected.
 //
 // This function MUST be called with the mempool lock held (for reads).
 func (mp *TxPool) txDescendants(tx *btcutil.Tx,
-	cache map[chainhash.Hash]map[chainhash.Hash]*btcutil.Tx) map[chainhash.Hash]*btcutil.Tx {
-
-	// If a cache was not provided, we'll initialize one now to use for the
-	// recursive calls.
-	if cache == nil {
-		cache = make(map[chainhash.Hash]map[chainhash.Hash]*btcutil.Tx)
-	}
+	descendants map[chainhash.Hash]*btcutil.Tx) map[chainhash.Hash]*btcutil.Tx {
 
 	// We'll go through all of the outputs of the transaction to determine
 	// if they are spent by any other mempool transactions.
-	descendants := make(map[chainhash.Hash]*btcutil.Tx)
+	if descendants == nil {
+		descendants = make(map[chainhash.Hash]*btcutil.Tx)
+	}
+
 	op := wire.OutPoint{Hash: *tx.Hash()}
 	for i := range tx.MsgTx().TxOut {
+		if len(descendants) > MaxReplacementEvictions {
+			break
+		}
+
 		op.Index = uint32(i)
 		descendant, ok := mp.outpoints[op]
 		if !ok {
 			continue
 		}
-		descendants[*descendant.Hash()] = descendant
 
-		// Determine if the descendants of this descendant have already
-		// been computed. If they haven't, we'll do so now and cache
-		// them to use them later on if necessary.
-		moreDescendants, ok := cache[*descendant.Hash()]
-		if !ok {
-			moreDescendants = mp.txDescendants(descendant, cache)
-			cache[*descendant.Hash()] = moreDescendants
+		// The map is a visited set. If this descendant is already present,
+		// its descendants have already been expanded.
+		descendantHash := *descendant.Hash()
+		if _, ok := descendants[descendantHash]; ok {
+			continue
 		}
 
-		for _, moreDescendant := range moreDescendants {
-			descendants[*moreDescendant.Hash()] = moreDescendant
-		}
+		descendants[descendantHash] = descendant
+		mp.txDescendants(descendant, descendants)
 	}
 
 	return descendants
@@ -772,9 +729,9 @@ func (mp *TxPool) txConflicts(tx *btcutil.Tx) map[chainhash.Hash]*btcutil.Tx {
 		if !ok {
 			continue
 		}
+
 		conflicts[*conflict.Hash()] = conflict
-		descendants := mp.txDescendants(conflict, nil)
-		maps.Copy(conflicts, descendants)
+		mp.txDescendants(conflict, conflicts)
 	}
 	return conflicts
 }
@@ -858,15 +815,20 @@ func (mp *TxPool) validateReplacement(tx *btcutil.Tx,
 		return nil, txRuleError(wire.RejectNonstandard, str)
 	}
 
-	// The set of conflicts (transactions we'll replace) and ancestors
-	// should not overlap, otherwise the replacement would be spending an
-	// output that no longer exists.
-	for ancestorHash := range mp.txAncestors(tx, nil) {
-		if _, ok := conflicts[ancestorHash]; !ok {
+	// A replacement must not spend an output of a transaction it would
+	// evict: that conflict (and therefore the output) is about to be
+	// removed, so the replacement would be left spending an output that no
+	// longer exists.
+	//
+	// The conflict set is closed under descendants, hence it is sufficient
+	// to check that there are no conflicting immediate ancestors of tx.
+	for _, txIn := range tx.MsgTx().TxIn {
+		parentHash := txIn.PreviousOutPoint.Hash
+		if _, ok := conflicts[parentHash]; !ok {
 			continue
 		}
 		str := fmt.Sprintf("%v: replacement transaction spends parent "+
-			"transaction %v", tx.Hash(), ancestorHash)
+			"transaction %v", tx.Hash(), parentHash)
 		return nil, txRuleError(wire.RejectInvalid, str)
 	}
 

--- a/node/mempool/mempool_test.go
+++ b/node/mempool/mempool_test.go
@@ -1403,9 +1403,9 @@ func TestConflicts(t *testing.T) {
 	}
 }
 
-// TestAncestorsDescendants ensures that we can properly retrieve the
-// unconfirmed ancestors and descendants of a transaction.
-func TestAncestorsDescendants(t *testing.T) {
+// TestDescendants ensures that we can properly retrieve the unconfirmed
+// descendants of a transaction.
+func TestDescendants(t *testing.T) {
 	t.Parallel()
 
 	// We'll start the test by initializing our mempool harness.
@@ -1443,26 +1443,8 @@ func TestAncestorsDescendants(t *testing.T) {
 	}
 	e := ctx.addSignedTx(eInputs, 1, minTestFee, false, false)
 
-	// We'll be querying for the ancestors of E. We should expect to see all
-	// of the transactions that it depends on.
-	expectedAncestors := map[chainhash.Hash]struct{}{
-		*a.Hash(): {}, *b.Hash(): {},
-		*c.Hash(): {}, *d.Hash(): {},
-	}
-	ancestors := ctx.harness.txPool.txAncestors(e, nil)
-	if len(ancestors) != len(expectedAncestors) {
-		ctx.t.Fatalf("expected %d ancestors, got %d",
-			len(expectedAncestors), len(ancestors))
-	}
-	for ancestorHash := range ancestors {
-		if _, ok := expectedAncestors[ancestorHash]; !ok {
-			ctx.t.Fatalf("found unexpected ancestor %v",
-				ancestorHash)
-		}
-	}
-
-	// Then, we'll query for the descendants of A. We should expect to see
-	// all of the transactions that depend on it.
+	// We'll query for the descendants of A. We should expect to see all of
+	// the transactions that depend on it.
 	expectedDescendants := map[chainhash.Hash]struct{}{
 		*b.Hash(): {}, *c.Hash(): {},
 		*d.Hash(): {}, *e.Hash(): {},
@@ -1478,6 +1460,91 @@ func TestAncestorsDescendants(t *testing.T) {
 				descendantHash)
 		}
 	}
+}
+
+// TestDescendantsBounded ensures that the descendant traversal stays bounded
+// by MaxReplacementEvictions even when fed a chain of unconfirmed transactions
+// that is much longer than the cap.
+func TestDescendantsBounded(t *testing.T) {
+	t.Parallel()
+
+	harness, outputs, err := newPoolHarness(&chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("unable to create test pool: %v", err)
+	}
+	ctx := &testContext{t, harness}
+
+	// Build a single linear chain of unconfirmed transactions, each one
+	// spending the sole output of the previous transaction. The chain is
+	// deliberately longer than the cap.
+	const chainLen = MaxReplacementEvictions + 50
+
+	chain := make([]*btcutil.Tx, 0, chainLen)
+	prevOut := outputs[0]
+	for i := 0; i < chainLen; i++ {
+		tx := ctx.addSignedTx(
+			[]spendableOutput{prevOut}, 1, minTestFee, false, false,
+		)
+		chain = append(chain, tx)
+		prevOut = txOutToSpendableOut(tx, 0)
+	}
+
+	// The root's descendants would, uncapped, span almost the entire
+	// chain. The traversal must instead stop at MaxReplacementEvictions + 1.
+	root := chain[0]
+	descendants := ctx.harness.txPool.txDescendants(root, nil)
+	if len(descendants) > MaxReplacementEvictions+1 {
+		t.Fatalf("descendants not bounded: got %d, want <= %d",
+			len(descendants), MaxReplacementEvictions+1)
+	}
+	if len(descendants) < MaxReplacementEvictions {
+		t.Fatalf("expected descendant traversal to reach the cap, "+
+			"got %d", len(descendants))
+	}
+}
+
+// TestRBFSpendsParentBeyondAncestorCap ensures a replacement that spends an
+// output of a transaction it would evict is rejected even when an earlier
+// input pulls in more unconfirmed ancestors than MaxReplacementEvictions. It
+// guards against the overlap check walking a bounded ancestor set, where a
+// long chain of cheap transactions on an earlier input could hide the
+// conflicting parent.
+func TestRBFSpendsParentBeyondAncestorCap(t *testing.T) {
+	t.Parallel()
+
+	harness, _, err := newPoolHarness(&chaincfg.MainNetParams)
+	require.NoError(t, err)
+	ctx := &testContext{t, harness}
+
+	coinbase := ctx.addCoinbaseTx(2)
+	chainTip := txOutToSpendableOut(coinbase, 0)
+	conflictOut := txOutToSpendableOut(coinbase, 1)
+
+	// An unconfirmed chain longer than the cap; walking its tip's ancestors
+	// alone would exhaust MaxReplacementEvictions.
+	for i := 0; i < MaxReplacementEvictions+5; i++ {
+		tx := ctx.addSignedTx(
+			[]spendableOutput{chainTip}, 1, minTestFee, false, false,
+		)
+		chainTip = txOutToSpendableOut(tx, 0)
+	}
+
+	// conflictTx both conflicts with the replacement (shares conflictOut)
+	// and is spent by it (the overlap).
+	conflictTx := ctx.addSignedTx(
+		[]spendableOutput{conflictOut}, 1, minTestFee, true, false,
+	)
+
+	// Spend the chain tip first so a bounded ancestor walk fills up before
+	// reaching the conflicting parent, then the conflict's output (overlap)
+	// and the conflicting outpoint itself.
+	replacement, err := ctx.harness.CreateSignedTx([]spendableOutput{
+		chainTip, txOutToSpendableOut(conflictTx, 0), conflictOut,
+	}, 1, minTestFee*100, false)
+	require.NoError(t, err)
+
+	_, err = harness.txPool.ProcessTransaction(replacement, false, false, 0)
+	require.ErrorContains(t, err, "spends parent transaction")
 }
 
 // TestRBF tests the different cases required for a transaction to properly

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 1
-	Patch uint = 2
+	Patch uint = 3
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
The descendant and conflict traversal helpers previously allocated a fresh result map at every recursion level plus a per-node cache map-of-maps, making RBF conflict resolution inefficient.

Refactor txDescendants to accumulate into a single shared map that doubles as the visited set, and cap the traversal at MaxReplacementEvictions so both map size and recursion depth stay bounded regardless of chain length.

Replace the ancestor-walk overlap check in validateReplacement with a direct-input check against the conflict set. Since the conflict set is closed under descendants, a conflicting ancestor always surfaces as a direct parent, making the full ancestor traversal unnecessary. This removes the now-unused txAncestors helper entirely.

Add regression tests for the bounded traversal and the overlap check.
