### PR TITLE
feat(miner): run gateway ZK proving in a worker process

### DIFF
--- a/miner/pearl-gateway/README.md
+++ b/miner/pearl-gateway/README.md
@@ -48,6 +48,7 @@ sequenceDiagram
     participant Miner
     participant AsyncLoopManager
     participant Gateway
+    participant ProofPool
     participant ProofGenerator
     participant PearlNode
 
@@ -55,9 +56,16 @@ sequenceDiagram
     AsyncLoopManager->>AsyncLoopManager: secondary_testing (uses noised)
     AsyncLoopManager->>AsyncLoopManager: create_proof (uses non-noised A, B)
     AsyncLoopManager->>Gateway: submitPlainProof(base64_string)
-    Gateway->>ProofGenerator: generate_block(PlainProof)
-    ProofGenerator->>PearlNode: submit block
+    Gateway->>ProofPool: prove(cert_version, header, plain_proof) [worker process]
+    ProofPool-->>Gateway: (public_data, proof_data)
+    Gateway->>ProofGenerator: build_block(public_data, proof_data, template)
+    ProofGenerator-->>Gateway: PearlBlock
+    Gateway->>PearlNode: submit block
 ```
+
+ZK proof generation is CPU-bound and holds the GIL, so it runs in a separate
+worker process (the `ProofPool`) rather than on the gateway's event loop; the
+loop assembles and submits the block from the returned proof bytes.
 
 
 ### Installation
@@ -97,6 +105,16 @@ All configuration can be set via environment variables:
 
 **Logging:**
 - `LOGGING_LEVEL` - Log level: `debug`, `info`, `warning`, `error` (default: `info`)
+
+**Proof Generation:**
+
+ZK proof generation is CPU-bound and holds the GIL, so it runs in a warmed
+worker process off the gateway's event loop.
+
+- `GATEWAY_PROOF_MAX_PENDING` - Max proof submissions queued before new ones
+  are rejected (positive integer, default: `64`). Enforced when a submission
+  arrives, bounding gateway memory if a miner outpaces the worker; excess
+  submissions are rejected rather than queued unboundedly.
 
 ## Usage
 

--- a/miner/pearl-gateway/src/pearl_gateway/config.py
+++ b/miner/pearl-gateway/src/pearl_gateway/config.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -49,6 +49,23 @@ class MinerRpcConfig(BaseSettings):
             raise ValueError("UDS transport requires socket_path")
 
 
+class ProofConfig(BaseSettings):
+    """ZK proof generation worker configuration.
+
+    Proof generation is CPU-bound and holds the GIL, so it runs in a warmed
+    worker process off the gateway's event loop.
+
+    Environment variables override defaults:
+    - GATEWAY_PROOF_MAX_PENDING
+    """
+
+    model_config = SettingsConfigDict(env_prefix="GATEWAY_PROOF_")
+
+    # Max proof submissions queued before new ones are rejected (enforced at
+    # the RPC boundary), bounding gateway memory when miners outpace the worker.
+    max_pending: int = Field(default=64, ge=1)
+
+
 class PearlGatewayConfig(BaseModel):
     """Complete PearlGateway configuration.
 
@@ -58,6 +75,7 @@ class PearlGatewayConfig(BaseModel):
 
     pearl: PearlConfig
     miner_rpc: MinerRpcConfig
+    proof: ProofConfig
 
 
 def load_config() -> PearlGatewayConfig:
@@ -73,4 +91,5 @@ def load_config() -> PearlGatewayConfig:
     return PearlGatewayConfig(
         pearl=PearlConfig(),
         miner_rpc=MinerRpcConfig(),
+        proof=ProofConfig(),
     )

--- a/miner/pearl-gateway/src/pearl_gateway/miner_rpc/server.py
+++ b/miner/pearl-gateway/src/pearl_gateway/miner_rpc/server.py
@@ -50,6 +50,7 @@ class MinerRpcServer:
         work_cache: WorkCache,
         submission_service: SubmissionService,
         config: MinerRpcConfig,
+        max_pending_submissions: int,
     ):
         self.work_cache = work_cache
         self.submission_service = submission_service
@@ -57,6 +58,12 @@ class MinerRpcServer:
         self.server: asyncio.Server | None = None
         self.clients: dict[int, ClientInfo] = {}
         self._next_client_id = 0
+        # Bounded intake: excess submissions are rejected at the RPC boundary rather
+        # than queued unboundedly while the single proving worker catches up.
+        self._submission_queue: asyncio.Queue[tuple[PlainProof, MiningJob]] = asyncio.Queue(
+            maxsize=max_pending_submissions
+        )
+        self._submission_consumer: asyncio.Task | None = None
 
     def _allocate_client_id(self) -> int:
         """Allocate a unique client ID."""
@@ -83,6 +90,8 @@ class MinerRpcServer:
             await self._start_uds()
         else:
             await self._start_tcp()
+
+        self._submission_consumer = asyncio.create_task(self._consume_submissions())
 
     async def _start_uds(self):
         """Start the server on a Unix Domain Socket."""
@@ -123,6 +132,13 @@ class MinerRpcServer:
             self.server.close()
             await self.server.wait_closed()
             self.server = None
+
+        # Intake is closed above; cancel the consumer, dropping any queued submissions.
+        if self._submission_consumer is not None:
+            self._submission_consumer.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._submission_consumer
+            self._submission_consumer = None
 
         # Clean up UDS file if applicable
         if self.config.transport == "uds" and os.path.exists(self.config.socket_path):
@@ -212,12 +228,7 @@ class MinerRpcServer:
                 return self._jsonrpc_success(job.to_dict(), request_id)
 
             elif method == "submitPlainProof":
-                if error := self._validate_params(validate_submit_plain_proof, params, request_id):
-                    return error
-                plain_proof = PlainProof.from_base64(params["plain_proof"])
-                mining_job = MiningJob.from_dict(params["mining_job"])
-                asyncio.create_task(self.handle_submit_plain_proof(plain_proof, mining_job))
-                return self._jsonrpc_success("submitted", request_id)
+                return self._accept_plain_proof(params, request_id)
 
             else:
                 return self._jsonrpc_error(-32601, f"Method {method} not found", request_id)
@@ -234,26 +245,51 @@ class MinerRpcServer:
             logger.exception(f"Error handling RPC request: {e}")
             return self._jsonrpc_error(-32000, str(e), request_id)
 
+    def _accept_plain_proof(self, params: dict[str, Any], request_id: int | None) -> dict[str, Any]:
+        """Validate, apply backpressure, and enqueue a submitPlainProof request."""
+        if error := self._validate_params(validate_submit_plain_proof, params, request_id):
+            return error
+
+        # Checked before parsing the (miner-controlled) proof; no awaits until
+        # put_nowait, so the queue cannot fill in between.
+        if self._submission_queue.full():
+            logger.warning("Proof submission queue full, rejecting submitPlainProof")
+            return self._jsonrpc_error(-32000, "proof submission queue full", request_id)
+
+        plain_proof = PlainProof.from_base64(params["plain_proof"])
+        mining_job = MiningJob.from_dict(params["mining_job"])
+        self._submission_queue.put_nowait((plain_proof, mining_job))
+        return self._jsonrpc_success("submitted", request_id)
+
+    async def _consume_submissions(self) -> None:
+        """Process queued submissions one at a time (there is a single proving worker)."""
+        while True:
+            plain_proof, mining_job = await self._submission_queue.get()
+            try:
+                await self.handle_submit_plain_proof(plain_proof, mining_job)
+            except Exception:
+                # Keep consuming: one bad submission must not stall the pipeline.
+                logger.exception("Error handling queued submission")
+            finally:
+                self._submission_queue.task_done()
+
     async def handle_submit_plain_proof(
         self, plain_proof: PlainProof, mining_job: MiningJob
     ) -> None:
-        """Handle submitPlainProof requests."""
-        # Get the current template (needed to build the full block)
-        if self.work_cache.current_template is None:
-            raise MiningPausedError("no block template available")
+        """Handle a submission; re-checks the job is still current after the queue wait."""
+        template = self.work_cache.current_template
+        if template is None:
+            logger.info("No current job; dropping queued submission")
+            return
 
-        logger.trace(f"Submitting plain proof for {mining_job.to_dict()=} and {plain_proof=}")
+        logger.debug(f"Submitting plain proof for {mining_job.to_dict()=} and {plain_proof=}")
 
-        current_header_bytes = (
-            self.work_cache.current_template.header.serialize_without_proof_commitment()
-        )
-        if mining_job.incomplete_header_bytes != current_header_bytes:
-            logger.warning("Submitted block with old header. Skipping submission.")
+        current_header = template.header.serialize_without_proof_commitment()
+        if mining_job.incomplete_header_bytes != current_header:
+            logger.info("Job changed since submission was queued; dropping stale proof")
             return
 
         # Submit the block via the submission service
-        result = await self.submission_service.submit_plain_proof(
-            plain_proof, self.work_cache.current_template
-        )
+        result = await self.submission_service.submit_plain_proof(plain_proof, template)
 
         logger.info(f"Block submission result: {result}")

--- a/miner/pearl-gateway/src/pearl_gateway/pearl_gateway.py
+++ b/miner/pearl-gateway/src/pearl_gateway/pearl_gateway.py
@@ -10,6 +10,7 @@ from miner_utils import get_logger
 from pearl_gateway.config import MinerRpcConfig, load_config
 from pearl_gateway.miner_rpc.server import MinerRpcServer
 from pearl_gateway.pearl_client import PearlNodeClient
+from pearl_gateway.proof_pool import ProofPool
 from pearl_gateway.scheduler import TemplateScheduler
 from pearl_gateway.submission_service import SubmissionService
 from pearl_gateway.work_cache import WorkCache
@@ -53,11 +54,15 @@ class PearlGateway:
         # Initialize components (but don't start them yet)
         self.work_cache = WorkCache()
         self.pearl_client = PearlNodeClient(self.config.pearl)
-        self.submission_service = SubmissionService(self.pearl_client, debug_mode=debug_mode)
+        self.proof_pool = ProofPool()
+        self.submission_service = SubmissionService(
+            self.pearl_client, self.proof_pool, debug_mode=debug_mode
+        )
         self.miner_rpc = MinerRpcServer(
             self.work_cache,
             self.submission_service,
             self.config.miner_rpc,
+            max_pending_submissions=self.config.proof.max_pending,
         )
         self.scheduler = TemplateScheduler(self.pearl_client, self.work_cache, self.config.pearl)
 
@@ -78,6 +83,9 @@ class PearlGateway:
         # Start the scheduler (which will immediately fetch a block template)
         await self.scheduler.start()
 
+        # Spawn and warm the ZK proof worker before accepting miner submissions
+        await self.proof_pool.start()
+
         # Start the Miner RPC server
         await self.miner_rpc.start()
 
@@ -96,6 +104,8 @@ class PearlGateway:
 
         # Stop components in reverse order
         await self.miner_rpc.stop()
+        # Stop intake (miner_rpc) before the proving worker so no proof is left in flight.
+        await self.proof_pool.stop()
         await self.scheduler.stop()
         await self.pearl_client.__aexit__(None, None, None)
 

--- a/miner/pearl-gateway/src/pearl_gateway/proof_generator.py
+++ b/miner/pearl-gateway/src/pearl_gateway/proof_generator.py
@@ -1,11 +1,7 @@
 from copy import copy
 
 from miner_utils import get_logger
-from pearl_mining import (
-    PlainProof,
-    generate_proof_for_cert_version,
-    verify_proof_for_cert_version,
-)
+from pearl_mining import ZKProof
 
 from pearl_gateway.blockchain_utils.pearl_block import PearlBlock
 from pearl_gateway.blockchain_utils.zk_certificate import ZKCertificate
@@ -15,33 +11,23 @@ _LOGGER = get_logger(__name__)
 
 
 class ProofGenerator:
-    """Builds a complete block from miner-supplied PlainProof and the cached block template."""
+    """Assembles a complete block from a worker-generated ZK proof and the cached template.
+
+    The CPU-bound proving step runs in a separate process (see ``proof_worker`` /
+    ``ProofPool``); this class only does the cheap, parent-side assembly from the
+    proof bytes the worker returns.
+    """
 
     @classmethod
-    def generate_block(
-        cls,
-        plain_proof: PlainProof,
-        template: BlockTemplate,
-        debug_mode: bool = False,
+    def build_block(
+        cls, public_data: bytes, proof_data: bytes, template: BlockTemplate
     ) -> PearlBlock:
-        """Generate a complete block from PlainProof and BlockTemplate."""
-        _LOGGER.debug("Generating block from PlainProof")
+        """Build a complete block from the worker's proof bytes and the template."""
+        _LOGGER.debug("Building block from ZK proof")
 
         # The certificate version is dictated by the block height via the template.
         cert_version = template.required_cert_version
-        zk_proof = generate_proof_for_cert_version(
-            cert_version, template.header.incomplete_header, plain_proof
-        )
-        _LOGGER.debug("Generated ZK proof")
-
-        if debug_mode:
-            _LOGGER.info("verifying ZK proof")
-            result, msg = verify_proof_for_cert_version(
-                cert_version, template.header.incomplete_header, zk_proof
-            )
-            if not result:
-                raise AssertionError(f"Failed to verify proof: {msg}")
-            _LOGGER.info("verified ZK proof")
+        zk_proof = ZKProof(public_data, proof_data)
 
         # We need to copy because ZKCertificate assigns the proof_commitment to the header
         header = copy(template.header)
@@ -53,5 +39,5 @@ class ProofGenerator:
             raw_txns=template.get_raw_transactions(),
             zk_certificate=zk_certificate,
         )
-        _LOGGER.debug("Generated block")
+        _LOGGER.debug("Built block")
         return block

--- a/miner/pearl-gateway/src/pearl_gateway/proof_pool.py
+++ b/miner/pearl-gateway/src/pearl_gateway/proof_pool.py
@@ -1,0 +1,95 @@
+"""Runs ZK proving in a dedicated, warmed worker process, off the event loop."""
+
+import asyncio
+import multiprocessing
+from concurrent.futures import BrokenExecutor, ProcessPoolExecutor
+
+from miner_utils import get_logger
+
+from pearl_gateway import proof_worker
+
+logger = get_logger(__name__)
+
+
+class ProofPool:
+    """Runs ``proof_worker`` functions in a dedicated, warmed worker process."""
+
+    def __init__(self) -> None:
+        # spawn, not fork: the native prover (Plonky2/rayon) spawns its own
+        # threads, and forking a multithreaded process risks deadlock. spawn also
+        # inherits the parent environment, so the worker can read
+        # PEARL_GATEWAY_WARMUP_SHAPE.
+        self._mp_context = multiprocessing.get_context("spawn")
+        self._executor: ProcessPoolExecutor | None = None
+        self._restart_lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        """Create and warm the worker so no proof is ever served on a cold worker."""
+        self._executor = self._new_executor()
+        await self._warm_worker(self._executor)
+
+    async def stop(self) -> None:
+        if self._executor is not None:
+            self._executor.shutdown(wait=False, cancel_futures=True)
+            self._executor = None
+
+    async def prove(
+        self,
+        cert_version: int,
+        incomplete_header_bytes: bytes,
+        plain_proof_b64: str,
+        debug: bool = False,
+    ) -> tuple[bytes, bytes]:
+        """Prove in the worker process; on worker death, recreate the pool and drop this proof."""
+        try:
+            return await self._run_prove(
+                cert_version, incomplete_header_bytes, plain_proof_b64, debug
+            )
+        except BrokenExecutor:
+            logger.warning("Proof worker died; recreating pool and dropping this proof")
+            await self._restart(self._executor)
+            raise
+
+    async def _run_prove(
+        self,
+        cert_version: int,
+        incomplete_header_bytes: bytes,
+        plain_proof_b64: str,
+        debug: bool,
+    ) -> tuple[bytes, bytes]:
+        if self._executor is None:
+            raise RuntimeError("ProofPool not started")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            proof_worker.prove,
+            cert_version,
+            incomplete_header_bytes,
+            plain_proof_b64,
+            debug,
+        )
+
+    def _new_executor(self) -> ProcessPoolExecutor:
+        # One worker: proof generation is already internally multi-threaded, so more
+        # worker processes would just oversubscribe cores.
+        return ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=self._mp_context,
+            initializer=proof_worker.worker_init,
+        )
+
+    async def _restart(self, broken: ProcessPoolExecutor | None) -> None:
+        """Replace a broken executor with a fresh, warmed one (idempotent under concurrency)."""
+        async with self._restart_lock:
+            if self._executor is not broken:
+                return
+            if broken is not None:
+                broken.shutdown(wait=False, cancel_futures=True)
+            self._executor = self._new_executor()
+            await self._warm_worker(self._executor)
+
+    async def _warm_worker(self, executor: ProcessPoolExecutor) -> None:
+        """Spawn the worker and wait for its warmup initializer to finish."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(executor, proof_worker.ready_probe)
+        logger.info("ZK proof worker ready")

--- a/miner/pearl-gateway/src/pearl_gateway/proof_worker.py
+++ b/miner/pearl-gateway/src/pearl_gateway/proof_worker.py
@@ -1,0 +1,66 @@
+"""ZK proving that runs in a separate worker process (see ``ProofPool``).
+
+Objects cross the process boundary as bytes/str -- the native ``pearl_mining``
+types are not picklable -- so callers pass serialized forms and we rebuild here.
+"""
+
+import os
+
+import pearl_mining
+from miner_utils import get_logger
+from pearl_mining import (
+    IncompleteBlockHeader,
+    PlainProof,
+    generate_proof_for_cert_version,
+    verify_proof_for_cert_version,
+)
+
+_LOGGER = get_logger(__name__)
+
+
+def worker_init() -> None:
+    """ProcessPoolExecutor initializer: warm this worker's circuits once at spawn."""
+    # Must never raise: a failing initializer marks the whole pool broken, so on
+    # error we log and let the worker warm lazily on its first proof instead.
+    try:
+        _run_warmup()
+    except Exception:
+        _LOGGER.exception("ZK warmup failed in worker; warming lazily on first proof")
+
+
+def _run_warmup() -> None:
+    warmup_hex = os.environ.get("PEARL_GATEWAY_WARMUP_SHAPE")
+    if not warmup_hex:
+        return
+
+    mining_config = pearl_mining.MiningConfiguration.from_bytes(bytes.fromhex(warmup_hex))
+    _LOGGER.info(
+        f"Starting ZK warmup: common_dim={mining_config.common_dim}, rank={mining_config.rank}"
+    )
+    pearl_mining.warmup_prove_v2(mining_config)
+    _LOGGER.info("ZK warmup completed")
+
+
+def ready_probe() -> bool:
+    """Trivial task used to force a worker to spawn (and thus run ``worker_init``)."""
+    return True
+
+
+def prove(
+    cert_version: int,
+    incomplete_header_bytes: bytes,
+    plain_proof_b64: str,
+    debug: bool = False,
+) -> tuple[bytes, bytes]:
+    """Generate a ZK proof; return its ``(public_data, proof_data)`` bytes."""
+    header = IncompleteBlockHeader.from_bytes(incomplete_header_bytes)
+    plain_proof = PlainProof.from_base64(plain_proof_b64)
+
+    zk_proof = generate_proof_for_cert_version(cert_version, header, plain_proof)
+
+    if debug:
+        result, msg = verify_proof_for_cert_version(cert_version, header, zk_proof)
+        if not result:
+            raise AssertionError(f"Failed to verify proof: {msg}")
+
+    return bytes(zk_proof.public_data), bytes(zk_proof.proof_data)

--- a/miner/pearl-gateway/src/pearl_gateway/submission_service.py
+++ b/miner/pearl-gateway/src/pearl_gateway/submission_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from miner_utils import get_logger
 from pearl_mining import PlainProof, check_cert_version_eligible
@@ -7,6 +7,10 @@ from pearl_mining import PlainProof, check_cert_version_eligible
 from pearl_gateway.comm.dataclasses import BlockTemplate
 from pearl_gateway.pearl_client import PearlNodeClient
 from pearl_gateway.proof_generator import ProofGenerator
+
+if TYPE_CHECKING:
+    from pearl_gateway.blockchain_utils.pearl_block import PearlBlock
+    from pearl_gateway.proof_pool import ProofPool
 
 logger = get_logger(__name__)
 
@@ -17,14 +21,27 @@ class SubmissionService:
     Receives PlainProof from miners and generates complete blocks.
     """
 
-    def __init__(self, pearl_client: PearlNodeClient, debug_mode: bool = False):
+    def __init__(
+        self, pearl_client: PearlNodeClient, proof_pool: "ProofPool", debug_mode: bool = False
+    ):
         self.pearl_client = pearl_client
+        self.proof_pool = proof_pool
         self.submission_lock = asyncio.Lock()  # Ensure serialized submissions
         self.submission_log = set()
         self.debug_mode = debug_mode
         self.submitted_blocks = 0
         self.accepted_blocks = 0
         self.rejected_blocks = 0
+
+    async def _build_block(self, plain_proof: PlainProof, template: BlockTemplate) -> "PearlBlock":
+        """Prove in a worker process and assemble the block from the returned bytes."""
+        public_data, proof_data = await self.proof_pool.prove(
+            int(template.required_cert_version),
+            template.header.serialize_without_proof_commitment(),
+            plain_proof.to_base64(),
+            self.debug_mode,
+        )
+        return ProofGenerator.build_block(public_data, proof_data, template)
 
     async def submit_plain_proof(
         self, plain_proof: PlainProof, template: BlockTemplate
@@ -50,7 +67,7 @@ class SubmissionService:
                     logger.warning(f"Rejecting proof: {e}")
                     return {"status": f"error: {e}"}
 
-                block = ProofGenerator.generate_block(plain_proof, template, self.debug_mode)
+                block = await self._build_block(plain_proof, template)
 
                 # Submit to the Pearl node
                 self.submitted_blocks += 1

--- a/miner/pearl-gateway/src/pearl_gateway/work_cache.py
+++ b/miner/pearl-gateway/src/pearl_gateway/work_cache.py
@@ -60,10 +60,3 @@ class WorkCache:
             if self.current_template is None:
                 return None
             return time.time() - self.last_update_time
-
-    async def invalidate(self) -> None:
-        """Invalidate the current template, forcing a refresh on next request."""
-        async with self.lock:
-            logger.info("Invalidating current template")
-            self.current_template = None
-            self.last_update_time = 0

--- a/miner/pearl-gateway/tests/miner_rpc/test_integration.py
+++ b/miner/pearl-gateway/tests/miner_rpc/test_integration.py
@@ -55,7 +55,7 @@ class TestMinerRpcIntegrationTcp:
             port=18446,
         )
 
-        server = MinerRpcServer(work_cache, submission_service, config)
+        server = MinerRpcServer(work_cache, submission_service, config, max_pending_submissions=64)
         await server.start()
 
         yield server, work_cache, submission_service
@@ -79,7 +79,7 @@ class TestMinerRpcIntegrationTcp:
             port=18447,
         )
 
-        server = MinerRpcServer(work_cache, submission_service, config)
+        server = MinerRpcServer(work_cache, submission_service, config, max_pending_submissions=64)
         await server.start()
 
         yield server, work_cache, submission_service
@@ -227,7 +227,7 @@ class TestMinerRpcIntegrationUds:
             socket_path=socket_path,
         )
 
-        server = MinerRpcServer(work_cache, submission_service, config)
+        server = MinerRpcServer(work_cache, submission_service, config, max_pending_submissions=64)
         await server.start()
 
         yield server, work_cache, submission_service, socket_path
@@ -300,7 +300,7 @@ class TestMinerRpcStressTests:
 
         config = MinerRpcConfig(transport="tcp", socket_path="", port=18448)
 
-        server = MinerRpcServer(work_cache, submission_service, config)
+        server = MinerRpcServer(work_cache, submission_service, config, max_pending_submissions=64)
         await server.start()
 
         yield server, work_cache, submission_service
@@ -376,7 +376,7 @@ class TestMinerRpcErrorScenarios:
 
         config = MinerRpcConfig(transport="tcp", socket_path="", port=18449)
 
-        server = MinerRpcServer(work_cache, submission_service, config)
+        server = MinerRpcServer(work_cache, submission_service, config, max_pending_submissions=64)
         await server.start()
 
         yield server, work_cache, submission_service

--- a/miner/pearl-gateway/tests/miner_rpc/test_performance.py
+++ b/miner/pearl-gateway/tests/miner_rpc/test_performance.py
@@ -333,7 +333,12 @@ def mock_submission_service_fast():
 @pytest.fixture
 async def performance_server(mock_work_cache, mock_submission_service_fast, performance_config):
     """Server instance optimized for performance testing."""
-    server = MinerRpcServer(mock_work_cache, mock_submission_service_fast, performance_config)
+    server = MinerRpcServer(
+        mock_work_cache,
+        mock_submission_service_fast,
+        performance_config,
+        max_pending_submissions=64,
+    )
     await server.start()
     yield server, performance_config
     await server.stop()

--- a/miner/pearl-gateway/tests/miner_rpc/test_server.py
+++ b/miner/pearl-gateway/tests/miner_rpc/test_server.py
@@ -3,6 +3,7 @@ Unit tests for MinerRpcServer.
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import tempfile
@@ -71,7 +72,9 @@ class TestMinerRpcServerInit:
 
     def test_init_with_tcp_config(self, mock_work_cache, mock_submission_service, tcp_config):
         """Test server initialization with TCP config."""
-        server = MinerRpcServer(mock_work_cache, mock_submission_service, tcp_config)
+        server = MinerRpcServer(
+            mock_work_cache, mock_submission_service, tcp_config, max_pending_submissions=64
+        )
 
         assert server.work_cache == mock_work_cache
         assert server.submission_service == mock_submission_service
@@ -81,7 +84,9 @@ class TestMinerRpcServerInit:
 
     def test_init_with_uds_config(self, mock_work_cache, mock_submission_service, uds_config):
         """Test server initialization with UDS config."""
-        server = MinerRpcServer(mock_work_cache, mock_submission_service, uds_config)
+        server = MinerRpcServer(
+            mock_work_cache, mock_submission_service, uds_config, max_pending_submissions=64
+        )
 
         assert server.work_cache == mock_work_cache
         assert server.submission_service == mock_submission_service
@@ -91,7 +96,9 @@ class TestMinerRpcServerInit:
 
     def test_init_without_auth(self, mock_work_cache, mock_submission_service, no_auth_config):
         """Test server initialization without authentication."""
-        server = MinerRpcServer(mock_work_cache, mock_submission_service, no_auth_config)
+        server = MinerRpcServer(
+            mock_work_cache, mock_submission_service, no_auth_config, max_pending_submissions=64
+        )
 
         assert server.work_cache == mock_work_cache
         assert server.submission_service == mock_submission_service
@@ -105,7 +112,9 @@ class TestMinerRpcServerTransport:
 
     @pytest.fixture
     def server(self, mock_work_cache, mock_submission_service, tcp_config):
-        return MinerRpcServer(mock_work_cache, mock_submission_service, tcp_config)
+        return MinerRpcServer(
+            mock_work_cache, mock_submission_service, tcp_config, max_pending_submissions=64
+        )
 
     @pytest.fixture
     def uds_server(self, mock_work_cache, mock_submission_service):
@@ -113,7 +122,9 @@ class TestMinerRpcServerTransport:
             transport="uds",
             socket_path=tempfile.mktemp(suffix=".sock"),
         )
-        return MinerRpcServer(mock_work_cache, mock_submission_service, config)
+        return MinerRpcServer(
+            mock_work_cache, mock_submission_service, config, max_pending_submissions=64
+        )
 
     async def test_start_stop_tcp(self, server):
         """Test starting and stopping TCP server."""
@@ -156,7 +167,9 @@ class TestMinerRpcServerHandlers:
 
     @pytest.fixture
     def server(self, mock_work_cache, mock_submission_service, no_auth_config):
-        return MinerRpcServer(mock_work_cache, mock_submission_service, no_auth_config)
+        return MinerRpcServer(
+            mock_work_cache, mock_submission_service, no_auth_config, max_pending_submissions=64
+        )
 
     async def test_handle_submit_plain_proof(
         self, server, sample_plain_proof, sample_mining_job, sample_block_template
@@ -173,13 +186,78 @@ class TestMinerRpcServerHandlers:
             sample_plain_proof, sample_block_template
         )
 
+    async def test_handle_submit_plain_proof_drops_stale_job(
+        self, server, sample_plain_proof, sample_block_template
+    ):
+        """A submission whose job no longer matches the current template is dropped."""
+        server.work_cache.current_template = sample_block_template
+        stale_job = MiningJob(incomplete_header_bytes=b"\x00" * 76, target=1)
+
+        await server.handle_submit_plain_proof(sample_plain_proof, stale_job)
+
+        server.submission_service.submit_plain_proof.assert_not_called()
+
+    async def test_handle_submit_plain_proof_drops_without_template(
+        self, server, sample_plain_proof, sample_mining_job
+    ):
+        """A queued submission is dropped (not raised) when no template is available."""
+        server.work_cache.current_template = None
+
+        await server.handle_submit_plain_proof(sample_plain_proof, sample_mining_job)
+
+        server.submission_service.submit_plain_proof.assert_not_called()
+
+    async def test_submission_consumer_processes_queued_submissions(
+        self, server, sample_plain_proof, sample_mining_job, sample_block_template
+    ):
+        """The consumer drains the queue and hands each submission to the service."""
+        server.work_cache.current_template = sample_block_template
+        server.submission_service.submit_plain_proof.return_value = {"status": "accepted"}
+
+        server._submission_queue.put_nowait((sample_plain_proof, sample_mining_job))
+        consumer = asyncio.create_task(server._consume_submissions())
+        try:
+            await asyncio.wait_for(server._submission_queue.join(), timeout=5)
+        finally:
+            consumer.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await consumer
+
+        server.submission_service.submit_plain_proof.assert_called_once_with(
+            sample_plain_proof, sample_block_template
+        )
+
+    async def test_submission_consumer_survives_handler_errors(
+        self, server, sample_plain_proof, sample_mining_job, sample_block_template
+    ):
+        """One failing submission must not stall the consumer for later ones."""
+        server.work_cache.current_template = sample_block_template
+        server.submission_service.submit_plain_proof.side_effect = [
+            RuntimeError("proof worker died"),
+            {"status": "accepted"},
+        ]
+
+        server._submission_queue.put_nowait((sample_plain_proof, sample_mining_job))
+        server._submission_queue.put_nowait((sample_plain_proof, sample_mining_job))
+        consumer = asyncio.create_task(server._consume_submissions())
+        try:
+            await asyncio.wait_for(server._submission_queue.join(), timeout=5)
+        finally:
+            consumer.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await consumer
+
+        assert server.submission_service.submit_plain_proof.call_count == 2
+
 
 class TestMinerRpcServerJsonRpc:
     """Test JSON-RPC request handling."""
 
     @pytest.fixture
     def server(self, mock_work_cache, mock_submission_service, no_auth_config):
-        return MinerRpcServer(mock_work_cache, mock_submission_service, no_auth_config)
+        return MinerRpcServer(
+            mock_work_cache, mock_submission_service, no_auth_config, max_pending_submissions=64
+        )
 
     @pytest.fixture
     def mock_client(self):
@@ -234,6 +312,31 @@ class TestMinerRpcServerJsonRpc:
         assert response["id"] == 2
         assert response.get("error") is None
         assert response["result"] == "submitted"
+
+    async def test_submit_plain_proof_rejected_when_queue_full(
+        self, server, sample_block_template, submit_plain_proof_params, mock_client
+    ):
+        """A flood of submissions is rejected once the queue capacity is reached."""
+        server.work_cache.current_template = sample_block_template
+        while not server._submission_queue.full():
+            server._submission_queue.put_nowait((None, None))
+
+        request_line = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "submitPlainProof",
+                "params": submit_plain_proof_params,
+                "id": 3,
+            }
+        )
+
+        response = await server._process_request(request_line, mock_client)
+
+        assert response["id"] == 3
+        assert response.get("result") is None
+        assert response["error"]["message"] == "proof submission queue full"
+        # Rejected before anything was enqueued for processing.
+        server.submission_service.submit_plain_proof.assert_not_called()
 
     async def test_invalid_json_request(self, server, mock_client):
         """Test handling of invalid JSON."""
@@ -342,7 +445,9 @@ class TestMinerRpcServerIntegration:
             socket_path="",  # Required field
             port=18445,  # Use different port to avoid conflicts
         )
-        server = MinerRpcServer(mock_work_cache, mock_submission_service, config)
+        server = MinerRpcServer(
+            mock_work_cache, mock_submission_service, config, max_pending_submissions=64
+        )
         await server.start()
         yield server
         await server.stop()

--- a/miner/pearl-gateway/tests/test_config.py
+++ b/miner/pearl-gateway/tests/test_config.py
@@ -10,6 +10,7 @@ from pearl_gateway.config import (
     MinerRpcConfig,
     PearlConfig,
     PearlGatewayConfig,
+    ProofConfig,
     load_config,
 )
 from pydantic import ValidationError
@@ -134,6 +135,28 @@ class TestMinerRpcConfig:
             assert config.host == "192.168.1.100"
 
 
+class TestProofConfig:
+    """Test ProofConfig."""
+
+    def test_proof_config_defaults(self):
+        """Test ProofConfig with default values."""
+        config = ProofConfig()
+
+        assert config.max_pending == 64
+
+    def test_proof_config_rejects_non_positive(self):
+        """Test ProofConfig rejects a non-positive in-flight cap."""
+        with pytest.raises(ValidationError, match="max_pending"):
+            ProofConfig(max_pending=0)
+
+    def test_proof_config_env_override(self):
+        """Test ProofConfig with environment variable overrides."""
+        with patch.dict(os.environ, {"GATEWAY_PROOF_MAX_PENDING": "8"}):
+            config = ProofConfig()
+
+            assert config.max_pending == 8
+
+
 class TestLoadConfig:
     """Test load_config function."""
 
@@ -148,10 +171,12 @@ class TestLoadConfig:
         assert isinstance(config, PearlGatewayConfig)
         assert isinstance(config.pearl, PearlConfig)
         assert isinstance(config.miner_rpc, MinerRpcConfig)
+        assert isinstance(config.proof, ProofConfig)
 
         # Verify some defaults
         assert config.pearl.rpc_url == "http://0.0.0.0:44107"
         assert config.miner_rpc.transport == "uds"
+        assert config.proof.max_pending == 64
 
     def test_load_config_with_env_overrides(self, mining_address):
         """Test loading configuration with environment variable overrides."""

--- a/miner/pearl-gateway/tests/test_pearl_gateway.py
+++ b/miner/pearl-gateway/tests/test_pearl_gateway.py
@@ -14,6 +14,7 @@ def mock_pearl_gateway_components():
     with (
         patch("pearl_gateway.pearl_gateway.WorkCache") as mock_work_cache_cls,
         patch("pearl_gateway.pearl_gateway.PearlNodeClient") as mock_pearl_client_cls,
+        patch("pearl_gateway.pearl_gateway.ProofPool") as mock_proof_pool_cls,
         patch("pearl_gateway.pearl_gateway.SubmissionService") as mock_submission_service_cls,
         patch("pearl_gateway.pearl_gateway.MinerRpcServer") as mock_miner_rpc_cls,
         patch("pearl_gateway.pearl_gateway.TemplateScheduler") as mock_scheduler_cls,
@@ -24,6 +25,7 @@ def mock_pearl_gateway_components():
         mock_pearl_client = AsyncMock()
         mock_pearl_client.__aenter__ = AsyncMock(return_value=mock_pearl_client)
         mock_pearl_client.__aexit__ = AsyncMock(return_value=None)
+        mock_proof_pool = AsyncMock()
         mock_submission_service = AsyncMock()
         mock_miner_rpc = AsyncMock()
         mock_scheduler = AsyncMock()
@@ -32,6 +34,7 @@ def mock_pearl_gateway_components():
         # Configure class constructors to return our mocks
         mock_work_cache_cls.return_value = mock_work_cache
         mock_pearl_client_cls.return_value = mock_pearl_client
+        mock_proof_pool_cls.return_value = mock_proof_pool
         mock_submission_service_cls.return_value = mock_submission_service
         mock_miner_rpc_cls.return_value = mock_miner_rpc
         mock_scheduler_cls.return_value = mock_scheduler
@@ -40,6 +43,7 @@ def mock_pearl_gateway_components():
         yield {
             "work_cache": mock_work_cache,
             "pearl_client": mock_pearl_client,
+            "proof_pool": mock_proof_pool,
             "submission_service": mock_submission_service,
             "miner_rpc": mock_miner_rpc,
             "scheduler": mock_scheduler,
@@ -47,6 +51,7 @@ def mock_pearl_gateway_components():
             "classes": {
                 "WorkCache": mock_work_cache_cls,
                 "PearlNodeClient": mock_pearl_client_cls,
+                "ProofPool": mock_proof_pool_cls,
                 "SubmissionService": mock_submission_service_cls,
                 "MinerRpcServer": mock_miner_rpc_cls,
                 "TemplateScheduler": mock_scheduler_cls,
@@ -108,6 +113,7 @@ class TestPearlGateway:
         # Verify components are started in order
         mock_pearl_gateway_components["pearl_client"].__aenter__.assert_called_once()
         mock_pearl_gateway_components["scheduler"].start.assert_called_once()
+        mock_pearl_gateway_components["proof_pool"].start.assert_called_once()
         mock_pearl_gateway_components["miner_rpc"].start.assert_called_once()
 
         # Verify log messages
@@ -143,6 +149,7 @@ class TestPearlGateway:
 
         # Verify components are stopped in reverse order
         mock_pearl_gateway_components["miner_rpc"].stop.assert_called_once()
+        mock_pearl_gateway_components["proof_pool"].stop.assert_called_once()
         mock_pearl_gateway_components["scheduler"].stop.assert_called_once()
         mock_pearl_gateway_components["pearl_client"].__aexit__.assert_called_once_with(
             None, None, None
@@ -235,8 +242,10 @@ class TestPearlGateway:
         # Verify all components were properly managed
         mock_pearl_gateway_components["pearl_client"].__aenter__.assert_called_once()
         mock_pearl_gateway_components["scheduler"].start.assert_called_once()
+        mock_pearl_gateway_components["proof_pool"].start.assert_called_once()
         mock_pearl_gateway_components["miner_rpc"].start.assert_called_once()
 
         mock_pearl_gateway_components["miner_rpc"].stop.assert_called_once()
+        mock_pearl_gateway_components["proof_pool"].stop.assert_called_once()
         mock_pearl_gateway_components["scheduler"].stop.assert_called_once()
         mock_pearl_gateway_components["pearl_client"].__aexit__.assert_called_once()

--- a/miner/pearl-gateway/tests/test_scheduler.py
+++ b/miner/pearl-gateway/tests/test_scheduler.py
@@ -22,7 +22,6 @@ def mock_work_cache():
     """Create a mock WorkCache."""
     cache = AsyncMock()
     cache.update_template = AsyncMock(return_value=True)
-    cache.invalidate = AsyncMock()
     return cache
 
 

--- a/miner/pearl-gateway/tests/test_submission_service.py
+++ b/miner/pearl-gateway/tests/test_submission_service.py
@@ -20,9 +20,17 @@ def mock_pearl_client():
 
 
 @pytest.fixture
-def submission_service(mock_pearl_client):
+def fake_proof_pool():
+    """A stand-in ProofPool whose prove() returns dummy proof bytes."""
+    pool = MagicMock()
+    pool.prove = AsyncMock(return_value=(b"public-data", b"proof-data"))
+    return pool
+
+
+@pytest.fixture
+def submission_service(mock_pearl_client, fake_proof_pool):
     """Create a SubmissionService instance for testing."""
-    return SubmissionService(mock_pearl_client)
+    return SubmissionService(mock_pearl_client, fake_proof_pool)
 
 
 def create_mock_block(hex_data: str):
@@ -40,6 +48,7 @@ class TestBlockSubmission:
         self,
         submission_service,
         mock_pearl_client,
+        fake_proof_pool,
         sample_plain_proof,
         sample_block_template,
         sample_pearl_block,
@@ -48,15 +57,26 @@ class TestBlockSubmission:
         mock_pearl_client.submit_block.return_value = "accepted"
 
         with patch(
-            "pearl_gateway.proof_generator.ProofGenerator.generate_block",
+            "pearl_gateway.proof_generator.ProofGenerator.build_block",
             return_value=sample_pearl_block,
-        ):
+        ) as mock_build_block:
             result = await submission_service.submit_plain_proof(
                 sample_plain_proof, sample_block_template
             )
 
         assert result["status"] == "accepted"
 
+        # The proof is generated in the worker via the serialized boundary args.
+        fake_proof_pool.prove.assert_awaited_once_with(
+            int(sample_block_template.required_cert_version),
+            sample_block_template.header.serialize_without_proof_commitment(),
+            sample_plain_proof.to_base64(),
+            False,
+        )
+        # The block is assembled in-process from the worker's proof bytes.
+        mock_build_block.assert_called_once_with(
+            b"public-data", b"proof-data", sample_block_template
+        )
         mock_pearl_client.submit_block.assert_called_once_with(sample_pearl_block.serialize().hex())
 
     @pytest.mark.asyncio
@@ -72,7 +92,7 @@ class TestBlockSubmission:
         mock_pearl_client.submit_block.return_value = "rejected: invalid proof"
 
         with patch(
-            "pearl_gateway.proof_generator.ProofGenerator.generate_block",
+            "pearl_gateway.proof_generator.ProofGenerator.build_block",
             return_value=sample_pearl_block,
         ):
             result = await submission_service.submit_plain_proof(
@@ -95,7 +115,7 @@ class TestBlockSubmission:
 
         with (
             patch(
-                "pearl_gateway.proof_generator.ProofGenerator.generate_block",
+                "pearl_gateway.proof_generator.ProofGenerator.build_block",
                 return_value=sample_pearl_block,
             ),
         ):
@@ -129,7 +149,7 @@ class TestBlockSubmission:
         mock_pearl_client.submit_block.side_effect = mock_submit_with_delay
 
         with patch(
-            "pearl_gateway.proof_generator.ProofGenerator.generate_block",
+            "pearl_gateway.proof_generator.ProofGenerator.build_block",
             side_effect=[sample_pearl_block, sample_pearl_block],
         ):
             # Submit two blocks concurrently with same template
@@ -190,14 +210,15 @@ class TestCrossoverEnforcement:
         mock_pearl_client.submit_block.return_value = "accepted"
 
         with patch(
-            "pearl_gateway.proof_generator.ProofGenerator.generate_block",
+            "pearl_gateway.proof_generator.ProofGenerator.build_block",
             return_value=sample_pearl_block,
         ) as mock_generate:
             result = await submission_service.submit_plain_proof(sample_plain_proof, v1_template)
 
         assert result["status"] == "accepted"
-        # The block must be generated for the V1-required template.
-        passed_template = mock_generate.call_args.args[1]
+        # The block must be assembled for the V1-required template
+        # (build_block signature: public_data, proof_data, template).
+        passed_template = mock_generate.call_args.args[2]
         assert passed_template.required_cert_version == CertificateVersion.ZK_DENSE
 
 
@@ -228,7 +249,7 @@ class TestSubmissionServiceIntegration:
         for _ in range(4):
             submission_service.submission_log.clear()  # Clear to simulate different blocks
             with patch(
-                "pearl_gateway.proof_generator.ProofGenerator.generate_block",
+                "pearl_gateway.proof_generator.ProofGenerator.build_block",
                 return_value=sample_pearl_block,
             ):
                 try:

--- a/miner/pearl-gateway/tests/test_work_cache.py
+++ b/miner/pearl-gateway/tests/test_work_cache.py
@@ -168,40 +168,6 @@ class TestMiningJob:
             assert job.target == sample_block_template.target
 
 
-class TestCacheInvalidation:
-    """Test cache invalidation functionality."""
-
-    @pytest.mark.asyncio
-    async def test_invalidate_empty_cache(self, work_cache):
-        """Test invalidating an empty cache."""
-        await work_cache.invalidate()
-
-        assert work_cache.current_template is None
-        assert work_cache.last_update_time == 0
-
-    @pytest.mark.asyncio
-    async def test_invalidate_cache_with_template(self, work_cache, sample_block_template):
-        """Test invalidating cache with existing template."""
-        # Set up cache with template
-        await work_cache.update_template(sample_block_template)
-        await work_cache.get_mining_job()  # Get a job
-
-        # Invalidate
-        await work_cache.invalidate()
-
-        assert work_cache.current_template is None
-        assert work_cache.last_update_time == 0
-
-    @pytest.mark.asyncio
-    async def test_get_mining_job_after_invalidation(self, work_cache, sample_block_template):
-        """Test getting mining job after invalidation raises error."""
-        await work_cache.update_template(sample_block_template)
-        await work_cache.invalidate()
-
-        with pytest.raises(MiningPausedError, match="no block template available"):
-            await work_cache.get_mining_job()
-
-
 class TestCacheIntegration:
     """Test WorkCache integration scenarios."""
 
@@ -241,11 +207,3 @@ class TestCacheIntegration:
             == different_block_template.header.serialize_without_proof_commitment()
         )
         assert job3.target == different_block_template.target
-
-        # 7. Invalidate
-        await work_cache.invalidate()
-        assert work_cache.current_template is None
-
-        # 8. Try to get job after invalidation
-        with pytest.raises(MiningPausedError):
-            await work_cache.get_mining_job()


### PR DESCRIPTION
## Summary

ZK proof generation is CPU-bound and holds the GIL, so a single proof froze the gateway's entire event loop (miner RPC, template refresh). This moves proving into a dedicated, warmed worker process and bounds submission intake at the RPC boundary.

## Type

feat

## Scope

miner (pearl-gateway)

## Changes

- New `proof_worker.py` / `proof_pool.py`: single-worker `ProcessPoolExecutor` (spawn, since the native prover is multithreaded), warmed at startup via `PEARL_GATEWAY_WARMUP_SHAPE`, auto-recreated if the worker dies; arguments cross the process boundary serialized because native `pearl_mining` types aren't picklable
- `ProofGenerator.generate_block()` → `build_block(public_data, proof_data, template)`: the event loop only assembles the block from worker-returned proof bytes; debug-mode verification moved into the worker
- `MinerRpcServer`: `submitPlainProof` intake is bounded by an `asyncio.Queue` (`GATEWAY_PROOF_MAX_PENDING`, default 64) drained by a single consumer task; queued jobs are re-checked against the current template before proving so stale proofs are dropped instead of proved
- `PearlGateway` lifecycle: proof pool starts (and warms) before the miner RPC server accepts submissions, and intake stops before the prover
- Removed unused `WorkCache.invalidate()`

## Test plan

- [x] Existing tests pass (pearl-gateway suite, 139 passed; full `task test` requires Linux/CUDA)
- [x] New tests added (queue backpressure and rejection, consumer error isolation, stale-job drop, prove boundary args, gateway lifecycle ordering, `ProofConfig`)
- [x] Real worker spawn + warmup smoke-tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)