### PR TITLE
wire: validate script count against remaining buffer in readScriptBuf

### DIFF
--- a/node/wire/msgtx.go
+++ b/node/wire/msgtx.go
@@ -1038,6 +1038,14 @@ func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
 		return nil, messageError("readScript", str)
 	}
 
+	if count > uint64(len(s)) {
+		// s is a suffix of the original script buffer; each entry is read into
+		// the front of s, so len(s) reflects the remaining capacity.
+		str := fmt.Sprintf("%s size exceeds remaining script buffer "+
+			"[count %d, remaining %d]", fieldName, count, len(s))
+		return nil, messageError("readScript", str)
+	}
+
 	_, err = io.ReadFull(r, s[:count])
 	if err != nil {
 		return nil, err

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 1
-	Patch uint = 3
+	Patch uint = 4
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
Add a bounds check ensuring the declared script byte count does not exceed the remaining capacity of the reusable script buffer. Without this, a malformed transaction with an overstated script length could index past the end of the buffer slice. Return a clear messageError with the field name, count, and remaining size for diagnostics.
