### PR TITLE
ci: check out cutlass submodule in miner image release

### DIFF
--- a/.github/workflows/miner_docker_release.yml
+++ b/.github/workflows/miner_docker_release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          submodules: recursive
           persist-credentials: false
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

The vLLM miner image release workflow failed building the `pearl-gemm` CUDA kernels because the CUTLASS git submodule wasn't checked out on the runner. This adds `submodules: recursive` to the checkout step.

## Type

ci

## Scope

miner (CI / Docker release)

## Changes

- Add `submodules: recursive` to the `actions/checkout` step in `miner_docker_release.yml`, so `miner/pearl-gemm/third_party/cutlass` is populated before the Docker build context is sent.

## Test plan

Without this, the build fails at `uv sync --package pearl-gemm` with `fatal error: cute/tensor.hpp / cutlass/numeric_types.h: No such file or directory`. The Dockerfile pulls CUTLASS in via `COPY` and can't `git submodule update` inside the image (no git, `.git` is `.dockerignore`d), so the host checkout must provide it — matching every other miner workflow. Verify by re-running the **Release Miner Docker Image** workflow (`push` unchecked is enough to validate the build).

- [ ] Existing tests pass (`task test`)
- [ ] New tests added (if applicable)