### PR TITLE
fix(release): scope binary download to pearl artifacts

### DIFF
--- a/.github/workflows/blockchain_release.yml
+++ b/.github/workflows/blockchain_release.yml
@@ -67,7 +67,11 @@ jobs:
 
     steps:
       # Fetch the binaries blockchain_build.yml already produced for this commit.
-      # Fails if no successful run exists for the commit (if_no_artifact_found).
+      # Restricted to the pearl-<os>-<arch> binary artifacts: the build run also
+      # uploads *.dockerbuild build-record artifacts (from docker/build-push-action
+      # inside docker/github-builder) which are not standard zips and break
+      # extraction if downloaded. Fails if no matching artifact exists for the
+      # commit (if_no_artifact_found).
       - name: Download tested binaries from blockchain_build.yml run
         uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
         with:
@@ -75,6 +79,8 @@ jobs:
           workflow: blockchain_build.yml
           commit: ${{ github.sha }}
           workflow_conclusion: success
+          name: '^pearl-(linux|darwin|windows)-'
+          name_is_regexp: true
           path: artifacts
           if_no_artifact_found: fail
 


### PR DESCRIPTION
## Summary

Fixes the partial failure of the first `Blockchain / Release` run ([run 28807326487](https://github.com/pearl-research-labs/pearl/actions/runs/28807326487)), where the `release` job errored while downloading binaries.

### Root cause
`blockchain_release.yml` downloads the tested binaries from the `blockchain_build.yml` run via `dawidd6/action-download-artifact` with no name filter, so it fetched **all** artifacts from that run. Besides the 5 `pearl-<os>-<arch>` binary artifacts, the build run also contains two `*.dockerbuild` build-record artifacts that `docker/build-push-action` (inside the `docker/github-builder` reusable workflow) auto-uploads. The action fails extracting those:

```
==> Downloading: pearl-research-labs~pearl~4B0BXS.dockerbuild.zip
##[error]ADM-ZIP: Invalid or unsupported zip format. No END header found
```

The `release` job failed before renaming/publishing binaries. Note `docker-promote` (image → `:v1.1.5` + `:latest`) succeeded, so only the binary GitHub Release was missing.

### Fix
Restrict the download to the binary artifacts via a name regex:

```yaml
name: '^pearl-(linux|darwin|windows)-'
name_is_regexp: true
```

### Why not fix at the source
Disabling the record upload (`DOCKER_BUILD_RECORD_UPLOAD=false`) isn't reachable while using `docker/github-builder@v1`: its `Build` step hardcodes its `env:` and exposes no passthrough input. Filtering on download is Docker's own documented fix for this exact `download-artifact` + `.dockerbuild` conflict.

## Test plan

- [ ] Re-run `Blockchain / Release` on a commit that has a successful `blockchain_build.yml` run; confirm the `release` job downloads only the 5 binaries, renames them to the version, and publishes the GitHub Release.
- [ ] Confirm `docker-promote` still succeeds (unchanged).