### PR TITLE
feat: add cross-platform release installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Download, inspect, then run:
 ```powershell
 irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
 notepad install.ps1   # review before running
-powershell -ExecutionPolicy Bypass -File .\install.ps1
+pwsh -File .\install.ps1
 ```
 
 Convenience one-liner:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ system, vLLM miner, and supporting tools.
 
 ## Install (prebuilt binaries)
 
+### macOS / Linux
+
 Download, inspect, then run the checksum-verified installer (recommended):
 
 ```bash
@@ -49,17 +51,38 @@ Convenience one-liner (pipes the script into `sh`):
 curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh | sh
 ```
 
-This installs `pearld`, `prlctl`, and `oyster` into `${XDG_BIN_HOME:-$HOME/.local/bin}`,
+### Windows
+
+Download, inspect, then run:
+
+```powershell
+irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
+notepad install.ps1   # review before running
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+Convenience one-liner:
+
+```powershell
+irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 | iex
+```
+
+### After install
+
+This installs `pearld`, `prlctl`, and `oyster` into:
+- macOS/Linux: `${XDG_BIN_HOME:-$HOME/.local/bin}`
+- Windows: `%LOCALAPPDATA%\Pearl\bin`
+
 and writes mainnet default configs into the OS default app-data paths (shared
 auto-generated RPC credentials). Oyster defaults to SPV sync (`usespv=1`), so a
 local pearld is optional for the wallet. No `-u` / `-P` / `-C` needed afterward —
 `prlctl getinfo` talks to pearld, and `prlctl --wallet getinfo` talks to oyster.
 
-| Tool | Linux | macOS |
-|------|-------|-------|
-| pearld | `~/.pearld/pearld.conf` | `~/Library/Application Support/Pearld/pearld.conf` |
-| oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` |
-| prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` |
+| Tool | Linux | macOS | Windows |
+|------|-------|-------|---------|
+| pearld | `~/.pearld/pearld.conf` | `~/Library/Application Support/Pearld/pearld.conf` | `%LOCALAPPDATA%\Pearld\pearld.conf` |
+| oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` | `%LOCALAPPDATA%\Oyster\oyster.conf` |
+| prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` | `%LOCALAPPDATA%\Prlctl\prlctl.conf` |
 
 Rerun the same command to upgrade binaries; existing configs are left unchanged.
 Pin a release or choose a destination:
@@ -67,6 +90,11 @@ Pin a release or choose a destination:
 ```bash
 sh install.sh --version v0.1.0
 sh install.sh --bin-dir "$HOME/bin"
+```
+
+```powershell
+.\install.ps1 -Version v0.1.0
+.\install.ps1 -BinDir "$env:USERPROFILE\bin"
 ```
 
 Remove the binaries with:
@@ -78,11 +106,18 @@ rm -f "${XDG_BIN_HOME:-$HOME/.local/bin}/pearld" \
       "${XDG_BIN_HOME:-$HOME/.local/bin}/sample-pearld.conf"
 ```
 
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Pearl\bin\pearld.exe", `
+            "$env:LOCALAPPDATA\Pearl\bin\prlctl.exe", `
+            "$env:LOCALAPPDATA\Pearl\bin\oyster.exe", `
+            "$env:LOCALAPPDATA\Pearl\bin\sample-pearld.conf" -ErrorAction SilentlyContinue
+```
+
 Configs are not removed automatically; delete them from the paths above if desired.
 Curl-based installs normally avoid macOS browser quarantine. Directly
-browser-downloaded archives can still be blocked by Gatekeeper unless Apple
-Developer ID signing/notarization is present; the installer never strips
-quarantine attributes.
+browser-downloaded archives can still be blocked by Gatekeeper / SmartScreen
+unless platform signing is present; the installer never strips quarantine
+attributes or Mark-of-the-Web.
 
 See [node/docs/installation.md](node/docs/installation.md) for full details.
 To build from source instead, see **Building** below.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,60 @@ system, vLLM miner, and supporting tools.
 | [`apps/`](apps/) | Frontend applications (website, desktop wallet — pnpm/Turborepo) |
 | [`tools/`](tools/) | Go development tool dependencies |
 
+## Install (prebuilt binaries)
+
+Download, inspect, then run the checksum-verified installer (recommended):
+
+```bash
+curl -fsSL -o install.sh https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh
+less install.sh   # review before running
+sh install.sh
+```
+
+Convenience one-liner (pipes the script into `sh`):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh | sh
+```
+
+This installs `pearld`, `prlctl`, and `oyster` into `${XDG_BIN_HOME:-$HOME/.local/bin}`,
+and writes mainnet default configs into the OS default app-data paths (shared
+auto-generated RPC credentials). Oyster defaults to SPV sync (`usespv=1`), so a
+local pearld is optional for the wallet. No `-u` / `-P` / `-C` needed afterward —
+`prlctl getinfo` talks to pearld, and `prlctl --wallet getinfo` talks to oyster.
+
+| Tool | Linux | macOS |
+|------|-------|-------|
+| pearld | `~/.pearld/pearld.conf` | `~/Library/Application Support/Pearld/pearld.conf` |
+| oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` |
+| prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` |
+
+Rerun the same command to upgrade binaries; existing configs are left unchanged.
+Pin a release or choose a destination:
+
+```bash
+sh install.sh --version v0.1.0
+sh install.sh --bin-dir "$HOME/bin"
+```
+
+Remove the binaries with:
+
+```bash
+rm -f "${XDG_BIN_HOME:-$HOME/.local/bin}/pearld" \
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/prlctl" \
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/oyster" \
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/sample-pearld.conf"
+```
+
+Configs are not removed automatically; delete them from the paths above if desired.
+Curl-based installs normally avoid macOS browser quarantine. Directly
+browser-downloaded archives can still be blocked by Gatekeeper unless Apple
+Developer ID signing/notarization is present; the installer never strips
+quarantine attributes.
+
+See [node/docs/installation.md](node/docs/installation.md) for full details.
+To build from source instead, see **Building** below.
+
 ## Prerequisites
 
 - [Go](https://golang.org) 1.26 or newer

--- a/README.md
+++ b/README.md
@@ -35,48 +35,22 @@ system, vLLM miner, and supporting tools.
 
 ## Install (prebuilt binaries)
 
-### macOS / Linux
-
-Download, inspect, then run the checksum-verified installer (recommended):
-
-```bash
-curl -fsSL -o install.sh https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh
-less install.sh   # review before running
-sh install.sh
-```
-
-Convenience one-liner (pipes the script into `sh`):
+macOS / Linux:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh | sh
 ```
 
-### Windows
-
-Download, inspect, then run:
-
-```powershell
-irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
-notepad install.ps1   # review before running
-pwsh -File .\install.ps1
-```
-
-Convenience one-liner:
+Windows:
 
 ```powershell
 irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 | iex
 ```
 
-### After install
-
-This installs `pearld`, `prlctl`, and `oyster` into:
-- macOS/Linux: `${XDG_BIN_HOME:-$HOME/.local/bin}`
-- Windows: `%LOCALAPPDATA%\Pearl\bin`
-
-and writes mainnet default configs into the OS default app-data paths (shared
-auto-generated RPC credentials). Oyster defaults to SPV sync (`usespv=1`), so a
-local pearld is optional for the wallet. No `-u` / `-P` / `-C` needed afterward —
-`prlctl getinfo` talks to pearld, and `prlctl --wallet getinfo` talks to oyster.
+Installs `pearld`, `prlctl`, and `oyster` with localhost-only mainnet defaults and
+shared RPC credentials (oyster uses SPV by default). Binaries go to
+`${XDG_BIN_HOME:-$HOME/.local/bin}` on macOS/Linux, or `%LOCALAPPDATA%\Pearl\bin`
+on Windows.
 
 | Tool | Linux | macOS | Windows |
 |------|-------|-------|---------|
@@ -84,43 +58,9 @@ local pearld is optional for the wallet. No `-u` / `-P` / `-C` needed afterward 
 | oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` | `%LOCALAPPDATA%\Oyster\oyster.conf` |
 | prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` | `%LOCALAPPDATA%\Prlctl\prlctl.conf` |
 
-Rerun the same command to upgrade binaries; existing configs are left unchanged.
-Pin a release or choose a destination:
-
-```bash
-sh install.sh --version v0.1.0
-sh install.sh --bin-dir "$HOME/bin"
-```
-
-```powershell
-.\install.ps1 -Version v0.1.0
-.\install.ps1 -BinDir "$env:USERPROFILE\bin"
-```
-
-Remove the binaries with:
-
-```bash
-rm -f "${XDG_BIN_HOME:-$HOME/.local/bin}/pearld" \
-      "${XDG_BIN_HOME:-$HOME/.local/bin}/prlctl" \
-      "${XDG_BIN_HOME:-$HOME/.local/bin}/oyster" \
-      "${XDG_BIN_HOME:-$HOME/.local/bin}/sample-pearld.conf"
-```
-
-```powershell
-Remove-Item "$env:LOCALAPPDATA\Pearl\bin\pearld.exe", `
-            "$env:LOCALAPPDATA\Pearl\bin\prlctl.exe", `
-            "$env:LOCALAPPDATA\Pearl\bin\oyster.exe", `
-            "$env:LOCALAPPDATA\Pearl\bin\sample-pearld.conf" -ErrorAction SilentlyContinue
-```
-
-Configs are not removed automatically; delete them from the paths above if desired.
-Curl-based installs normally avoid macOS browser quarantine. Directly
-browser-downloaded archives can still be blocked by Gatekeeper / SmartScreen
-unless platform signing is present; the installer never strips quarantine
-attributes or Mark-of-the-Web.
-
-See [node/docs/installation.md](node/docs/installation.md) for full details.
-To build from source instead, see **Building** below.
+Pin a version or install directory with `--version` / `--bin-dir` (or `-Version` /
+`-BinDir` on Windows). See [node/docs/installation.md](node/docs/installation.md)
+for upgrade, removal, and other details. To build from source, see **Building** below.
 
 ## Prerequisites
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,260 +1,124 @@
 # Install pearld, prlctl, and oyster from Pearl GitHub Releases (Windows).
 # Prefer: download, inspect, then run.
 #   irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
-#   powershell -ExecutionPolicy Bypass -File .\install.ps1
+#   pwsh -File .\install.ps1
 # Convenience:
 #   irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 | iex
 
+#Requires -Version 5.1
+
+<#
+.SYNOPSIS
+  Install Pearl release binaries and mainnet configs on Windows.
+
+.PARAMETER Version
+  Release tag to install (default: latest stable), e.g. v1.1.5
+
+.PARAMETER BinDir
+  Install directory (default: $env:LOCALAPPDATA\Pearl\bin)
+
+.EXAMPLE
+  .\install.ps1
+
+.EXAMPLE
+  .\install.ps1 -Version v1.1.5 -BinDir $env:USERPROFILE\bin
+#>
 [CmdletBinding()]
 param(
-	[string]$Version = "",
-	[string]$BinDir = "",
+	[string]$Version,
+	[string]$BinDir,
 	[switch]$Help
 )
 
 Set-StrictMode -Version Latest
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
 
-$Repo = "pearl-research-labs/pearl"
-$GitHubBase = "https://github.com/$Repo"
-$ReleaseBase = "$GitHubBase/releases"
-$Binaries = @("pearld", "prlctl", "oyster")
-$Configs = @("pearld", "oyster", "prlctl")
+$Repo = 'pearl-research-labs/pearl'
+$Binaries = @('pearld', 'prlctl', 'oyster')
+$AllowedArchiveBins = $Binaries + 'prlmon'
+$TempDir = $null
+$RpcUser = $null
+$RpcPass = $null
 
-$script:RpcUser = ""
-$script:RpcPass = ""
-$script:TempDir = $null
-
-function Write-Info {
-	param([string]$Message)
+function Write-InstallLog([string]$Message) {
 	Write-Host "pearl-install: $Message"
 }
 
-function Die {
-	param([string]$Message)
-	[Console]::Error.WriteLine("pearl-install: $Message")
-	exit 1
-}
-
-function Show-Usage {
-	@"
-Install Pearl release binaries (pearld, prlctl, oyster) and mainnet configs.
-
-Usage:
-  install.ps1 [-Version vX.Y.Z] [-BinDir PATH]
-
-Parameters:
-  -Version vX.Y.Z   Install a specific release (default: latest stable)
-  -BinDir PATH      Install directory (default: `$env:LOCALAPPDATA\Pearl\bin)
-  -Help             Show this help
-
-Examples:
-  .\install.ps1
-  .\install.ps1 -Version v0.1.0
-  .\install.ps1 -BinDir "`$env:USERPROFILE\bin"
-"@
-}
-
-function Test-Version {
-	param([string]$V)
-	if ($V -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9._-]*)$') {
-		return $false
-	}
-	if ($V -match '[/\\]' -or $V -match '\.\.') {
-		return $false
-	}
-	return $true
-}
-
-function Get-PearlArch {
-	$arch = $env:PROCESSOR_ARCHITECTURE
-	if ($env:PROCESSOR_ARCHITEW6432) {
-		$arch = $env:PROCESSOR_ARCHITEW6432
-	}
-	switch ($arch.ToUpperInvariant()) {
-		"AMD64" { return "amd64" }
-		"ARM64" {
-			Die "unsupported architecture: ARM64 (Windows releases are amd64 only)"
-		}
-		default {
-			Die "unsupported architecture: $arch (supported: amd64)"
-		}
-	}
+function Get-LocalAppData {
+	$local = $env:LOCALAPPDATA
+	if (-not $local) { $local = $env:APPDATA }
+	if (-not $local) { throw 'cannot determine LOCALAPPDATA / APPDATA' }
+	$local
 }
 
 # Match node/btcutil.AppDataDir(app, roaming=false): %LOCALAPPDATA%\AppName
-function Get-AppDataDir {
-	param([string]$App)
-	$local = $env:LOCALAPPDATA
-	if (-not $local) {
-		$local = $env:APPDATA
-	}
-	if (-not $local) {
-		Die "cannot determine LOCALAPPDATA / APPDATA"
-	}
-	$upper = $App.Substring(0, 1).ToUpperInvariant() + $App.Substring(1)
-	return (Join-Path $local $upper)
+function Get-AppConfigPath([string]$Name) {
+	$app = $Name.Substring(0, 1).ToUpperInvariant() + $Name.Substring(1)
+	Join-Path (Join-Path (Get-LocalAppData) $app) "$Name.conf"
 }
 
-function Get-ConfigPath {
-	param([string]$Name)
-	return (Join-Path (Get-AppDataDir $Name) "$Name.conf")
+function Test-ReleaseVersion([string]$V) {
+	$V -match '^v[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9._-]*$' -and $V -notmatch '[/\\]|\.\.'
 }
 
-function Get-DefaultBinDir {
-	$local = $env:LOCALAPPDATA
-	if (-not $local) {
-		Die "LOCALAPPDATA is not set"
-	}
-	return (Join-Path $local "Pearl\bin")
-}
-
-function Ensure-BinDir {
-	param([string]$Dir)
-	if (-not (Test-Path -LiteralPath $Dir)) {
-		try {
-			New-Item -ItemType Directory -Path $Dir -Force | Out-Null
-		} catch {
-			Die "cannot create install directory: $Dir`ntry: .\install.ps1 -BinDir `"$env:LOCALAPPDATA\Pearl\bin`""
-		}
-	}
-	try {
-		$probe = Join-Path $Dir ".pearl-install-write-test"
-		[IO.File]::WriteAllText($probe, "ok")
-		Remove-Item -LiteralPath $probe -Force
-	} catch {
-		Die "install directory is not writable: $Dir`ntry: .\install.ps1 -BinDir `"$env:LOCALAPPDATA\Pearl\bin`""
+function Get-WindowsArch {
+	$arch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+	switch ($arch.ToUpperInvariant()) {
+		'AMD64' { 'amd64' }
+		'ARM64' { throw 'unsupported architecture: ARM64 (Windows releases are amd64 only)' }
+		default { throw "unsupported architecture: $arch (supported: amd64)" }
 	}
 }
 
-function Get-Https {
-	param(
-		[string]$Url,
-		[string]$Dest
-	)
-	if ($Url -notmatch '^https://') {
-		Die "refusing non-HTTPS download URL: $Url"
-	}
-	Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing
+function Save-HttpsFile([string]$Uri, [string]$OutFile) {
+	if ($Uri -notmatch '^https://') { throw "refusing non-HTTPS download URL: $Uri" }
+	Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing
 }
 
-function Resolve-LatestVersion {
-	$rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
-	$tag = [string]$rel.tag_name
-	if (-not (Test-Version $tag)) {
-		Die "could not parse latest release version from API: $tag"
-	}
-	return $tag
+function Install-FileAtomic([string]$Source, [string]$Destination) {
+	$dir = Split-Path -Parent $Destination
+	if ($dir) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+	$tmp = "$Destination.tmp.$PID"
+	Copy-Item -LiteralPath $Source -Destination $tmp -Force
+	Move-Item -LiteralPath $tmp -Destination $Destination -Force
 }
 
-function Assert-Checksum {
-	param(
-		[string]$Archive,
-		[string]$ChecksumsFile
-	)
-	$name = Split-Path -Leaf $Archive
-	$expected = $null
-	foreach ($line in Get-Content -LiteralPath $ChecksumsFile) {
-		$trimmed = $line.Trim()
-		if (-not $trimmed) { continue }
-		$parts = $trimmed -split '\s+', 2
-		if ($parts.Count -eq 2 -and $parts[1] -eq $name) {
-			$expected = $parts[0].ToLowerInvariant()
-			break
-		}
-	}
-	if (-not $expected) {
-		Die "no checksum entry for $name in checksums.txt"
-	}
-	if ($expected -notmatch '^[0-9a-f]{64}$') {
-		Die "malformed checksum for $name"
-	}
-	$actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
-	if ($actual -ne $expected) {
-		Die "checksum mismatch for $name`n  expected: $expected`n  actual:   $actual"
-	}
-}
-
-function Expand-PearlArchive {
-	param(
-		[string]$Archive,
-		[string]$Staging
-	)
-	New-Item -ItemType Directory -Path $Staging -Force | Out-Null
-	$extract = Join-Path $Staging "_extract"
-	New-Item -ItemType Directory -Path $extract -Force | Out-Null
-	Expand-Archive -LiteralPath $Archive -DestinationPath $extract -Force
-
-	Get-ChildItem -LiteralPath $extract -Force | ForEach-Object {
-		$name = $_.Name
-		$base = [IO.Path]::GetFileNameWithoutExtension($name)
-		$ext = [IO.Path]::GetExtension($name).ToLowerInvariant()
-		if ($_.PSIsContainer) {
-			Die "refusing nested archive path: $name"
-		}
-		if ($ext -ne ".exe") {
-			Die "unexpected archive member: $name"
-		}
-		switch ($base) {
-			{ $_ -in @("pearld", "prlctl", "oyster", "prlmon") } { }
-			default { Die "unexpected archive member: $name" }
-		}
-	}
-
-	foreach ($bin in $Binaries) {
-		$src = Join-Path $extract "$bin.exe"
-		if (-not (Test-Path -LiteralPath $src)) {
-			Die "archive is missing $bin.exe"
-		}
-		if ((Get-Item -LiteralPath $src).Attributes -band [IO.FileAttributes]::ReparsePoint) {
-			Die "refusing symlink/reparse point in archive: $bin.exe"
-		}
-		Copy-Item -LiteralPath $src -Destination (Join-Path $Staging "$bin.exe") -Force
-	}
-}
-
-function Install-Binary {
-	param(
-		[string]$Src,
-		[string]$DestDir
-	)
-	$name = Split-Path -Leaf $Src
-	$tmp = Join-Path $DestDir ".$name.tmp.$PID"
-	$dest = Join-Path $DestDir $name
-	Copy-Item -LiteralPath $Src -Destination $tmp -Force
-	Move-Item -LiteralPath $tmp -Destination $dest -Force
-}
-
-function New-Secret {
-	$bytes = New-Object byte[] 24
-	$rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
-	try {
-		$rng.GetBytes($bytes)
-	} finally {
-		$rng.Dispose()
-	}
-	return [Convert]::ToBase64String($bytes).TrimEnd("=")
-}
-
-function Write-AtomicFile {
-	param(
-		[string]$Dest,
-		[string]$Content
-	)
-	$dir = Split-Path -Parent $Dest
-	if (-not (Test-Path -LiteralPath $dir)) {
-		New-Item -ItemType Directory -Path $dir -Force | Out-Null
-	}
-	$tmp = "$Dest.tmp.$PID"
+function Write-FileAtomic([string]$Destination, [string]$Content) {
+	$dir = Split-Path -Parent $Destination
+	if ($dir) { New-Item -ItemType Directory -Path $dir -Force | Out-Null }
+	$tmp = "$Destination.tmp.$PID"
 	[IO.File]::WriteAllText($tmp, $Content)
-	Move-Item -LiteralPath $tmp -Destination $Dest -Force
+	Move-Item -LiteralPath $tmp -Destination $Destination -Force
 }
 
-function Get-ConfigText {
-	param([string]$Name)
+function New-RpcSecret {
+	$bytes = [byte[]]::new(24)
+	$rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+	try { $rng.GetBytes($bytes) } finally { $rng.Dispose() }
+	[Convert]::ToBase64String($bytes).TrimEnd('=')
+}
+
+function Get-ConfValue([string]$Key, [string]$File) {
+	if (-not (Test-Path -LiteralPath $File)) { return $null }
+	foreach ($line in Get-Content -LiteralPath $File) {
+		if ($line -match "^$([regex]::Escape($Key))=(.+)$") { return $Matches[1] }
+	}
+	$null
+}
+
+function Test-ConfigHasSecrets([string]$Name, [string]$File) {
+	$keys = switch ($Name) {
+		'oyster' { @('username', 'password') }
+		{ $_ -in 'pearld', 'prlctl' } { @('rpcuser', 'rpcpass') }
+		default { return $false }
+	}
+	(Get-ConfValue $keys[0] $File) -and (Get-ConfValue $keys[1] $File)
+}
+
+function Get-ConfigBody([string]$Name) {
 	switch ($Name) {
-		"pearld" {
-			return @"
+		'pearld' {
+			@"
 [Application Options]
 
 ; Default mainnet configuration for pearld.
@@ -262,15 +126,15 @@ function Get-ConfigText {
 ; P2P still listens on all interfaces so the node can sync with the network.
 ; txindex helps prlctl / explorers; oyster defaults to SPV and does not require it.
 
-rpcuser=$($script:RpcUser)
-rpcpass=$($script:RpcPass)
+rpcuser=$RpcUser
+rpcpass=$RpcPass
 rpclisten=127.0.0.1:44107
 rpclisten=[::1]:44107
 txindex=1
 "@
 		}
-		"oyster" {
-			return @"
+		'oyster' {
+			@"
 [Application Options]
 
 ; Default mainnet configuration for oyster.
@@ -279,228 +143,201 @@ txindex=1
 ; username/password authenticate wallet RPC (prlctl --wallet) and optional pearld RPC.
 
 usespv=1
-username=$($script:RpcUser)
-password=$($script:RpcPass)
-pearldusername=$($script:RpcUser)
-pearldpassword=$($script:RpcPass)
+username=$RpcUser
+password=$RpcPass
+pearldusername=$RpcUser
+pearldpassword=$RpcPass
 rpcconnect=127.0.0.1:44107
 rpclisten=127.0.0.1:44207
 rpclisten=[::1]:44207
 "@
 		}
-		"prlctl" {
-			return @"
+		'prlctl' {
+			@"
 ; Default mainnet configuration for prlctl.
 ; Shared credentials work for both:
 ;   prlctl getinfo           -> local pearld (port 44107)
 ;   prlctl --wallet getinfo  -> local oyster (port 44207)
 ; TLS cert defaults: pearld's rpc.cert, or oyster's when --wallet is set.
 
-rpcuser=$($script:RpcUser)
-rpcpass=$($script:RpcPass)
+rpcuser=$RpcUser
+rpcpass=$RpcPass
 rpcserver=127.0.0.1
 "@
 		}
-		default { Die "unknown config: $Name" }
+		default { throw "unknown config: $Name" }
 	}
 }
 
-function Get-ConfValue {
-	param(
-		[string]$Key,
-		[string]$File
-	)
-	if (-not (Test-Path -LiteralPath $File)) {
-		return ""
-	}
-	foreach ($line in Get-Content -LiteralPath $File) {
-		if ($line -match "^$([regex]::Escape($Key))=(.*)$") {
-			$val = $Matches[1]
-			if ($val -ne "") {
-				return $val
-			}
-		}
-	}
-	return ""
-}
-
-function Test-ConfigHasSecrets {
-	param(
-		[string]$Name,
-		[string]$File
-	)
-	if (-not (Test-Path -LiteralPath $File)) {
-		return $false
-	}
-	switch ($Name) {
-		{ $_ -in @("pearld", "prlctl") } {
-			$user = Get-ConfValue "rpcuser" $File
-			$pass = Get-ConfValue "rpcpass" $File
-		}
-		"oyster" {
-			$user = Get-ConfValue "username" $File
-			$pass = Get-ConfValue "password" $File
-		}
-		default { return $false }
-	}
-	return ($user -ne "" -and $pass -ne "")
-}
-
-function Ensure-RpcCredentials {
-	if ($script:RpcUser -and $script:RpcPass) {
-		return
-	}
-
-	foreach ($pair in @(
-			@{ File = (Get-ConfigPath "pearld"); UserKey = "rpcuser"; PassKey = "rpcpass" },
-			@{ File = (Get-ConfigPath "oyster"); UserKey = "username"; PassKey = "password" },
-			@{ File = (Get-ConfigPath "prlctl"); UserKey = "rpcuser"; PassKey = "rpcpass" }
+function Initialize-RpcCredentials {
+	foreach ($probe in @(
+			@{ Path = (Get-AppConfigPath 'pearld'); User = 'rpcuser'; Pass = 'rpcpass' }
+			@{ Path = (Get-AppConfigPath 'oyster'); User = 'username'; Pass = 'password' }
+			@{ Path = (Get-AppConfigPath 'prlctl'); User = 'rpcuser'; Pass = 'rpcpass' }
 		)) {
-		$u = Get-ConfValue $pair.UserKey $pair.File
-		$p = Get-ConfValue $pair.PassKey $pair.File
+		$u = Get-ConfValue $probe.User $probe.Path
+		$p = Get-ConfValue $probe.Pass $probe.Path
 		if ($u -and $p) {
 			$script:RpcUser = $u
 			$script:RpcPass = $p
 			return
 		}
 	}
-
-	$script:RpcUser = New-Secret
-	$script:RpcPass = New-Secret
-}
-
-function Install-DefaultConfigs {
-	param([string]$InstallBinDir)
-	$created = $false
-	Ensure-RpcCredentials
-
-	$sample = Join-Path $InstallBinDir "sample-pearld.conf"
-	Write-AtomicFile $sample (Get-ConfigText "pearld")
-	Write-Info "default config template -> $sample"
-
-	foreach ($name in $Configs) {
-		$dest = Get-ConfigPath $name
-		if (Test-ConfigHasSecrets $name $dest) {
-			Write-Info "kept existing config -> $dest"
-			continue
-		}
-		Write-AtomicFile $dest (Get-ConfigText $name)
-		Write-Info "wrote config -> $dest"
-		$created = $true
-	}
-
-	if ($created) {
-		Write-Info "RPC username/password were auto-generated; no -u/-P flags needed"
-	}
-}
-
-function Test-PathContains {
-	param([string]$Dir)
-	$parts = ($env:PATH -split ";") | Where-Object { $_ -ne "" }
-	foreach ($p in $parts) {
-		try {
-			if ([IO.Path]::GetFullPath($p).TrimEnd("\") -eq [IO.Path]::GetFullPath($Dir).TrimEnd("\")) {
-				return $true
-			}
-		} catch {
-			# ignore invalid PATH entries
-		}
-	}
-	return $false
-}
-
-function Show-Summary {
-	param(
-		[string]$Ver,
-		[string]$InstallBinDir
-	)
-	Write-Host ""
-	Write-Host "pearl-install: done ($Ver)"
-	Write-Host ""
-	Write-Host "Binaries:"
-	Write-Host "  $(Join-Path $InstallBinDir 'pearld.exe')"
-	Write-Host "  $(Join-Path $InstallBinDir 'prlctl.exe')"
-	Write-Host "  $(Join-Path $InstallBinDir 'oyster.exe')"
-	Write-Host "  $(Join-Path $InstallBinDir 'sample-pearld.conf')"
-	Write-Host ""
-	Write-Host "Configs (OS default locations, shared RPC credentials):"
-	Write-Host "  $(Get-ConfigPath 'pearld')"
-	Write-Host "  $(Get-ConfigPath 'oyster')"
-	Write-Host "  $(Get-ConfigPath 'prlctl')"
-	Write-Host ""
-	Write-Host "Next steps (no -u/-P/-C needed):"
-	Write-Host "  pearld"
-	Write-Host "  oyster --create"
-	Write-Host "  oyster                 # SPV sync by default"
-	Write-Host "  prlctl getinfo"
-	Write-Host "  prlctl --wallet getinfo"
-
-	if (-not (Test-PathContains $InstallBinDir)) {
-		Write-Host ""
-		Write-Info "note: $InstallBinDir is not on your PATH"
-		Write-Host "  add it for this session: `$env:PATH = `"$InstallBinDir;`$env:PATH`""
-		Write-Host "  or set a permanent User PATH entry in System Properties"
-	}
-}
-
-function Clear-TempDir {
-	if ($script:TempDir -and (Test-Path -LiteralPath $script:TempDir)) {
-		Remove-Item -LiteralPath $script:TempDir -Recurse -Force -ErrorAction SilentlyContinue
-	}
+	$script:RpcUser = New-RpcSecret
+	$script:RpcPass = New-RpcSecret
 }
 
 try {
 	if ($Help) {
-		Show-Usage
+		@'
+Install Pearl release binaries (pearld, prlctl, oyster) and mainnet configs.
+
+Usage:
+  install.ps1 [-Version vX.Y.Z] [-BinDir PATH]
+
+Examples:
+  .\install.ps1
+  .\install.ps1 -Version v1.1.5
+  .\install.ps1 -BinDir "$env:USERPROFILE\bin"
+'@
 		exit 0
 	}
 
-	if ($env:OS -ne "Windows_NT") {
-		Die "this installer is for Windows; use install.sh on macOS/Linux"
+	if ($env:OS -ne 'Windows_NT') {
+		throw 'this installer is for Windows; use install.sh on macOS/Linux'
 	}
 
-	$arch = Get-PearlArch
-	if (-not $BinDir) {
-		$BinDir = Get-DefaultBinDir
+	if (-not $BinDir) { $BinDir = Join-Path (Get-LocalAppData) 'Pearl\bin' }
+	try {
+		New-Item -ItemType Directory -Path $BinDir -Force | Out-Null
+		$probe = Join-Path $BinDir ".pearl-install-write-test.$PID"
+		[IO.File]::WriteAllText($probe, 'ok')
+		Remove-Item -LiteralPath $probe -Force
+	} catch {
+		throw "install directory is not writable: $BinDir`ntry: .\install.ps1 -BinDir `"$env:LOCALAPPDATA\Pearl\bin`""
 	}
-	Ensure-BinDir $BinDir
 
 	if (-not $Version) {
-		Write-Info "resolving latest release..."
-		$Version = Resolve-LatestVersion
+		Write-InstallLog 'resolving latest release...'
+		$Version = [string](Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest").tag_name
 	}
-	if (-not (Test-Version $Version)) {
-		Die "invalid version '$Version' (expected vX.Y.Z)"
+	if (-not (Test-ReleaseVersion $Version)) {
+		throw "invalid version '$Version' (expected vX.Y.Z)"
 	}
 
+	$arch = Get-WindowsArch
 	$archiveName = "pearl-windows-$arch-$Version.zip"
-	$assetBase = "$ReleaseBase/download/$Version"
+	$assetBase = "https://github.com/$Repo/releases/download/$Version"
 
-	$script:TempDir = Join-Path ([IO.Path]::GetTempPath()) ("pearl-install." + [guid]::NewGuid().ToString("N"))
-	New-Item -ItemType Directory -Path $script:TempDir -Force | Out-Null
+	$TempDir = Join-Path ([IO.Path]::GetTempPath()) ("pearl-install." + [guid]::NewGuid().ToString('N'))
+	$extract = Join-Path $TempDir 'extract'
+	New-Item -ItemType Directory -Path $extract -Force | Out-Null
 
-	$archivePath = Join-Path $script:TempDir $archiveName
-	$checksumsPath = Join-Path $script:TempDir "checksums.txt"
-	$staging = Join-Path $script:TempDir "staging"
+	$archivePath = Join-Path $TempDir $archiveName
+	$checksumsPath = Join-Path $TempDir 'checksums.txt'
 
-	Write-Info "downloading $archiveName"
-	Get-Https "$assetBase/$archiveName" $archivePath
-	Write-Info "downloading checksums.txt"
-	Get-Https "$assetBase/checksums.txt" $checksumsPath
+	Write-InstallLog "downloading $archiveName"
+	Save-HttpsFile "$assetBase/$archiveName" $archivePath
+	Write-InstallLog 'downloading checksums.txt'
+	Save-HttpsFile "$assetBase/checksums.txt" $checksumsPath
 
-	Write-Info "verifying SHA-256..."
-	Assert-Checksum $archivePath $checksumsPath
-
-	Write-Info "extracting binaries..."
-	Expand-PearlArchive $archivePath $staging
-	foreach ($bin in $Binaries) {
-		$destName = "$bin.exe"
-		Write-Info "installing binary -> $(Join-Path $BinDir $destName)"
-		Install-Binary (Join-Path $staging $destName) $BinDir
+	Write-InstallLog 'verifying SHA-256...'
+	$expected = $null
+	foreach ($line in Get-Content -LiteralPath $checksumsPath) {
+		if ($line -match '^\s*([0-9a-fA-F]{64})\s+(\S+)\s*$' -and $Matches[2] -eq $archiveName) {
+			$expected = $Matches[1].ToLowerInvariant()
+			break
+		}
+	}
+	if (-not $expected) { throw "no checksum entry for $archiveName in checksums.txt" }
+	$actual = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+	if ($actual -ne $expected) {
+		throw "checksum mismatch for $archiveName`n  expected: $expected`n  actual:   $actual"
 	}
 
-	Install-DefaultConfigs $BinDir
-	Show-Summary $Version $BinDir
+	Write-InstallLog 'extracting binaries...'
+	Expand-Archive -LiteralPath $archivePath -DestinationPath $extract -Force
+	foreach ($item in Get-ChildItem -LiteralPath $extract -Force) {
+		if ($item.PSIsContainer) { throw "refusing nested archive path: $($item.Name)" }
+		$base = [IO.Path]::GetFileNameWithoutExtension($item.Name)
+		if ($item.Extension -ne '.exe' -or $base -notin $AllowedArchiveBins) {
+			throw "unexpected archive member: $($item.Name)"
+		}
+	}
+
+	foreach ($bin in $Binaries) {
+		$src = Join-Path $extract "$bin.exe"
+		if (-not (Test-Path -LiteralPath $src)) { throw "archive is missing $bin.exe" }
+		if ((Get-Item -LiteralPath $src).Attributes -band [IO.FileAttributes]::ReparsePoint) {
+			throw "refusing symlink/reparse point in archive: $bin.exe"
+		}
+		$dest = Join-Path $BinDir "$bin.exe"
+		Write-InstallLog "installing binary -> $dest"
+		Install-FileAtomic $src $dest
+	}
+
+	Initialize-RpcCredentials
+	$sample = Join-Path $BinDir 'sample-pearld.conf'
+	Write-FileAtomic $sample (Get-ConfigBody 'pearld')
+	Write-InstallLog "default config template -> $sample"
+
+	$created = $false
+	foreach ($name in @('pearld', 'oyster', 'prlctl')) {
+		$dest = Get-AppConfigPath $name
+		if (Test-ConfigHasSecrets $name $dest) {
+			Write-InstallLog "kept existing config -> $dest"
+			continue
+		}
+		Write-FileAtomic $dest (Get-ConfigBody $name)
+		Write-InstallLog "wrote config -> $dest"
+		$created = $true
+	}
+	if ($created) {
+		Write-InstallLog 'RPC username/password were auto-generated; no -u/-P flags needed'
+	}
+
+	$binLines = ($Binaries | ForEach-Object { "  $(Join-Path $BinDir "$_.exe")" }) -join "`n"
+	$configLines = (@('pearld', 'oyster', 'prlctl') | ForEach-Object { "  $(Get-AppConfigPath $_)" }) -join "`n"
+	@"
+
+pearl-install: done ($Version)
+
+Binaries:
+$binLines
+  $(Join-Path $BinDir 'sample-pearld.conf')
+
+Configs (OS default locations, shared RPC credentials):
+$configLines
+
+Next steps (no -u/-P/-C needed):
+  pearld
+  oyster --create
+  oyster                 # SPV sync by default
+  prlctl getinfo
+  prlctl --wallet getinfo
+"@ | Write-Host
+
+	$normalizedBin = [IO.Path]::GetFullPath($BinDir).TrimEnd('\')
+	$onPath = $false
+	foreach ($entry in ($env:PATH -split ';')) {
+		if (-not $entry) { continue }
+		try {
+			if ([IO.Path]::GetFullPath($entry).TrimEnd('\') -eq $normalizedBin) {
+				$onPath = $true
+				break
+			}
+		} catch { }
+	}
+	if (-not $onPath) {
+		Write-InstallLog "note: $BinDir is not on your PATH"
+		Write-Host "  add it for this session: `$env:PATH = `"$BinDir;`$env:PATH`""
+		Write-Host '  or set a permanent User PATH entry in System Properties'
+	}
+} catch {
+	[Console]::Error.WriteLine("pearl-install: $($_.Exception.Message)")
+	exit 1
 } finally {
-	Clear-TempDir
+	if ($TempDir -and (Test-Path -LiteralPath $TempDir)) {
+		Remove-Item -LiteralPath $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+	}
 }

--- a/install.ps1
+++ b/install.ps1
@@ -277,8 +277,24 @@ Examples:
 	}
 
 	Initialize-RpcCredentials
+
+	# pearld bootstraps missing pearld.conf from sample-pearld.conf beside the
+	# binary, replacing rpcuser=/rpcpass= with freshly generated values. Keep
+	# this template secret-free — bin dirs are often readable by other users.
 	$sample = Join-Path $BinDir 'sample-pearld.conf'
-	Write-FileAtomic $sample (Get-ConfigBody 'pearld')
+	Write-FileAtomic $sample @'
+[Application Options]
+
+; Template used by pearld when creating a missing pearld.conf.
+; Do not put real credentials here; the installer writes those to the OS
+; app-data pearld.conf.
+
+rpcuser=
+rpcpass=
+rpclisten=127.0.0.1:44107
+rpclisten=[::1]:44107
+txindex=1
+'@
 	Write-InstallLog "default config template -> $sample"
 
 	$created = $false

--- a/install.ps1
+++ b/install.ps1
@@ -154,12 +154,13 @@ function Assert-Checksum {
 	)
 	$name = Split-Path -Leaf $Archive
 	$expected = $null
-	Get-Content -LiteralPath $ChecksumsFile | ForEach-Object {
-		$line = $_.Trim()
-		if (-not $line) { return }
-		$parts = $line -split '\s+', 2
+	foreach ($line in Get-Content -LiteralPath $ChecksumsFile) {
+		$trimmed = $line.Trim()
+		if (-not $trimmed) { continue }
+		$parts = $trimmed -split '\s+', 2
 		if ($parts.Count -eq 2 -and $parts[1] -eq $name) {
 			$expected = $parts[0].ToLowerInvariant()
+			break
 		}
 	}
 	if (-not $expected) {

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,505 @@
+# Install pearld, prlctl, and oyster from Pearl GitHub Releases (Windows).
+# Prefer: download, inspect, then run.
+#   irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
+#   powershell -ExecutionPolicy Bypass -File .\install.ps1
+# Convenience:
+#   irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 | iex
+
+[CmdletBinding()]
+param(
+	[string]$Version = "",
+	[string]$BinDir = "",
+	[switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Repo = "pearl-research-labs/pearl"
+$GitHubBase = "https://github.com/$Repo"
+$ReleaseBase = "$GitHubBase/releases"
+$Binaries = @("pearld", "prlctl", "oyster")
+$Configs = @("pearld", "oyster", "prlctl")
+
+$script:RpcUser = ""
+$script:RpcPass = ""
+$script:TempDir = $null
+
+function Write-Info {
+	param([string]$Message)
+	Write-Host "pearl-install: $Message"
+}
+
+function Die {
+	param([string]$Message)
+	Write-Error "pearl-install: $Message"
+	exit 1
+}
+
+function Show-Usage {
+	@"
+Install Pearl release binaries (pearld, prlctl, oyster) and mainnet configs.
+
+Usage:
+  install.ps1 [-Version vX.Y.Z] [-BinDir PATH]
+
+Parameters:
+  -Version vX.Y.Z   Install a specific release (default: latest stable)
+  -BinDir PATH      Install directory (default: `$env:LOCALAPPDATA\Pearl\bin)
+  -Help             Show this help
+
+Examples:
+  .\install.ps1
+  .\install.ps1 -Version v0.1.0
+  .\install.ps1 -BinDir "`$env:USERPROFILE\bin"
+"@
+}
+
+function Test-Version {
+	param([string]$V)
+	if ($V -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9._-]*)$') {
+		return $false
+	}
+	if ($V -match '[/\\]' -or $V -match '\.\.') {
+		return $false
+	}
+	return $true
+}
+
+function Get-PearlArch {
+	$arch = $env:PROCESSOR_ARCHITECTURE
+	if ($env:PROCESSOR_ARCHITEW6432) {
+		$arch = $env:PROCESSOR_ARCHITEW6432
+	}
+	switch ($arch.ToUpperInvariant()) {
+		"AMD64" { return "amd64" }
+		"ARM64" {
+			Die "unsupported architecture: ARM64 (Windows releases are amd64 only)"
+		}
+		default {
+			Die "unsupported architecture: $arch (supported: amd64)"
+		}
+	}
+}
+
+# Match node/btcutil.AppDataDir(app, roaming=false): %LOCALAPPDATA%\AppName
+function Get-AppDataDir {
+	param([string]$App)
+	$local = $env:LOCALAPPDATA
+	if (-not $local) {
+		$local = $env:APPDATA
+	}
+	if (-not $local) {
+		Die "cannot determine LOCALAPPDATA / APPDATA"
+	}
+	$upper = $App.Substring(0, 1).ToUpperInvariant() + $App.Substring(1)
+	return (Join-Path $local $upper)
+}
+
+function Get-ConfigPath {
+	param([string]$Name)
+	return (Join-Path (Get-AppDataDir $Name) "$Name.conf")
+}
+
+function Get-DefaultBinDir {
+	$local = $env:LOCALAPPDATA
+	if (-not $local) {
+		Die "LOCALAPPDATA is not set"
+	}
+	return (Join-Path $local "Pearl\bin")
+}
+
+function Ensure-BinDir {
+	param([string]$Dir)
+	if (-not (Test-Path -LiteralPath $Dir)) {
+		try {
+			New-Item -ItemType Directory -Path $Dir -Force | Out-Null
+		} catch {
+			Die "cannot create install directory: $Dir`ntry: .\install.ps1 -BinDir `"$env:LOCALAPPDATA\Pearl\bin`""
+		}
+	}
+	try {
+		$probe = Join-Path $Dir ".pearl-install-write-test"
+		[IO.File]::WriteAllText($probe, "ok")
+		Remove-Item -LiteralPath $probe -Force
+	} catch {
+		Die "install directory is not writable: $Dir`ntry: .\install.ps1 -BinDir `"$env:LOCALAPPDATA\Pearl\bin`""
+	}
+}
+
+function Get-Https {
+	param(
+		[string]$Url,
+		[string]$Dest
+	)
+	if ($Url -notmatch '^https://') {
+		Die "refusing non-HTTPS download URL: $Url"
+	}
+	Invoke-WebRequest -Uri $Url -OutFile $Dest -UseBasicParsing
+}
+
+function Resolve-LatestVersion {
+	$rel = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+	$tag = [string]$rel.tag_name
+	if (-not (Test-Version $tag)) {
+		Die "could not parse latest release version from API: $tag"
+	}
+	return $tag
+}
+
+function Assert-Checksum {
+	param(
+		[string]$Archive,
+		[string]$ChecksumsFile
+	)
+	$name = Split-Path -Leaf $Archive
+	$expected = $null
+	Get-Content -LiteralPath $ChecksumsFile | ForEach-Object {
+		$line = $_.Trim()
+		if (-not $line) { return }
+		$parts = $line -split '\s+', 2
+		if ($parts.Count -eq 2 -and $parts[1] -eq $name) {
+			$expected = $parts[0].ToLowerInvariant()
+		}
+	}
+	if (-not $expected) {
+		Die "no checksum entry for $name in checksums.txt"
+	}
+	if ($expected -notmatch '^[0-9a-f]{64}$') {
+		Die "malformed checksum for $name"
+	}
+	$actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
+	if ($actual -ne $expected) {
+		Die "checksum mismatch for $name`n  expected: $expected`n  actual:   $actual"
+	}
+}
+
+function Expand-PearlArchive {
+	param(
+		[string]$Archive,
+		[string]$Staging
+	)
+	New-Item -ItemType Directory -Path $Staging -Force | Out-Null
+	$extract = Join-Path $Staging "_extract"
+	New-Item -ItemType Directory -Path $extract -Force | Out-Null
+	Expand-Archive -LiteralPath $Archive -DestinationPath $extract -Force
+
+	Get-ChildItem -LiteralPath $extract -Force | ForEach-Object {
+		$name = $_.Name
+		$base = [IO.Path]::GetFileNameWithoutExtension($name)
+		$ext = [IO.Path]::GetExtension($name).ToLowerInvariant()
+		if ($_.PSIsContainer) {
+			Die "refusing nested archive path: $name"
+		}
+		if ($ext -ne ".exe") {
+			Die "unexpected archive member: $name"
+		}
+		switch ($base) {
+			{ $_ -in @("pearld", "prlctl", "oyster", "prlmon") } { }
+			default { Die "unexpected archive member: $name" }
+		}
+	}
+
+	foreach ($bin in $Binaries) {
+		$src = Join-Path $extract "$bin.exe"
+		if (-not (Test-Path -LiteralPath $src)) {
+			Die "archive is missing $bin.exe"
+		}
+		if ((Get-Item -LiteralPath $src).Attributes -band [IO.FileAttributes]::ReparsePoint) {
+			Die "refusing symlink/reparse point in archive: $bin.exe"
+		}
+		Copy-Item -LiteralPath $src -Destination (Join-Path $Staging "$bin.exe") -Force
+	}
+}
+
+function Install-Binary {
+	param(
+		[string]$Src,
+		[string]$DestDir
+	)
+	$name = Split-Path -Leaf $Src
+	$tmp = Join-Path $DestDir ".$name.tmp.$PID"
+	$dest = Join-Path $DestDir $name
+	Copy-Item -LiteralPath $Src -Destination $tmp -Force
+	Move-Item -LiteralPath $tmp -Destination $dest -Force
+}
+
+function New-Secret {
+	$bytes = New-Object byte[] 24
+	$rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+	try {
+		$rng.GetBytes($bytes)
+	} finally {
+		$rng.Dispose()
+	}
+	return [Convert]::ToBase64String($bytes).TrimEnd("=")
+}
+
+function Write-AtomicFile {
+	param(
+		[string]$Dest,
+		[string]$Content
+	)
+	$dir = Split-Path -Parent $Dest
+	if (-not (Test-Path -LiteralPath $dir)) {
+		New-Item -ItemType Directory -Path $dir -Force | Out-Null
+	}
+	$tmp = "$Dest.tmp.$PID"
+	[IO.File]::WriteAllText($tmp, $Content)
+	Move-Item -LiteralPath $tmp -Destination $Dest -Force
+}
+
+function Get-ConfigText {
+	param([string]$Name)
+	switch ($Name) {
+		"pearld" {
+			return @"
+[Application Options]
+
+; Default mainnet configuration for pearld.
+; RPC is bound to localhost only. TLS remains enabled by default.
+; P2P still listens on all interfaces so the node can sync with the network.
+; txindex helps prlctl / explorers; oyster defaults to SPV and does not require it.
+
+rpcuser=$($script:RpcUser)
+rpcpass=$($script:RpcPass)
+rpclisten=127.0.0.1:44107
+rpclisten=[::1]:44107
+txindex=1
+"@
+		}
+		"oyster" {
+			return @"
+[Application Options]
+
+; Default mainnet configuration for oyster.
+; Syncs via SPV (neutrino) by default — no local pearld required for chain data.
+; Wallet RPC is bound to localhost only. TLS remains enabled by default.
+; username/password authenticate wallet RPC (prlctl --wallet) and optional pearld RPC.
+
+usespv=1
+username=$($script:RpcUser)
+password=$($script:RpcPass)
+pearldusername=$($script:RpcUser)
+pearldpassword=$($script:RpcPass)
+rpcconnect=127.0.0.1:44107
+rpclisten=127.0.0.1:44207
+rpclisten=[::1]:44207
+"@
+		}
+		"prlctl" {
+			return @"
+; Default mainnet configuration for prlctl.
+; Shared credentials work for both:
+;   prlctl getinfo           -> local pearld (port 44107)
+;   prlctl --wallet getinfo  -> local oyster (port 44207)
+; TLS cert defaults: pearld's rpc.cert, or oyster's when --wallet is set.
+
+rpcuser=$($script:RpcUser)
+rpcpass=$($script:RpcPass)
+rpcserver=127.0.0.1
+"@
+		}
+		default { Die "unknown config: $Name" }
+	}
+}
+
+function Get-ConfValue {
+	param(
+		[string]$Key,
+		[string]$File
+	)
+	if (-not (Test-Path -LiteralPath $File)) {
+		return ""
+	}
+	foreach ($line in Get-Content -LiteralPath $File) {
+		if ($line -match "^$([regex]::Escape($Key))=(.*)$") {
+			$val = $Matches[1]
+			if ($val -ne "") {
+				return $val
+			}
+		}
+	}
+	return ""
+}
+
+function Test-ConfigHasSecrets {
+	param(
+		[string]$Name,
+		[string]$File
+	)
+	if (-not (Test-Path -LiteralPath $File)) {
+		return $false
+	}
+	switch ($Name) {
+		{ $_ -in @("pearld", "prlctl") } {
+			$user = Get-ConfValue "rpcuser" $File
+			$pass = Get-ConfValue "rpcpass" $File
+		}
+		"oyster" {
+			$user = Get-ConfValue "username" $File
+			$pass = Get-ConfValue "password" $File
+		}
+		default { return $false }
+	}
+	return ($user -ne "" -and $pass -ne "")
+}
+
+function Ensure-RpcCredentials {
+	if ($script:RpcUser -and $script:RpcPass) {
+		return
+	}
+
+	foreach ($pair in @(
+			@{ File = (Get-ConfigPath "pearld"); UserKey = "rpcuser"; PassKey = "rpcpass" },
+			@{ File = (Get-ConfigPath "oyster"); UserKey = "username"; PassKey = "password" },
+			@{ File = (Get-ConfigPath "prlctl"); UserKey = "rpcuser"; PassKey = "rpcpass" }
+		)) {
+		$u = Get-ConfValue $pair.UserKey $pair.File
+		$p = Get-ConfValue $pair.PassKey $pair.File
+		if ($u -and $p) {
+			$script:RpcUser = $u
+			$script:RpcPass = $p
+			return
+		}
+	}
+
+	$script:RpcUser = New-Secret
+	$script:RpcPass = New-Secret
+}
+
+function Install-DefaultConfigs {
+	param([string]$InstallBinDir)
+	$created = $false
+	Ensure-RpcCredentials
+
+	$sample = Join-Path $InstallBinDir "sample-pearld.conf"
+	Write-AtomicFile $sample (Get-ConfigText "pearld")
+	Write-Info "default config template -> $sample"
+
+	foreach ($name in $Configs) {
+		$dest = Get-ConfigPath $name
+		if (Test-ConfigHasSecrets $name $dest) {
+			Write-Info "kept existing config -> $dest"
+			continue
+		}
+		Write-AtomicFile $dest (Get-ConfigText $name)
+		Write-Info "wrote config -> $dest"
+		$created = $true
+	}
+
+	if ($created) {
+		Write-Info "RPC username/password were auto-generated; no -u/-P flags needed"
+	}
+}
+
+function Test-PathContains {
+	param([string]$Dir)
+	$parts = ($env:PATH -split ";") | Where-Object { $_ -ne "" }
+	foreach ($p in $parts) {
+		try {
+			if ([IO.Path]::GetFullPath($p).TrimEnd("\") -eq [IO.Path]::GetFullPath($Dir).TrimEnd("\")) {
+				return $true
+			}
+		} catch {
+			# ignore invalid PATH entries
+		}
+	}
+	return $false
+}
+
+function Show-Summary {
+	param(
+		[string]$Ver,
+		[string]$InstallBinDir
+	)
+	Write-Host ""
+	Write-Host "pearl-install: done ($Ver)"
+	Write-Host ""
+	Write-Host "Binaries:"
+	Write-Host "  $(Join-Path $InstallBinDir 'pearld.exe')"
+	Write-Host "  $(Join-Path $InstallBinDir 'prlctl.exe')"
+	Write-Host "  $(Join-Path $InstallBinDir 'oyster.exe')"
+	Write-Host "  $(Join-Path $InstallBinDir 'sample-pearld.conf')"
+	Write-Host ""
+	Write-Host "Configs (OS default locations, shared RPC credentials):"
+	Write-Host "  $(Get-ConfigPath 'pearld')"
+	Write-Host "  $(Get-ConfigPath 'oyster')"
+	Write-Host "  $(Get-ConfigPath 'prlctl')"
+	Write-Host ""
+	Write-Host "Next steps (no -u/-P/-C needed):"
+	Write-Host "  pearld"
+	Write-Host "  oyster --create"
+	Write-Host "  oyster                 # SPV sync by default"
+	Write-Host "  prlctl getinfo"
+	Write-Host "  prlctl --wallet getinfo"
+
+	if (-not (Test-PathContains $InstallBinDir)) {
+		Write-Host ""
+		Write-Info "note: $InstallBinDir is not on your PATH"
+		Write-Host "  add it for this session: `$env:PATH = `"$InstallBinDir;`$env:PATH`""
+		Write-Host "  or set a permanent User PATH entry in System Properties"
+	}
+}
+
+function Clear-TempDir {
+	if ($script:TempDir -and (Test-Path -LiteralPath $script:TempDir)) {
+		Remove-Item -LiteralPath $script:TempDir -Recurse -Force -ErrorAction SilentlyContinue
+	}
+}
+
+try {
+	if ($Help) {
+		Show-Usage
+		exit 0
+	}
+
+	if ($env:OS -ne "Windows_NT") {
+		Die "this installer is for Windows; use install.sh on macOS/Linux"
+	}
+
+	$arch = Get-PearlArch
+	if (-not $BinDir) {
+		$BinDir = Get-DefaultBinDir
+	}
+	Ensure-BinDir $BinDir
+
+	if (-not $Version) {
+		Write-Info "resolving latest release..."
+		$Version = Resolve-LatestVersion
+	}
+	if (-not (Test-Version $Version)) {
+		Die "invalid version '$Version' (expected vX.Y.Z)"
+	}
+
+	$archiveName = "pearl-windows-$arch-$Version.zip"
+	$assetBase = "$ReleaseBase/download/$Version"
+
+	$script:TempDir = Join-Path ([IO.Path]::GetTempPath()) ("pearl-install." + [guid]::NewGuid().ToString("N"))
+	New-Item -ItemType Directory -Path $script:TempDir -Force | Out-Null
+
+	$archivePath = Join-Path $script:TempDir $archiveName
+	$checksumsPath = Join-Path $script:TempDir "checksums.txt"
+	$staging = Join-Path $script:TempDir "staging"
+
+	Write-Info "downloading $archiveName"
+	Get-Https "$assetBase/$archiveName" $archivePath
+	Write-Info "downloading checksums.txt"
+	Get-Https "$assetBase/checksums.txt" $checksumsPath
+
+	Write-Info "verifying SHA-256..."
+	Assert-Checksum $archivePath $checksumsPath
+
+	Write-Info "extracting binaries..."
+	Expand-PearlArchive $archivePath $staging
+	foreach ($bin in $Binaries) {
+		$destName = "$bin.exe"
+		Write-Info "installing binary -> $(Join-Path $BinDir $destName)"
+		Install-Binary (Join-Path $staging $destName) $BinDir
+	}
+
+	Install-DefaultConfigs $BinDir
+	Show-Summary $Version $BinDir
+} finally {
+	Clear-TempDir
+}

--- a/install.ps1
+++ b/install.ps1
@@ -32,7 +32,7 @@ function Write-Info {
 
 function Die {
 	param([string]$Message)
-	Write-Error "pearl-install: $Message"
+	[Console]::Error.WriteLine("pearl-install: $Message")
 	exit 1
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -278,25 +278,6 @@ Examples:
 
 	Initialize-RpcCredentials
 
-	# pearld bootstraps missing pearld.conf from sample-pearld.conf beside the
-	# binary, replacing rpcuser=/rpcpass= with freshly generated values. Keep
-	# this template secret-free — bin dirs are often readable by other users.
-	$sample = Join-Path $BinDir 'sample-pearld.conf'
-	Write-FileAtomic $sample @'
-[Application Options]
-
-; Template used by pearld when creating a missing pearld.conf.
-; Do not put real credentials here; the installer writes those to the OS
-; app-data pearld.conf.
-
-rpcuser=
-rpcpass=
-rpclisten=127.0.0.1:44107
-rpclisten=[::1]:44107
-txindex=1
-'@
-	Write-InstallLog "default config template -> $sample"
-
 	$created = $false
 	foreach ($name in @('pearld', 'oyster', 'prlctl')) {
 		$dest = Get-AppConfigPath $name
@@ -320,7 +301,6 @@ pearl-install: done ($Version)
 
 Binaries:
 $binLines
-  $(Join-Path $BinDir 'sample-pearld.conf')
 
 Configs (OS default locations, shared RPC credentials):
 $configLines

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,553 @@
+#!/bin/sh
+# Install pearld, prlctl, and oyster from Pearl GitHub Releases.
+# Usage: curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh | sh
+# Prefer: download, inspect, then run with sh.
+
+set -eu
+
+REPO="pearl-research-labs/pearl"
+GITHUB_BASE="https://github.com/${REPO}"
+RELEASE_BASE="${GITHUB_BASE}/releases"
+BINARIES="pearld prlctl oyster"
+CONFIGS="pearld oyster prlctl"
+
+PRINT_HELP=0
+VERSION=""
+BIN_DIR=""
+TMP_DIR=""
+OS=""
+RPC_USER=""
+RPC_PASS=""
+
+usage() {
+	cat << 'EOF'
+Install Pearl release binaries (pearld, prlctl, oyster) and mainnet configs.
+
+Usage:
+  install.sh [options]
+
+Options:
+  --version vX.Y.Z   Install a specific release (default: latest stable)
+  --bin-dir PATH     Install directory (default: ${XDG_BIN_HOME:-$HOME/.local/bin})
+  -h, --help         Show this help
+
+Examples:
+  install.sh
+  install.sh --version v0.1.0
+  install.sh --bin-dir "$HOME/bin"
+EOF
+}
+
+err() {
+	printf 'pearl-install: %s\n' "$*" >&2
+}
+
+die() {
+	err "$*"
+	exit 1
+}
+
+info() {
+	printf 'pearl-install: %s\n' "$*"
+}
+
+need_cmd() {
+	command -v "$1" > /dev/null 2>&1 || die "required command not found: $1"
+}
+
+cleanup() {
+	if [ -n "${TMP_DIR:-}" ] && [ -d "${TMP_DIR}" ]; then
+		rm -rf "${TMP_DIR}"
+	fi
+}
+
+parse_args() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+			--version)
+				[ "$#" -ge 2 ] || die "--version requires an argument"
+				VERSION=$2
+				shift 2
+				;;
+			--version=*)
+				VERSION=${1#--version=}
+				shift
+				;;
+			--bin-dir)
+				[ "$#" -ge 2 ] || die "--bin-dir requires an argument"
+				BIN_DIR=$2
+				shift 2
+				;;
+			--bin-dir=*)
+				BIN_DIR=${1#--bin-dir=}
+				shift
+				;;
+			-h | --help)
+				PRINT_HELP=1
+				shift
+				;;
+			*)
+				die "unknown argument: $1 (try --help)"
+				;;
+		esac
+	done
+}
+
+validate_version() {
+	case "$1" in
+		v[0-9]*.[0-9]*.[0-9]*) ;;
+		*) return 1 ;;
+	esac
+	case "$1" in
+		*[!A-Za-z0-9._-]* | */* | *..*) return 1 ;;
+	esac
+}
+
+detect_os() {
+	case "$(uname -s)" in
+		Linux) printf 'linux\n' ;;
+		Darwin) printf 'darwin\n' ;;
+		*) die "unsupported operating system: $(uname -s) (supported: Linux, macOS)" ;;
+	esac
+}
+
+detect_arch() {
+	# Prefer hardware arch so Rosetta does not select the wrong binary.
+	if [ "$1" = "darwin" ] && [ "$(sysctl -n hw.optional.arm64 2> /dev/null || true)" = "1" ]; then
+		printf 'arm64\n'
+		return 0
+	fi
+	case "$(uname -m)" in
+		x86_64 | amd64) printf 'amd64\n' ;;
+		aarch64 | arm64) printf 'arm64\n' ;;
+		*) die "unsupported architecture: $(uname -m) (supported: amd64, arm64)" ;;
+	esac
+}
+
+# Home directory the Pearl binaries resolve (passwd entry), matching
+# node/btcutil.AppDataDir. $HOME alone is not enough because the Go binaries
+# prefer the passwd home over the HOME environment variable.
+user_home() {
+	if command -v python3 > /dev/null 2>&1; then
+		python3 -c 'import os, pwd; print(pwd.getpwuid(os.getuid()).pw_dir)'
+		return 0
+	fi
+	if command -v dscl > /dev/null 2>&1; then
+		# macOS fallback when python3 is unavailable.
+		_home=$(dscl . -read "/Users/$(id -un)" NFSHomeDirectory 2> /dev/null | awk '{print $2}')
+		if [ -n "$_home" ]; then
+			printf '%s\n' "$_home"
+			return 0
+		fi
+	fi
+	if [ -n "${HOME:-}" ]; then
+		printf '%s\n' "$HOME"
+		return 0
+	fi
+	die "cannot determine home directory"
+}
+
+# Match node/btcutil.AppDataDir for pearld / oyster / prlctl.
+app_data_dir() {
+	app=$1
+	_home=$(user_home)
+	case "$OS" in
+		darwin)
+			first=$(printf '%s' "$app" | cut -c1 | tr '[:lower:]' '[:upper:]')
+			rest=$(printf '%s' "$app" | cut -c2-)
+			printf '%s\n' "${_home}/Library/Application Support/${first}${rest}"
+			;;
+		*)
+			printf '%s\n' "${_home}/.${app}"
+			;;
+	esac
+}
+
+config_path() {
+	printf '%s/%s.conf\n' "$(app_data_dir "$1")" "$1"
+}
+
+default_bin_dir() {
+	if [ -n "${XDG_BIN_HOME:-}" ]; then
+		printf '%s\n' "$XDG_BIN_HOME"
+	else
+		printf '%s\n' "${HOME}/.local/bin"
+	fi
+}
+
+ensure_bin_dir() {
+	if [ ! -d "$1" ]; then
+		mkdir -p "$1" 2> /dev/null || die "cannot create install directory: $1
+try: install.sh --bin-dir \"\$HOME/.local/bin\""
+	fi
+	[ -w "$1" ] || die "install directory is not writable: $1
+try: install.sh --bin-dir \"\$HOME/.local/bin\""
+}
+
+download() {
+	_url=$1
+	_dest=$2
+	case "$_url" in
+		https://*) ;;
+		*) die "refusing non-HTTPS download URL: $_url" ;;
+	esac
+
+	if command -v curl > /dev/null 2>&1; then
+		curl --fail --show-error --silent --location --proto '=https' --tlsv1.2 \
+			--output "$_dest" "$_url" || die "download failed: $_url"
+		return 0
+	fi
+	if command -v wget > /dev/null 2>&1; then
+		wget --quiet --https-only --output-document="$_dest" "$_url" || die "download failed: $_url"
+		return 0
+	fi
+	die "required command not found: curl or wget"
+}
+
+resolve_latest_version() {
+	need_cmd curl
+	url=$(curl --fail --silent --show-error --location --head \
+		--proto '=https' --tlsv1.2 \
+		--output /dev/null --write-out '%{url_effective}' \
+		"${GITHUB_BASE}/releases/latest") \
+		|| die "failed to resolve latest release from GitHub"
+	version=${url##*/}
+	validate_version "$version" || die "could not parse latest release version from: $url"
+	printf '%s\n' "$version"
+}
+
+sha256_file() {
+	if command -v sha256sum > /dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+		return 0
+	fi
+	if command -v shasum > /dev/null 2>&1; then
+		shasum -a 256 "$1" | awk '{print $1}'
+		return 0
+	fi
+	die "required command not found: sha256sum or shasum"
+}
+
+verify_checksum() {
+	_archive=$1
+	_checksums=$2
+	_name=$(basename "$_archive")
+	_expected=$(awk -v name="$_name" '
+		$2 == name { print $1; found=1; exit }
+		END { if (!found) exit 1 }
+	' "$_checksums") || die "no checksum entry for ${_name} in checksums.txt"
+
+	case "$_expected" in
+		[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]*)
+			[ "${#_expected}" -eq 64 ] || die "malformed checksum for ${_name}"
+			;;
+		*) die "malformed checksum for ${_name}" ;;
+	esac
+
+	_actual=$(sha256_file "$_archive")
+	[ "$_actual" = "$_expected" ] || die "checksum mismatch for ${_name}
+  expected: ${_expected}
+  actual:   ${_actual}"
+}
+
+extract_binaries() {
+	_archive=$1
+	_staging=$2
+	_list="${_staging}.members"
+	mkdir -p "$_staging"
+	tar -tzf "$_archive" > "$_list" || die "failed to list archive contents"
+
+	while IFS= read -r _member; do
+		[ -n "$_member" ] || continue
+		_name=${_member#./}
+		case "$_name" in
+			'' | */) continue ;;
+			*/*) die "refusing nested archive path: $_member" ;;
+			pearld | prlctl | oyster | prlmon) ;;
+			*) die "unexpected archive member: $_member" ;;
+		esac
+	done < "$_list"
+
+	if ! tar -xzf "$_archive" -C "$_staging" pearld prlctl oyster 2> /dev/null; then
+		tar -xzf "$_archive" -C "$_staging" ./pearld ./prlctl ./oyster \
+			|| die "archive is missing one or more of: ${BINARIES}"
+	fi
+
+	for _bin in $BINARIES; do
+		_path="${_staging}/${_bin}"
+		[ -e "$_path" ] || die "missing ${_bin} after extraction"
+		[ ! -L "$_path" ] || die "refusing symlink in archive: ${_bin}"
+		[ -f "$_path" ] || die "refusing non-regular file: ${_bin}"
+	done
+}
+
+install_binary() {
+	_src=$1
+	_dest_dir=$2
+	_name=$(basename "$_src")
+	_tmp="${_dest_dir}/.${_name}.tmp.$$"
+	cp "$_src" "$_tmp"
+	chmod 755 "$_tmp"
+	mv -f "$_tmp" "${_dest_dir}/${_name}"
+}
+
+path_contains() {
+	case ":${PATH}:" in
+		*":$1:"*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+gen_secret() {
+	if command -v openssl > /dev/null 2>&1; then
+		openssl rand -base64 24 | tr -d '\n='
+		return 0
+	fi
+	if command -v base64 > /dev/null 2>&1; then
+		dd if=/dev/urandom bs=24 count=1 2> /dev/null | base64 | tr -d '\n='
+		return 0
+	fi
+	die "required command not found: openssl or base64 (needed to generate RPC credentials)"
+}
+
+write_file() {
+	_dest=$1
+	_mode=$2
+	_dir=$(dirname "$_dest")
+	mkdir -p "$_dir"
+	chmod 700 "$_dir" 2> /dev/null || true
+	_tmp="${_dest}.tmp.$$"
+	cat > "$_tmp"
+	chmod "$_mode" "$_tmp"
+	mv -f "$_tmp" "$_dest"
+}
+
+# Mainnet defaults. Uses RPC_USER / RPC_PASS (always set before calling).
+write_config() {
+	_name=$1
+	_dest=$2
+	_mode=$3
+	case "$_name" in
+		pearld)
+			write_file "$_dest" "$_mode" << EOF
+[Application Options]
+
+; Default mainnet configuration for pearld.
+; RPC is bound to localhost only. TLS remains enabled by default.
+; P2P still listens on all interfaces so the node can sync with the network.
+; txindex helps prlctl / explorers; oyster defaults to SPV and does not require it.
+
+rpcuser=${RPC_USER}
+rpcpass=${RPC_PASS}
+rpclisten=127.0.0.1:44107
+rpclisten=[::1]:44107
+txindex=1
+EOF
+			;;
+		oyster)
+			write_file "$_dest" "$_mode" << EOF
+[Application Options]
+
+; Default mainnet configuration for oyster.
+; Syncs via SPV (neutrino) by default — no local pearld required for chain data.
+; Wallet RPC is bound to localhost only. TLS remains enabled by default.
+; username/password authenticate wallet RPC (prlctl --wallet) and optional pearld RPC.
+
+usespv=1
+username=${RPC_USER}
+password=${RPC_PASS}
+pearldusername=${RPC_USER}
+pearldpassword=${RPC_PASS}
+rpcconnect=127.0.0.1:44107
+rpclisten=127.0.0.1:44207
+rpclisten=[::1]:44207
+EOF
+			;;
+		prlctl)
+			write_file "$_dest" "$_mode" << EOF
+; Default mainnet configuration for prlctl.
+; Shared credentials work for both:
+;   prlctl getinfo           -> local pearld (port 44107)
+;   prlctl --wallet getinfo  -> local oyster (port 44207)
+; TLS cert defaults: pearld's rpc.cert, or oyster's when --wallet is set.
+
+rpcuser=${RPC_USER}
+rpcpass=${RPC_PASS}
+rpcserver=127.0.0.1
+EOF
+			;;
+		*)
+			die "unknown config: $_name"
+			;;
+	esac
+}
+
+conf_get() {
+	[ -f "$2" ] || return 0
+	awk -F= -v key="$1" '$0 ~ "^" key "=" {
+		val = substr($0, index($0, "=") + 1)
+		if (val != "") print val
+		exit
+	}' "$2"
+}
+
+# True when the installed config already has non-empty RPC credentials.
+config_has_secrets() {
+	_name=$1
+	_file=$2
+	[ -f "$_file" ] || return 1
+	case "$_name" in
+		pearld | prlctl)
+			_user=$(conf_get rpcuser "$_file")
+			_pass=$(conf_get rpcpass "$_file")
+			;;
+		oyster)
+			_user=$(conf_get username "$_file")
+			_pass=$(conf_get password "$_file")
+			;;
+		*)
+			return 1
+			;;
+	esac
+	[ -n "$_user" ] && [ -n "$_pass" ]
+}
+
+ensure_rpc_credentials() {
+	[ -n "$RPC_USER" ] && [ -n "$RPC_PASS" ] && return 0
+
+	RPC_USER=$(conf_get rpcuser "$(config_path pearld)")
+	RPC_PASS=$(conf_get rpcpass "$(config_path pearld)")
+	if [ -n "$RPC_USER" ] && [ -n "$RPC_PASS" ]; then
+		return 0
+	fi
+
+	RPC_USER=$(conf_get username "$(config_path oyster)")
+	RPC_PASS=$(conf_get password "$(config_path oyster)")
+	if [ -n "$RPC_USER" ] && [ -n "$RPC_PASS" ]; then
+		return 0
+	fi
+
+	RPC_USER=$(conf_get rpcuser "$(config_path prlctl)")
+	RPC_PASS=$(conf_get rpcpass "$(config_path prlctl)")
+	if [ -n "$RPC_USER" ] && [ -n "$RPC_PASS" ]; then
+		return 0
+	fi
+
+	RPC_USER=$(gen_secret)
+	RPC_PASS=$(gen_secret)
+}
+
+install_default_configs() {
+	created=0
+	ensure_rpc_credentials
+
+	# pearld bootstraps missing pearld.conf from sample-pearld.conf beside the binary.
+	write_config pearld "${BIN_DIR}/sample-pearld.conf" 644
+	info "default config template -> ${BIN_DIR}/sample-pearld.conf"
+
+	for name in $CONFIGS; do
+		dest=$(config_path "$name")
+		if config_has_secrets "$name" "$dest"; then
+			info "kept existing config -> ${dest}"
+			continue
+		fi
+		write_config "$name" "$dest" 600
+		info "wrote config -> ${dest}"
+		created=1
+	done
+
+	if [ "$created" -eq 1 ]; then
+		info "RPC username/password were auto-generated; no -u/-P flags needed"
+	fi
+}
+
+print_summary() {
+	cat << EOF
+
+pearl-install: done (${VERSION})
+
+Binaries:
+  ${BIN_DIR}/pearld
+  ${BIN_DIR}/prlctl
+  ${BIN_DIR}/oyster
+  ${BIN_DIR}/sample-pearld.conf
+
+Configs (OS default locations, shared RPC credentials):
+  $(config_path pearld)
+  $(config_path oyster)
+  $(config_path prlctl)
+
+Next steps (no -u/-P/-C needed):
+  pearld
+  oyster --create
+  oyster                 # SPV sync by default
+  prlctl getinfo
+  prlctl --wallet getinfo
+EOF
+
+	if ! path_contains "$BIN_DIR"; then
+		printf '\n'
+		info "note: ${BIN_DIR} is not on your PATH"
+		# shellcheck disable=SC2016
+		printf '  add it with: export PATH="%s:%s"\n' "$BIN_DIR" '$PATH'
+	fi
+}
+
+main() {
+	parse_args "$@"
+	if [ "$PRINT_HELP" -eq 1 ]; then
+		usage
+		exit 0
+	fi
+
+	need_cmd uname
+	need_cmd mktemp
+	need_cmd awk
+	need_cmd basename
+	need_cmd dirname
+	need_cmd tar
+	need_cmd cut
+	need_cmd tr
+	need_cmd cp
+
+	# Binaries install under $HOME/.local/bin by default; configs use passwd home.
+	: "${HOME:=$(user_home)}"
+	[ -n "$HOME" ] || die "HOME is not set"
+
+	OS=$(detect_os)
+	arch=$(detect_arch "$OS")
+	BIN_DIR=${BIN_DIR:-$(default_bin_dir)}
+	ensure_bin_dir "$BIN_DIR"
+
+	if [ -z "$VERSION" ]; then
+		info "resolving latest release..."
+		VERSION=$(resolve_latest_version)
+	fi
+	validate_version "$VERSION" || die "invalid version '${VERSION}' (expected vX.Y.Z)"
+
+	archive_name="pearl-${OS}-${arch}-${VERSION}.tar.gz"
+	asset_base="${RELEASE_BASE}/download/${VERSION}"
+
+	TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pearl-install.XXXXXX")
+	trap cleanup EXIT INT HUP TERM
+
+	info "downloading ${archive_name}"
+	download "${asset_base}/${archive_name}" "${TMP_DIR}/${archive_name}"
+	info "downloading checksums.txt"
+	download "${asset_base}/checksums.txt" "${TMP_DIR}/checksums.txt"
+
+	info "verifying SHA-256..."
+	verify_checksum "${TMP_DIR}/${archive_name}" "${TMP_DIR}/checksums.txt"
+
+	info "extracting binaries..."
+	extract_binaries "${TMP_DIR}/${archive_name}" "${TMP_DIR}/staging"
+	for bin in $BINARIES; do
+		info "installing binary -> ${BIN_DIR}/${bin}"
+		install_binary "${TMP_DIR}/staging/${bin}" "$BIN_DIR"
+	done
+
+	install_default_configs
+	print_summary
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -441,8 +441,22 @@ install_default_configs() {
 	created=0
 	ensure_rpc_credentials
 
-	# pearld bootstraps missing pearld.conf from sample-pearld.conf beside the binary.
-	write_config pearld "${BIN_DIR}/sample-pearld.conf" 644
+	# pearld bootstraps missing pearld.conf from sample-pearld.conf beside the
+	# binary, replacing rpcuser=/rpcpass= with freshly generated values. Keep
+	# this template secret-free — bin dirs are often world-readable.
+	write_file "${BIN_DIR}/sample-pearld.conf" 644 << 'EOF'
+[Application Options]
+
+; Template used by pearld when creating a missing pearld.conf.
+; Do not put real credentials here; the installer writes those to the OS
+; app-data pearld.conf with mode 0600.
+
+rpcuser=
+rpcpass=
+rpclisten=127.0.0.1:44107
+rpclisten=[::1]:44107
+txindex=1
+EOF
 	info "default config template -> ${BIN_DIR}/sample-pearld.conf"
 
 	for name in $CONFIGS; do

--- a/install.sh
+++ b/install.sh
@@ -441,24 +441,6 @@ install_default_configs() {
 	created=0
 	ensure_rpc_credentials
 
-	# pearld bootstraps missing pearld.conf from sample-pearld.conf beside the
-	# binary, replacing rpcuser=/rpcpass= with freshly generated values. Keep
-	# this template secret-free — bin dirs are often world-readable.
-	write_file "${BIN_DIR}/sample-pearld.conf" 644 << 'EOF'
-[Application Options]
-
-; Template used by pearld when creating a missing pearld.conf.
-; Do not put real credentials here; the installer writes those to the OS
-; app-data pearld.conf with mode 0600.
-
-rpcuser=
-rpcpass=
-rpclisten=127.0.0.1:44107
-rpclisten=[::1]:44107
-txindex=1
-EOF
-	info "default config template -> ${BIN_DIR}/sample-pearld.conf"
-
 	for name in $CONFIGS; do
 		dest=$(config_path "$name")
 		if config_has_secrets "$name" "$dest"; then
@@ -484,7 +466,6 @@ Binaries:
   ${BIN_DIR}/pearld
   ${BIN_DIR}/prlctl
   ${BIN_DIR}/oyster
-  ${BIN_DIR}/sample-pearld.conf
 
 Configs (OS default locations, shared RPC credentials):
   $(config_path pearld)

--- a/node/docs/installation.md
+++ b/node/docs/installation.md
@@ -43,7 +43,7 @@ curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/in
 ```powershell
 irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
 notepad install.ps1
-powershell -ExecutionPolicy Bypass -File .\install.ps1
+pwsh -File .\install.ps1
 ```
 
 ### Windows — one-line convenience form

--- a/node/docs/installation.md
+++ b/node/docs/installation.md
@@ -1,6 +1,72 @@
 # Installation
 
-## Requirements
+## Prebuilt binaries (recommended)
+
+The release installer downloads the platform archive from GitHub Releases,
+verifies its SHA-256 against `checksums.txt`, and installs `pearld`, `prlctl`,
+and `oyster` into `${XDG_BIN_HOME:-$HOME/.local/bin}`.
+
+It also writes mainnet default configs into the OS default app-data paths when
+missing, with shared auto-generated RPC credentials. Oyster defaults to SPV
+sync (`usespv=1`), so a local pearld is optional for the wallet. After install,
+no `-u` / `-P` / `-C` is required: `prlctl getinfo` targets local pearld, and
+`prlctl --wallet getinfo` targets local oyster. Existing configs that already
+have credentials are left unchanged. RPC stays localhost-only.
+
+| Tool | Linux | macOS |
+|------|-------|-------|
+| pearld | `~/.pearld/pearld.conf` | `~/Library/Application Support/Pearld/pearld.conf` |
+| oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` |
+| prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` |
+
+Supported platforms: macOS and Linux on amd64 and arm64.
+
+### Download, inspect, then run
+
+```bash
+curl -fsSL -o install.sh https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh
+less install.sh
+sh install.sh
+```
+
+### One-line convenience form
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh | sh
+```
+
+### Pin a version or install directory
+
+```bash
+sh install.sh --version v0.1.0
+sh install.sh --bin-dir "$HOME/bin"
+```
+
+### Upgrade
+
+Rerun the installer (with the same `--bin-dir` if you customized it). Existing
+binaries are replaced atomically. Existing config files are left unchanged.
+
+### Remove
+
+```bash
+rm -f "${XDG_BIN_HOME:-$HOME/.local/bin}/pearld" \
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/prlctl" \
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/oyster" \
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/sample-pearld.conf"
+```
+
+Configs are not removed automatically. Delete them from the paths in the table
+above if you also want to discard RPC credentials and settings.
+### macOS Gatekeeper / quarantine
+
+Installing via `curl`/`sh` normally does not attach the browser quarantine
+flag, so Gatekeeper typically does not block the binaries. Archives downloaded
+in a browser can still be quarantined when the app is not Developer ID signed
+and notarized. The installer never deletes quarantine metadata or otherwise
+bypasses Gatekeeper.
+
+## Requirements (build from source)
 
 - [Go](https://golang.org) 1.26 or newer
 - [Rust](https://rustup.rs) toolchain (for ZK verification library)

--- a/node/docs/installation.md
+++ b/node/docs/installation.md
@@ -4,7 +4,10 @@
 
 The release installer downloads the platform archive from GitHub Releases,
 verifies its SHA-256 against `checksums.txt`, and installs `pearld`, `prlctl`,
-and `oyster` into `${XDG_BIN_HOME:-$HOME/.local/bin}`.
+and `oyster`:
+
+- macOS/Linux: `install.sh` → `${XDG_BIN_HOME:-$HOME/.local/bin}`
+- Windows: `install.ps1` → `%LOCALAPPDATA%\Pearl\bin`
 
 It also writes mainnet default configs into the OS default app-data paths when
 missing, with shared auto-generated RPC credentials. Oyster defaults to SPV
@@ -13,15 +16,15 @@ no `-u` / `-P` / `-C` is required: `prlctl getinfo` targets local pearld, and
 `prlctl --wallet getinfo` targets local oyster. Existing configs that already
 have credentials are left unchanged. RPC stays localhost-only.
 
-| Tool | Linux | macOS |
-|------|-------|-------|
-| pearld | `~/.pearld/pearld.conf` | `~/Library/Application Support/Pearld/pearld.conf` |
-| oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` |
-| prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` |
+| Tool | Linux | macOS | Windows |
+|------|-------|-------|---------|
+| pearld | `~/.pearld/pearld.conf` | `~/Library/Application Support/Pearld/pearld.conf` | `%LOCALAPPDATA%\Pearld\pearld.conf` |
+| oyster | `~/.oyster/oyster.conf` | `~/Library/Application Support/Oyster/oyster.conf` | `%LOCALAPPDATA%\Oyster\oyster.conf` |
+| prlctl | `~/.prlctl/prlctl.conf` | `~/Library/Application Support/Prlctl/prlctl.conf` | `%LOCALAPPDATA%\Prlctl\prlctl.conf` |
 
-Supported platforms: macOS and Linux on amd64 and arm64.
+Supported platforms: macOS and Linux on amd64 and arm64; Windows on amd64.
 
-### Download, inspect, then run
+### macOS / Linux — download, inspect, then run
 
 ```bash
 curl -fsSL -o install.sh https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh
@@ -29,10 +32,24 @@ less install.sh
 sh install.sh
 ```
 
-### One-line convenience form
+### macOS / Linux — one-line convenience form
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.sh | sh
+```
+
+### Windows — download, inspect, then run
+
+```powershell
+irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 -OutFile install.ps1
+notepad install.ps1
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+### Windows — one-line convenience form
+
+```powershell
+irm https://raw.githubusercontent.com/pearl-research-labs/pearl/master/install.ps1 | iex
 ```
 
 ### Pin a version or install directory
@@ -42,10 +59,16 @@ sh install.sh --version v0.1.0
 sh install.sh --bin-dir "$HOME/bin"
 ```
 
+```powershell
+.\install.ps1 -Version v0.1.0
+.\install.ps1 -BinDir "$env:USERPROFILE\bin"
+```
+
 ### Upgrade
 
-Rerun the installer (with the same `--bin-dir` if you customized it). Existing
-binaries are replaced atomically. Existing config files are left unchanged.
+Rerun the installer (with the same `--bin-dir` / `-BinDir` if you customized it).
+Existing binaries are replaced atomically. Existing config files are left
+unchanged.
 
 ### Remove
 
@@ -56,15 +79,24 @@ rm -f "${XDG_BIN_HOME:-$HOME/.local/bin}/pearld" \
       "${XDG_BIN_HOME:-$HOME/.local/bin}/sample-pearld.conf"
 ```
 
+```powershell
+Remove-Item "$env:LOCALAPPDATA\Pearl\bin\pearld.exe", `
+            "$env:LOCALAPPDATA\Pearl\bin\prlctl.exe", `
+            "$env:LOCALAPPDATA\Pearl\bin\oyster.exe", `
+            "$env:LOCALAPPDATA\Pearl\bin\sample-pearld.conf" -ErrorAction SilentlyContinue
+```
+
 Configs are not removed automatically. Delete them from the paths in the table
 above if you also want to discard RPC credentials and settings.
-### macOS Gatekeeper / quarantine
 
-Installing via `curl`/`sh` normally does not attach the browser quarantine
-flag, so Gatekeeper typically does not block the binaries. Archives downloaded
-in a browser can still be quarantined when the app is not Developer ID signed
-and notarized. The installer never deletes quarantine metadata or otherwise
-bypasses Gatekeeper.
+### macOS Gatekeeper / Windows SmartScreen
+
+Installing via `curl`/`sh` or `irm` normally does not attach browser quarantine
+/ Mark-of-the-Web the same way a browser download does, so Gatekeeper and
+SmartScreen typically do not block the binaries. Archives downloaded in a
+browser can still be blocked when the app is not platform-signed. The installer
+never deletes quarantine metadata, Zone.Identifier streams, or otherwise
+bypasses OS protections.
 
 ## Requirements (build from source)
 

--- a/node/docs/installation.md
+++ b/node/docs/installation.md
@@ -75,15 +75,13 @@ unchanged.
 ```bash
 rm -f "${XDG_BIN_HOME:-$HOME/.local/bin}/pearld" \
       "${XDG_BIN_HOME:-$HOME/.local/bin}/prlctl" \
-      "${XDG_BIN_HOME:-$HOME/.local/bin}/oyster" \
-      "${XDG_BIN_HOME:-$HOME/.local/bin}/sample-pearld.conf"
+      "${XDG_BIN_HOME:-$HOME/.local/bin}/oyster"
 ```
 
 ```powershell
 Remove-Item "$env:LOCALAPPDATA\Pearl\bin\pearld.exe", `
             "$env:LOCALAPPDATA\Pearl\bin\prlctl.exe", `
-            "$env:LOCALAPPDATA\Pearl\bin\oyster.exe", `
-            "$env:LOCALAPPDATA\Pearl\bin\sample-pearld.conf" -ErrorAction SilentlyContinue
+            "$env:LOCALAPPDATA\Pearl\bin\oyster.exe" -ErrorAction SilentlyContinue
 ```
 
 Configs are not removed automatically. Delete them from the paths in the table


### PR DESCRIPTION
## Summary

Adds portable, checksum-verified installers for Pearl release binaries on macOS, Linux, and Windows.

- `install.sh` installs `pearld` / `prlctl` / `oyster` to `${XDG_BIN_HOME:-$HOME/.local/bin}`
- `install.ps1` does the same on Windows amd64 into `%LOCALAPPDATA%\Pearl\bin`
- Both verify SHA-256 against `checksums.txt`, write localhost-only mainnet defaults with shared RPC credentials, and default oyster to `usespv=1`
- Documents inspect-then-run install, pinning, upgrade, removal, and Gatekeeper / SmartScreen notes

## Test plan

- [ ] `sh -n install.sh`; dry-run with a temp home / `--bin-dir` (configs + `usespv=1`)
- [ ] `pwsh -File .\install.ps1 -Version v1.1.5` on Windows (or mocked env under pwsh)
- [ ] Shared RPC creds work for `prlctl` / `prlctl --wallet` without `-u` / `-P` / `-C`
- [ ] Reinstall leaves existing credentialed configs unchanged