### PR TITLE
feat(oystercli): restore recovery, multi-network and remote daemon support

### DIFF
--- a/wallet/cmd/oystercli/README.md
+++ b/wallet/cmd/oystercli/README.md
@@ -52,7 +52,9 @@ optimistically and needs no configuration from you:
 1. Flags win: `--connect`, `--rpcuser`, `--rpcpass`, `--cafile`, `--notls`,
    `--testnet`/`--testnet2`/`--simnet`/`--signet`, `--appdata`.
 2. Otherwise it reads the existing `~/.oyster/oyster.conf`
-   (`username=`/`password=`, `noservertls=`, `rpclisten=`) and connects.
+   (`username=`/`password=`, `noservertls=`, `rpclisten=`) and connects. An
+   explicit `rpclisten=` is where the daemon actually listens, so oystercli
+   dials it — whatever the active network's default port would be.
 3. If there is no config at all, oystercli **writes a secure one itself**
    (see below) — you are never asked to make configuration choices.
 
@@ -66,12 +68,14 @@ connect target, wallet, oyster binary), and always under `--verbose`.
 When no daemon is reachable, oystercli provisions and manages one for you:
 
 - **Auto-provisioned config.** If `~/.oyster/oyster.conf` is missing, oystercli
-  writes a secure one — generated RPC credentials, `usespv=1` (no pearld
-  needed), a **loopback-only** `rpclisten=127.0.0.1:<port>`, and TLS left on
-  (oyster's default). An existing config is never overridden: if it merely
-  lacks credentials, only those are appended; any other settings are left
-  exactly as they are. If an existing config is insecure (`noservertls`, a
-  non-loopback listener), oystercli warns but respects it.
+  writes a secure one — generated RPC credentials and `usespv=1` (no pearld
+  needed). TLS and listeners are left at oyster's defaults, which are TLS on
+  and **loopback-only** listeners on the active network's RPC port — so the
+  same conf serves mainnet and testnet. An existing config is never
+  overridden: if it merely lacks credentials, only those are appended; any
+  other settings are left exactly as they are. If an existing config is
+  insecure (`noservertls`, a non-loopback listener), oystercli warns but
+  respects it.
 - **Create a wallet** (when none exists) — drives `oyster --createfromfile`
   (the desktop wallet's mechanism), with a seed backup ceremony for new
   wallets. Restores recover funds by rescanning from the wallet birthday you
@@ -96,6 +100,43 @@ before use.
 If something is listening on `127.0.0.1:8335`, triage points out that this is
 the desktop wallet's private oyster instance (random per-session credentials)
 and steers toward running a dedicated daemon instead.
+
+## Remote daemons
+
+oystercli can drive an oyster running on another machine:
+
+```
+oystercli -c wallet-host:44207 -u <user> -P <pass> --cafile <copied rpc.cert>
+```
+
+- On the daemon's machine: set a non-loopback `rpclisten=` in its
+  `oyster.conf` and open the port in the firewall. The auto-generated
+  certificate already covers that machine's hostname and interface IPs; if
+  its address changed since generation, delete `rpc.cert`/`rpc.key` and
+  restart oyster to regenerate.
+- On the client: copy the daemon's `rpc.cert` and point `--cafile` at it —
+  or skip both by tunnelling (`ssh -L 44207:127.0.0.1:44207 wallet-host`)
+  and connecting to `localhost`, which every generated certificate covers.
+- Flag-free alternative: keep a dedicated client appdata dir
+  (`oystercli -A ~/.oyster-remote`) whose `oyster.conf` holds the remote
+  daemon's credentials and `rpclisten=wallet-host:44207` (oystercli dials
+  the listener address), with the copied `rpc.cert` beside it.
+
+With a remote target the local bootstrapping steps — config provisioning,
+wallet creation, starting or stopping-and-restarting the daemon from triage —
+are not offered; that machine's operator owns its configuration.
+
+## Testnet
+
+`oystercli --testnet` runs the exact same flow against the test network:
+credentials come from the shared `oyster.conf`, the wallet lives in the
+per-network directory (`~/.oyster/testnet/wallet.db`), "Create a wallet" and
+"Start oyster now" pass `--testnet` through to the daemon, and the RPC port
+defaults to the testnet port (`44209`). Mainnet and testnet daemons can run
+side by side from the same config. The one caveat: a config with an explicit
+`rpclisten=` pins the daemon (and oystercli) to that address on every
+network, so port-sharing setups should drop the line and rely on the
+per-network defaults.
 
 ## Flags
 

--- a/wallet/cmd/oystercli/README.md
+++ b/wallet/cmd/oystercli/README.md
@@ -74,7 +74,8 @@ When no daemon is reachable, oystercli provisions and manages one for you:
   non-loopback listener), oystercli warns but respects it.
 - **Create a wallet** (when none exists) — drives `oyster --createfromfile`
   (the desktop wallet's mechanism), with a seed backup ceremony for new
-  wallets.
+  wallets. Restores recover funds by rescanning from the wallet birthday you
+  enter, or from the chain's genesis when you leave it empty.
 - **Start oyster now** — spawns the daemon detached (it keeps running after
   oystercli exits; the PID and log path are printed), waits for its RPC, and
   connects.

--- a/wallet/cmd/oystercli/config.go
+++ b/wallet/cmd/oystercli/config.go
@@ -5,11 +5,12 @@
 package main
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/pearl-research-labs/pearl/node/btcutil"
@@ -144,6 +145,16 @@ func loadConfig() (*config, error) {
 	cfg.src.connect = "--connect"
 	if cfg.Connect == "localhost" {
 		cfg.src.connect = fmt.Sprintf("default %s port", cfg.activeNet.Params.Name)
+		// The daemon listens where oyster.conf's rpclisten says, so an
+		// explicit listener there is the address to dial — same
+		// flags > conf > default order as every other setting.
+		for _, listen := range fileCfg.rpcListen {
+			if target := dialTarget(listen, cfg.activeNet.RPCServerPort); target != "" {
+				cfg.Connect = target
+				cfg.src.connect = "oyster.conf (rpclisten)"
+				break
+			}
+		}
 	}
 	var err error
 	cfg.Connect, err = cfgutil.NormalizeAddress(cfg.Connect, cfg.activeNet.RPCServerPort)
@@ -158,6 +169,45 @@ func loadConfig() (*config, error) {
 // resolved appdata directory.
 func (c *config) oysterConfPath() string {
 	return filepath.Join(c.AppData, "oyster.conf")
+}
+
+// remoteTarget reports whether the connect target points at another machine.
+// Local bootstrapping — provisioning a config, creating a wallet, spawning
+// the daemon — only makes sense when the daemon runs here; a remote target
+// gets connection triage only, and its operator owns that machine's config.
+func (c *config) remoteTarget() bool {
+	host, _, err := net.SplitHostPort(c.Connect)
+	if err != nil {
+		host = c.Connect
+	}
+	switch host {
+	case "", "localhost":
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return !ip.IsLoopback()
+	}
+	return true
+}
+
+// dialTarget converts an rpclisten value from oyster.conf into an address a
+// client can dial, or "" for listeners that cannot be translated. Wildcard
+// and empty hosts mean "every interface" on the daemon side; loopback is the
+// right way to reach them from the same machine.
+func dialTarget(listen, defaultPort string) string {
+	norm, err := cfgutil.NormalizeAddress(listen, defaultPort)
+	if err != nil {
+		return ""
+	}
+	host, port, err := net.SplitHostPort(norm)
+	if err != nil {
+		return ""
+	}
+	switch host {
+	case "", "0.0.0.0", "::", "*":
+		host = "localhost"
+	}
+	return net.JoinHostPort(host, port)
 }
 
 // rescrapeConf re-reads oyster.conf after oystercli created or amended it and
@@ -205,36 +255,32 @@ type oysterConfValues struct {
 	rpcListen   []string
 }
 
-var (
-	// Oyster names its wallet RPC auth options username/password, but accept
-	// the pearld-style rpcuser/rpcpass spelling as well since both appear in
-	// the wild (prlctl scrapes the latter).
-	confUserRe   = regexp.MustCompile(`(?m)^\s*(?:username|rpcuser)\s*=\s*(\S+)`)
-	confPassRe   = regexp.MustCompile(`(?m)^\s*(?:password|rpcpass)\s*=\s*(\S+)`)
-	confNoTLSRe  = regexp.MustCompile(`(?m)^\s*noservertls\s*=\s*(1|true)(?:\s|$)`)
-	confListenRe = regexp.MustCompile(`(?m)^\s*rpclisten\s*=\s*(\S+)`)
-)
-
 // scrapeOysterConf extracts RPC credentials and server TLS/listener
-// configuration from an oyster.conf file. Missing files or fields simply
+// configuration from an oyster.conf file, parsing it with the same ini
+// machinery the daemon itself uses (go-flags), so quoting, comments, and
+// sections behave identically. Oyster names the auth options
+// username/password, but the pearld-style rpcuser/rpcpass spelling appears in
+// the wild too (prlctl scrapes the latter). Missing files or fields simply
 // yield zero values.
 func scrapeOysterConf(path string) oysterConfValues {
-	var vals oysterConfValues
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return vals
+	var opts struct {
+		Username    string   `long:"username"`
+		RPCUser     string   `long:"rpcuser"`
+		Password    string   `long:"password"`
+		RPCPass     string   `long:"rpcpass"`
+		NoServerTLS bool     `long:"noservertls"`
+		RPCListen   []string `long:"rpclisten"`
 	}
-	if m := confUserRe.FindSubmatch(content); m != nil {
-		vals.username = string(m[1])
+	parser := flags.NewParser(&opts, flags.IgnoreUnknown)
+	if err := flags.NewIniParser(parser).ParseFile(path); err != nil {
+		return oysterConfValues{}
 	}
-	if m := confPassRe.FindSubmatch(content); m != nil {
-		vals.password = string(m[1])
+	return oysterConfValues{
+		username:    cmp.Or(opts.Username, opts.RPCUser),
+		password:    cmp.Or(opts.Password, opts.RPCPass),
+		noServerTLS: opts.NoServerTLS,
+		rpcListen:   opts.RPCListen,
 	}
-	vals.noServerTLS = confNoTLSRe.Match(content)
-	for _, m := range confListenRe.FindAllSubmatch(content, -1) {
-		vals.rpcListen = append(vals.rpcListen, string(m[1]))
-	}
-	return vals
 }
 
 // cleanAndExpandPath expands environment variables and leading ~ in path.

--- a/wallet/cmd/oystercli/config_test.go
+++ b/wallet/cmd/oystercli/config_test.go
@@ -69,51 +69,6 @@ func TestScrapeOysterConfMissingFile(t *testing.T) {
 	assert.Equal(t, oysterConfValues{}, got)
 }
 
-// The connect target must follow an explicit rpclisten in oyster.conf: the
-// daemon listens exactly where the conf says, whatever the active network's
-// default port is. Wildcard listeners are dialed via loopback.
-func TestDialTarget(t *testing.T) {
-	tests := []struct {
-		listen string
-		want   string
-	}{
-		{"127.0.0.1:44209", "127.0.0.1:44209"},
-		{"127.0.0.1", "127.0.0.1:44207"},
-		{"[::1]:44209", "[::1]:44209"},
-		{"0.0.0.0:44209", "localhost:44209"},
-		{":44209", "localhost:44209"},
-		{"localhost:44209", "localhost:44209"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.listen, func(t *testing.T) {
-			assert.Equal(t, tt.want, dialTarget(tt.listen, "44207"))
-		})
-	}
-}
-
-// Local bootstrapping (provisioning, wallet creation, daemon spawning) must
-// be suppressed for targets on other machines.
-func TestRemoteTarget(t *testing.T) {
-	tests := []struct {
-		connect string
-		want    bool
-	}{
-		{"localhost:44207", false},
-		{"127.0.0.1:44207", false},
-		{"[::1]:44207", false},
-		{"127.0.0.2:44207", false},
-		{"192.168.1.50:44207", true},
-		{"wallet.example.com:44207", true},
-		{"[2001:db8::1]:44207", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.connect, func(t *testing.T) {
-			cfg := &config{Connect: tt.connect}
-			assert.Equal(t, tt.want, cfg.remoteTarget())
-		})
-	}
-}
-
 func TestRescrapeConf(t *testing.T) {
 	cfg := &config{AppData: t.TempDir()}
 	cfg.activeNet = mainNetForTest()

--- a/wallet/cmd/oystercli/config_test.go
+++ b/wallet/cmd/oystercli/config_test.go
@@ -69,6 +69,51 @@ func TestScrapeOysterConfMissingFile(t *testing.T) {
 	assert.Equal(t, oysterConfValues{}, got)
 }
 
+// The connect target must follow an explicit rpclisten in oyster.conf: the
+// daemon listens exactly where the conf says, whatever the active network's
+// default port is. Wildcard listeners are dialed via loopback.
+func TestDialTarget(t *testing.T) {
+	tests := []struct {
+		listen string
+		want   string
+	}{
+		{"127.0.0.1:44209", "127.0.0.1:44209"},
+		{"127.0.0.1", "127.0.0.1:44207"},
+		{"[::1]:44209", "[::1]:44209"},
+		{"0.0.0.0:44209", "localhost:44209"},
+		{":44209", "localhost:44209"},
+		{"localhost:44209", "localhost:44209"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.listen, func(t *testing.T) {
+			assert.Equal(t, tt.want, dialTarget(tt.listen, "44207"))
+		})
+	}
+}
+
+// Local bootstrapping (provisioning, wallet creation, daemon spawning) must
+// be suppressed for targets on other machines.
+func TestRemoteTarget(t *testing.T) {
+	tests := []struct {
+		connect string
+		want    bool
+	}{
+		{"localhost:44207", false},
+		{"127.0.0.1:44207", false},
+		{"[::1]:44207", false},
+		{"127.0.0.2:44207", false},
+		{"192.168.1.50:44207", true},
+		{"wallet.example.com:44207", true},
+		{"[2001:db8::1]:44207", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.connect, func(t *testing.T) {
+			cfg := &config{Connect: tt.connect}
+			assert.Equal(t, tt.want, cfg.remoteTarget())
+		})
+	}
+}
+
 func TestRescrapeConf(t *testing.T) {
 	cfg := &config{AppData: t.TempDir()}
 	cfg.activeNet = mainNetForTest()

--- a/wallet/cmd/oystercli/createwallet.go
+++ b/wallet/cmd/oystercli/createwallet.go
@@ -61,8 +61,8 @@ func createWalletWizard(cfg *config) error {
 				Value(&seedInput),
 			huh.NewInput().
 				Title("Wallet birthday (optional)").
-				Description("Approximate creation date, YYYY-MM-DD. Speeds up the initial scan.").
-				Placeholder("2026-01-31").
+				Description("Date of the wallet's first use, YYYY-MM-DD; narrows the recovery scan.\nLeave empty to scan the whole chain.").
+				Placeholder("2026-05-01").
 				Validate(validateBirthday).
 				Value(&birthday),
 		)))
@@ -96,10 +96,7 @@ func createWalletWizard(cfg *config) error {
 	setup := map[string]string{"PrivatePassphrase": passphrase}
 	if mode == modeImport {
 		setup["Seed"] = strings.TrimSpace(seedInput)
-		if b := strings.TrimSpace(birthday); b != "" {
-			t, _ := time.Parse("2006-01-02", b)
-			setup["Bday"] = fmt.Sprintf("%d", t.Unix())
-		}
+		setup["Bday"] = fmt.Sprintf("%d", importBirthday(cfg, birthday).Unix())
 	}
 
 	var seed string
@@ -253,6 +250,20 @@ func wrapWords(s string, perLine int) string {
 		fmt.Fprintf(&b, "%2d.%s", i+1, w)
 	}
 	return b.String()
+}
+
+// importBirthday resolves the recovery start time for a restore. A restored
+// wallet only finds its addresses and balance by rescanning the chain from
+// the birthday, and oyster defaults a missing Bday to time.Now() — which
+// skips all history and leaves the wallet empty. An omitted birthday must
+// therefore mean "scan everything": the chain's genesis time.
+func importBirthday(cfg *config, input string) time.Time {
+	if s := strings.TrimSpace(input); s != "" {
+		if t, err := time.Parse("2006-01-02", s); err == nil {
+			return t
+		}
+	}
+	return cfg.activeNet.Params.GenesisBlock.BlockHeader().Timestamp
 }
 
 // validateBirthday accepts empty or YYYY-MM-DD dates in the past.

--- a/wallet/cmd/oystercli/createwallet.go
+++ b/wallet/cmd/oystercli/createwallet.go
@@ -57,7 +57,7 @@ func createWalletWizard(cfg *config) error {
 			huh.NewText().
 				Title("Recovery seed").
 				Description("The 12-word BIP39 mnemonic (or legacy hex seed) to restore from.").
-				Validate(nonEmpty("seed")).
+				Validate(huh.ValidateNotEmpty()).
 				Value(&seedInput),
 			huh.NewInput().
 				Title("Wallet birthday (optional)").
@@ -76,7 +76,7 @@ func createWalletWizard(cfg *config) error {
 			Title("Private passphrase").
 			Description("Encrypts your keys; required for every spend. There is no recovery if lost.").
 			EchoMode(huh.EchoModePassword).
-			Validate(nonEmpty("passphrase")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&passphrase),
 		huh.NewInput().
 			Title("Repeat passphrase").

--- a/wallet/cmd/oystercli/createwallet_test.go
+++ b/wallet/cmd/oystercli/createwallet_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,6 +35,22 @@ func TestWrapWords(t *testing.T) {
 	got := wrapWords("alpha beta gamma delta epsilon", 2)
 	want := " 1.alpha   2.beta\n 3.gamma   4.delta\n 5.epsilon"
 	assert.Equal(t, want, got)
+}
+
+// An omitted birthday must resolve to genesis, not "now": oyster starts the
+// restore recovery scan at the birthday, so a too-recent one silently skips
+// all history and the wallet comes up with no addresses and no balance.
+func TestImportBirthday(t *testing.T) {
+	cfg := &config{}
+	cfg.activeNet = mainNetForTest()
+	genesis := cfg.activeNet.Params.GenesisBlock.BlockHeader().Timestamp
+
+	assert.Equal(t, genesis, importBirthday(cfg, ""))
+	assert.Equal(t, genesis, importBirthday(cfg, "   "))
+
+	want, err := time.Parse("2006-01-02", "2026-05-01")
+	assert.NoError(t, err)
+	assert.Equal(t, want, importBirthday(cfg, " 2026-05-01 "))
 }
 
 func TestValidateBirthday(t *testing.T) {

--- a/wallet/cmd/oystercli/logs.go
+++ b/wallet/cmd/oystercli/logs.go
@@ -192,7 +192,10 @@ func colorizeLogLine(line string) string {
 
 // stripControlRunes replaces C0/C1 control characters (except tab) with the
 // Unicode replacement character, keeping injected sequences visible rather
-// than silently dropping them.
+// than silently dropping them. ansi.Strip is deliberately not used here: it
+// removes well-formed escape sequences but passes bare C0 controls through
+// (its Execute action keeps them), so carriage-return and backspace spoofing
+// would survive it.
 func stripControlRunes(s string) string {
 	return strings.Map(func(r rune) rune {
 		if r == '\t' {

--- a/wallet/cmd/oystercli/logs_test.go
+++ b/wallet/cmd/oystercli/logs_test.go
@@ -36,7 +36,6 @@ func TestStripControlRunes(t *testing.T) {
 }
 
 func TestColorizeLogLineSanitizes(t *testing.T) {
-	initUI(true)
 	out := colorizeLogLine("[INF] peer (\x1b]0;spoofed\x07)")
 	assert.NotContains(t, out, "\x1b]0;", "OSC sequence must not survive")
 	assert.Contains(t, out, "spoofed", "text content is kept visible")

--- a/wallet/cmd/oystercli/main.go
+++ b/wallet/cmd/oystercli/main.go
@@ -37,7 +37,6 @@ func run() error {
 		return fmt.Errorf("%s is an interactive tool and needs a terminal (set ACCESSIBLE=1 for screen-reader prompts)", appName)
 	}
 
-	initUI(detectDarkBackground())
 	printBanner(cfg)
 	if cfg.Verbose {
 		lipgloss.Println("\n" + resolutionStory(cfg))
@@ -46,8 +45,9 @@ func run() error {
 	// Zero-config: if no credentials were discovered (flags or an existing
 	// oyster.conf), write a secure config ourselves rather than asking the
 	// user to choose anything. An existing config is respected, not
-	// overridden.
-	if cfg.RPCUser == "" || cfg.RPCPass == "" {
+	// overridden. Remote targets are excluded: locally generated
+	// credentials cannot match a daemon provisioned elsewhere.
+	if !cfg.remoteTarget() && (cfg.RPCUser == "" || cfg.RPCPass == "") {
 		if err := autoProvision(cfg); err != nil {
 			return err
 		}

--- a/wallet/cmd/oystercli/provenance_test.go
+++ b/wallet/cmd/oystercli/provenance_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestResolutionStory(t *testing.T) {
-	initUI(true)
 
 	cfg := &config{
 		AppData: t.TempDir(),

--- a/wallet/cmd/oystercli/provision.go
+++ b/wallet/cmd/oystercli/provision.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"cmp"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -24,10 +25,9 @@ import (
 // provisionedConf is the secure configuration oystercli writes when none
 // exists.
 type provisionedConf struct {
-	username  string
-	password  string
-	rpcListen string // loopback listener, e.g. 127.0.0.1:44207
-	useSPV    bool
+	username string
+	password string
+	useSPV   bool
 }
 
 // autoProvision ensures oystercli has RPC credentials to connect with or
@@ -35,10 +35,15 @@ type provisionedConf struct {
 //
 //   - If credentials are already resolved (flags or an existing oyster.conf),
 //     do nothing.
-//   - Otherwise write a secure oyster.conf: generated credentials, loopback
-//     rpclisten, TLS on (the oyster default), and SPV so no pearld is needed.
-//     A missing file is created; an existing file only has the missing
-//     credential keys appended — other settings are never touched.
+//   - Otherwise write a secure oyster.conf: generated credentials, TLS on
+//     (the oyster default), and SPV so no pearld is needed. A missing file
+//     is created; an existing file only has the missing credential keys
+//     appended — other settings are never touched.
+//
+// No rpclisten is written: oyster's own default is loopback-only listeners
+// on the active network's RPC port, so omitting it keeps the wallet
+// unreachable off-host while letting one conf serve every network (a pinned
+// port would make a --testnet daemon listen on the mainnet port).
 func autoProvision(cfg *config) error {
 	if cfg.RPCUser != "" && cfg.RPCPass != "" {
 		return nil
@@ -47,10 +52,9 @@ func autoProvision(cfg *config) error {
 	confPath := cfg.oysterConfPath()
 	existing := scrapeOysterConf(confPath)
 	pc := provisionedConf{
-		username:  firstNonEmpty(existing.username, appName+"-"+randomHex(4)),
-		password:  firstNonEmpty(existing.password, randomHex(24)),
-		rpcListen: net.JoinHostPort("127.0.0.1", cfg.activeNet.RPCServerPort),
-		useSPV:    true,
+		username: cmp.Or(existing.username, appName+"-"+randomHex(4)),
+		password: cmp.Or(existing.password, randomHex(24)),
+		useSPV:   true,
 	}
 
 	created, err := writeProvisionedConf(confPath, existing, pc)
@@ -83,9 +87,10 @@ func writeProvisionedConf(path string, existing oysterConfValues, pc provisioned
 		if pc.useSPV {
 			lines = append(lines, "usespv=1")
 		}
-		// Pin the RPC listener to loopback so the wallet is never
-		// reachable off-host; TLS stays on (oyster's default).
-		lines = append(lines, "rpclisten="+pc.rpcListen)
+		// TLS and rpclisten are deliberately left at oyster's defaults
+		// (TLS on, loopback-only listeners on the active network's
+		// port), so this one conf serves mainnet and testnet alike.
+		lines = append(lines, "; rpc listeners default to loopback on the active network's port")
 		return true, os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o600)
 	case readErr != nil:
 		return false, readErr
@@ -156,14 +161,6 @@ func isLoopbackListener(listen string) bool {
 		return ip.IsLoopback()
 	}
 	return false
-}
-
-// firstNonEmpty returns a if it is non-empty, otherwise b.
-func firstNonEmpty(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
 }
 
 // randomHex returns n random bytes hex-encoded (2n characters).

--- a/wallet/cmd/oystercli/provision_test.go
+++ b/wallet/cmd/oystercli/provision_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAutoProvisionWritesSecureConfWhenAbsent(t *testing.T) {
-	initUI(true)
 	cfg := &config{AppData: t.TempDir()}
 	cfg.activeNet = mainNetForTest()
 
@@ -30,15 +29,15 @@ func TestAutoProvisionWritesSecureConfWhenAbsent(t *testing.T) {
 	content, err := os.ReadFile(cfg.oysterConfPath())
 	require.NoError(t, err)
 	text := string(content)
-	// Secure defaults: SPV, loopback-only RPC listener, TLS left on.
+	// Secure defaults: SPV on, TLS untouched, and no pinned listener —
+	// oyster defaults to loopback on the active network's port, so the
+	// same conf must serve mainnet and testnet.
 	assert.Contains(t, text, "usespv=1")
-	assert.Contains(t, text, "rpclisten=127.0.0.1:"+cfg.activeNet.RPCServerPort)
+	assert.NotContains(t, text, "rpclisten=")
 	assert.NotContains(t, text, "noservertls")
-	assert.NotContains(t, text, "0.0.0.0")
 }
 
 func TestAutoProvisionRespectsExistingCredentials(t *testing.T) {
-	initUI(true)
 	cfg := &config{AppData: t.TempDir()}
 	cfg.activeNet = mainNetForTest()
 	original := "[Application Options]\nusername=existing\npassword=secret\nnoservertls=1\nlogdir=/custom\n"
@@ -54,7 +53,6 @@ func TestAutoProvisionRespectsExistingCredentials(t *testing.T) {
 }
 
 func TestAutoProvisionAppendsOnlyMissingCreds(t *testing.T) {
-	initUI(true)
 	cfg := &config{AppData: t.TempDir()}
 	cfg.activeNet = mainNetForTest()
 	// A conf that configures the backend but has no credentials (the
@@ -84,7 +82,6 @@ func TestAutoProvisionTightensPermsBeforeAppendingCreds(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("chmod semantics differ for root")
 	}
-	initUI(true)
 	cfg := &config{AppData: t.TempDir()}
 	cfg.activeNet = mainNetForTest()
 	// A world-readable conf without credentials: os.WriteFile alone would

--- a/wallet/cmd/oystercli/receive.go
+++ b/wallet/cmd/oystercli/receive.go
@@ -9,6 +9,7 @@ import (
 
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	"charm.land/lipgloss/v2/compat"
 	qrterminal "github.com/mdp/qrterminal/v3"
 	"github.com/pearl-research-labs/pearl/node/btcutil"
 )
@@ -80,7 +81,7 @@ func printQR(text string) {
 		HalfBlocks: true,
 		QuietZone:  2,
 	}
-	if th.isDark {
+	if compat.HasDarkBackground {
 		// Foreground blocks are light on dark terminals, so draw the QR
 		// background cells with blocks and leave the modules dark.
 		cfg.BlackChar = qrterminal.BLACK_BLACK

--- a/wallet/cmd/oystercli/security.go
+++ b/wallet/cmd/oystercli/security.go
@@ -51,7 +51,7 @@ func promptUnlock(c *client) (bool, error) {
 		huh.NewInput().
 			Title("Wallet passphrase").
 			EchoMode(huh.EchoModePassword).
-			Validate(nonEmpty("passphrase")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&passphrase),
 		huh.NewSelect[int64]().
 			Title("Stay unlocked for").
@@ -146,12 +146,12 @@ func changePassphraseFlow(c *client) error {
 		huh.NewInput().
 			Title("Current passphrase").
 			EchoMode(huh.EchoModePassword).
-			Validate(nonEmpty("passphrase")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&oldPass),
 		huh.NewInput().
 			Title("New passphrase").
 			EchoMode(huh.EchoModePassword).
-			Validate(nonEmpty("passphrase")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&newPass),
 		huh.NewInput().
 			Title("Repeat new passphrase").
@@ -183,7 +183,7 @@ func importKeyFlow(c *client) error {
 		huh.NewInput().
 			Title("Private key (WIF)").
 			EchoMode(huh.EchoModePassword).
-			Validate(nonEmpty("key")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&wif),
 		huh.NewConfirm().
 			Title("Rescan the chain for its history?").
@@ -254,7 +254,7 @@ func signMessageFlow(c *client) error {
 			Value(&address),
 		huh.NewText().
 			Title("Message").
-			Validate(nonEmpty("message")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&message),
 	)))
 	if err != nil || !ok {
@@ -283,11 +283,11 @@ func verifyMessageFlow(c *client) error {
 			Value(&address),
 		huh.NewInput().
 			Title("Signature (base64)").
-			Validate(nonEmpty("signature")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&signature),
 		huh.NewText().
 			Title("Message").
-			Validate(nonEmpty("message")).
+			Validate(huh.ValidateNotEmpty()).
 			Value(&message),
 	)))
 	if err != nil || !ok {

--- a/wallet/cmd/oystercli/theme.go
+++ b/wallet/cmd/oystercli/theme.go
@@ -2,35 +2,26 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-// Visual identity: the pearl palette, the shared lipgloss styles, and the
+// Visual identity: the shared lipgloss styles for printed output and the
 // huh theme/keymap adaptations.
 
 package main
 
 import (
-	"os"
-	"strings"
-
 	"charm.land/bubbles/v2/key"
 	"charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
 )
 
-// The pearl palette: nacre white, iridescent violet, and sea tones.
-var (
-	colorViolet = lipgloss.Color("#8B7CF6")
-	colorTeal   = lipgloss.Color("#2DD4BF")
-	colorPink   = lipgloss.Color("#F0A6CA")
-	colorGold   = lipgloss.Color("#E8C268")
-	colorRed    = lipgloss.Color("#ED567A")
-	colorGreen  = lipgloss.Color("#02BF87")
-)
-
-// ui holds the resolved styles for the detected terminal background. It is
-// initialized once at startup via initUI.
+// ui holds the shared styles for printed (non-form) output.
+//
+// Only the terminal's own palette is used: basic ANSI colors and text
+// attributes, which every terminal theme — light or dark — is responsible
+// for keeping readable. Plain text stays at the default foreground and
+// de-emphasis is the Faint attribute, so nothing here depends on background
+// detection. The one detection-dependent piece (QR contrast) reads
+// lipgloss's compat global.
 type ui struct {
-	isDark bool
-
 	title  lipgloss.Style
 	subtle lipgloss.Style
 	accent lipgloss.Style
@@ -42,77 +33,37 @@ type ui struct {
 	header lipgloss.Style
 }
 
-var th ui
-
-// detectDarkBackground guesses the terminal background without any terminal
-// I/O. Querying the terminal (lipgloss.HasDarkBackground) reads from stdin
-// and its response can race with the first huh form, which then sees the
-// leftover bytes as phantom input and auto-submits. The stakes are only
-// slightly-off colors in printed output (forms detect the background safely
-// themselves via Bubble Tea), so an environment heuristic is enough:
-// COLORFGBG is "<fg>;<bg>" (some terminals "<fg>;<default>;<bg>"), where a
-// background of 0-6 or 8 means dark. Unknown means dark, the common case.
-func detectDarkBackground() bool {
-	parts := strings.Split(os.Getenv("COLORFGBG"), ";")
-	if len(parts) < 2 {
-		return true
-	}
-	switch parts[len(parts)-1] {
-	case "7", "15":
-		return false
-	}
-	return true
+var th = ui{
+	title:  lipgloss.NewStyle().Foreground(lipgloss.Magenta).Bold(true),
+	subtle: lipgloss.NewStyle().Faint(true),
+	accent: lipgloss.NewStyle().Foreground(lipgloss.Cyan),
+	value:  lipgloss.NewStyle(),
+	good:   lipgloss.NewStyle().Foreground(lipgloss.Green),
+	warn:   lipgloss.NewStyle().Foreground(lipgloss.Yellow),
+	bad:    lipgloss.NewStyle().Foreground(lipgloss.Red),
+	box: lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.BrightBlack).
+		Padding(0, 2),
+	header: lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Magenta).
+		Padding(0, 2),
 }
 
-func initUI(isDark bool) {
-	ld := lipgloss.LightDark(isDark)
-	text := ld(lipgloss.Color("235"), lipgloss.Color("252"))
-	faint := ld(lipgloss.Color("246"), lipgloss.Color("243"))
-	borderCol := ld(lipgloss.Color("250"), lipgloss.Color("238"))
-
-	th = ui{
-		isDark: isDark,
-		title:  lipgloss.NewStyle().Foreground(colorViolet).Bold(true),
-		subtle: lipgloss.NewStyle().Foreground(faint),
-		accent: lipgloss.NewStyle().Foreground(colorTeal),
-		value:  lipgloss.NewStyle().Foreground(text),
-		good:   lipgloss.NewStyle().Foreground(colorGreen),
-		warn:   lipgloss.NewStyle().Foreground(colorGold),
-		bad:    lipgloss.NewStyle().Foreground(colorRed),
-		box: lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(borderCol).
-			Padding(0, 2),
-		header: lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorViolet).
-			Padding(0, 2),
-	}
-}
-
-// oysterTheme adapts the charm theme to the pearl palette.
+// oysterTheme is huh's stock charm theme with one workaround: menu option
+// foregrounds are unset so they render in the terminal's default color.
+// huh v2.0.3 always renders its light palette (nothing requests the terminal
+// background) whose option foreground is near-white — invisible on light
+// terminals. Both defects are fixed upstream in charmbracelet/huh#776;
+// once released, this collapses to a plain ThemeCharm.
 func oysterTheme() huh.Theme {
 	return huh.ThemeFunc(func(isDark bool) *huh.Styles {
 		t := huh.ThemeCharm(isDark)
-		ld := lipgloss.LightDark(isDark)
-
-		t.Focused.Title = t.Focused.Title.Foreground(colorViolet).Bold(true)
-		t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(colorViolet).Bold(true)
-		t.Focused.Description = t.Focused.Description.Foreground(ld(lipgloss.Color("246"), lipgloss.Color("243")))
-		t.Focused.SelectSelector = t.Focused.SelectSelector.Foreground(colorTeal).SetString("❯ ")
-		t.Focused.NextIndicator = t.Focused.NextIndicator.Foreground(colorTeal)
-		t.Focused.PrevIndicator = t.Focused.PrevIndicator.Foreground(colorTeal)
-		t.Focused.MultiSelectSelector = t.Focused.MultiSelectSelector.Foreground(colorTeal).SetString("❯ ")
-		t.Focused.SelectedOption = t.Focused.SelectedOption.Foreground(colorTeal)
-		t.Focused.SelectedPrefix = t.Focused.SelectedPrefix.Foreground(colorGreen)
-		t.Focused.FocusedButton = t.Focused.FocusedButton.Background(colorViolet)
-		t.Focused.TextInput.Prompt = t.Focused.TextInput.Prompt.Foreground(colorTeal)
-		t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(colorPink)
-		t.Focused.ErrorIndicator = t.Focused.ErrorIndicator.Foreground(colorRed)
-		t.Focused.ErrorMessage = t.Focused.ErrorMessage.Foreground(colorRed)
-
-		t.Blurred.Title = t.Blurred.Title.Foreground(colorViolet)
-		t.Blurred.TextInput.Prompt = t.Blurred.TextInput.Prompt.Foreground(colorTeal)
+		t.Focused.Option = t.Focused.Option.UnsetForeground()
+		t.Focused.UnselectedOption = t.Focused.UnselectedOption.UnsetForeground()
+		t.Blurred.Option = t.Blurred.Option.UnsetForeground()
+		t.Blurred.UnselectedOption = t.Blurred.UnselectedOption.UnsetForeground()
 		return t
 	})
 }

--- a/wallet/cmd/oystercli/triage.go
+++ b/wallet/cmd/oystercli/triage.go
@@ -51,11 +51,15 @@ func runTriage(cfg *config, connectErr error) (bool, error) {
 		opQuit   = "quit"
 	)
 	opts := []huh.Option[string]{}
-	if !cfg.walletDBExists() {
-		opts = append(opts, huh.NewOption("Create a wallet   new or restored from seed", opCreate))
-	}
-	if confHasCredentials(cfg) && cfg.walletDBExists() && kind != triageAuth {
-		opts = append(opts, huh.NewOption("Start oyster now  spawn the daemon and connect", opStart))
+	// Wallet creation and daemon spawning act on this machine, so they are
+	// only offered for local targets.
+	if !cfg.remoteTarget() {
+		if !cfg.walletDBExists() {
+			opts = append(opts, huh.NewOption("Create a wallet   new or restored from seed", opCreate))
+		}
+		if confHasCredentials(cfg) && cfg.walletDBExists() && kind != triageAuth {
+			opts = append(opts, huh.NewOption("Start oyster now  spawn the daemon and connect", opStart))
+		}
 	}
 	opts = append(opts,
 		huh.NewOption("Retry connection", opRetry),
@@ -99,7 +103,9 @@ func runTriage(cfg *config, connectErr error) (bool, error) {
 // classifyConnectError distinguishes the common cold start failures so the
 // advice can be specific.
 func classifyConnectError(cfg *config, err error) triageKind {
-	if !cfg.walletDBExists() {
+	// A missing local wallet.db only explains local failures; a remote
+	// daemon has its own wallet.
+	if !cfg.remoteTarget() && !cfg.walletDBExists() {
 		return triageNoWallet
 	}
 	msg := strings.ToLower(err.Error())
@@ -128,6 +134,11 @@ func triageAdvice(cfg *config, kind triageKind) string {
 			"No wallet database found at %s.\nIt looks like this machine has no %s wallet yet.",
 			cfg.walletDBPath(), cfg.activeNet.Params.Name)
 	case triageNotRunning:
+		if cfg.remoteTarget() {
+			return fmt.Sprintf(
+				"Nothing is answering at %s.\nOn the remote machine, check that oyster is running with an rpclisten\ncovering this address and that its firewall allows the port. The\ncredentials and --cafile certificate must be that daemon's.",
+				cfg.Connect)
+		}
 		advice := fmt.Sprintf("Nothing is listening at %s, so the daemon is most likely not running.", cfg.Connect)
 		_, _, findErr := findOysterBinary(cfg)
 		switch {
@@ -153,6 +164,9 @@ func triageAdvice(cfg *config, kind triageKind) string {
 // make it unreachable for other clients.
 func desktopWalletNote(cfg *config, kind triageKind) string {
 	const desktopAddr = "127.0.0.1:8335"
+	if cfg.remoteTarget() {
+		return ""
+	}
 	if kind != triageNotRunning && kind != triageNoWallet {
 		return ""
 	}

--- a/wallet/cmd/oystercli/triage_test.go
+++ b/wallet/cmd/oystercli/triage_test.go
@@ -17,6 +17,9 @@ func TestClassifyConnectError(t *testing.T) {
 
 	cfgWithWallet := configWithWalletDB(t)
 
+	cfgRemote := &config{AppData: t.TempDir(), Connect: "wallet.example.com:44207"}
+	cfgRemote.activeNet = mainNetForTest()
+
 	tests := []struct {
 		name string
 		cfg  *config
@@ -24,6 +27,9 @@ func TestClassifyConnectError(t *testing.T) {
 		want triageKind
 	}{
 		{"missing wallet wins", cfgNoWallet, errors.New("connection refused"), triageNoWallet},
+		// A remote daemon has its own wallet: the local wallet.db must
+		// not steer triage toward creating one here.
+		{"remote ignores local wallet", cfgRemote, errors.New("connection refused"), triageNotRunning},
 		{"refused", cfgWithWallet, errors.New("dial tcp 127.0.0.1:44207: connection refused"), triageNotRunning},
 		{"timeout", cfgWithWallet, errors.New("i/o timeout"), triageNotRunning},
 		{"tls", cfgWithWallet, errors.New("x509: certificate signed by unknown authority"), triageTLS},

--- a/wallet/cmd/oystercli/ui.go
+++ b/wallet/cmd/oystercli/ui.go
@@ -48,16 +48,6 @@ func runForm(f *huh.Form) (bool, error) {
 	return false, err
 }
 
-// nonEmpty validates required text inputs.
-func nonEmpty(what string) func(string) error {
-	return func(s string) error {
-		if len(s) == 0 {
-			return fmt.Errorf("%s is required", what)
-		}
-		return nil
-	}
-}
-
 // spinnerDelay is how long an operation may run before a spinner appears.
 const spinnerDelay = 150 * time.Millisecond
 


### PR DESCRIPTION
## Summary

Follow-ups to #244 from field-testing oystercli against real wallets, light terminals, testnet, and remote setups. Two commits.

### Restore recovery fix (`c581cf02`)

Restoring a wallet from seed without a birthday produced an empty wallet: oyster starts the recovery scan at the birthday and defaults a missing `Bday` to `time.Now()`, silently skipping all history (the desktop wallet hardcodes a pre-genesis birthday, which is why the same seed imported fine there). An empty birthday now sends the chain's genesis time — scan everything — and the field description says so instead of presenting the birthday as an optimization.

### Multi-network, remote daemons, library-first internals (`3bdd91e4`)

- **One conf, every network.** Auto-provisioned configs no longer pin `rpclisten` — oyster's own default is loopback-only listeners on the active network's port — so the same `oyster.conf` serves mainnet and testnet daemons side by side, and `oystercli --testnet` works end to end (per-network wallet dir, `--testnet` passed through to create/start, port 44209).
- **The conf is the source of truth for dialing.** An explicit `rpclisten` in an existing conf (e.g. the release installer's) is where the daemon listens, so oystercli now dials it, with wildcard hosts mapped to loopback and provenance shown as `oyster.conf (rpclisten)`.
- **Remote daemons.** Non-loopback connect targets skip local bootstrapping entirely: no auto-provisioning, no local wallet-creation/daemon-start offers in triage, and remote-appropriate not-running advice (remote `rpclisten`, firewall, credentials, certificate). Supported patterns documented in the README: direct flags with a copied `rpc.cert`, SSH tunnel (generated certs always cover localhost), or a dedicated client appdata dir.
- **Terminal-theme readability.** The custom hex palette is gone. Printed output uses only basic ANSI colors plus the Faint attribute — readable on any terminal theme, light or dark. Forms use huh's stock `ThemeCharm` with a single workaround (option foregrounds unset to the terminal default): huh v2.0.3 always renders its light palette, whose option foreground is near-white — invisible on light terminals (e.g. Warp Light). Both defects are fixed upstream in charmbracelet/huh#776; when released, the wrapper collapses to a plain `ThemeCharm`.
- **Library-first internals.** `oyster.conf` is parsed with go-flags' ini parser (the daemon's own format machinery) instead of regexes; required-field validation uses `huh.ValidateNotEmpty`; first-non-empty selection uses `cmp.Or`. The log sanitizer deliberately stays custom — `x/ansi.Strip` passes bare C0 controls through, which would defeat the escape-injection defense (documented in code).

## Test plan

- [x] `go test -race` on `wallet/cmd/oystercli` and `wallet/cmd/seedscan`; `go vet`, `gofmt` clean
- [x] Restore with empty birthday recovers funds from genesis (verified against a live wallet + Blockbook)
- [x] Conf with pinned `rpclisten` is dialed at that address (live smoke, provenance shows `oyster.conf (rpclisten)`)
- [x] Remote target: no config provisioned, triage offers no local create/start (smoke against blackhole address)
- [x] Hand-check menu/status readability in Warp light and dark (stock ThemeCharm confirmed unreadable on light; workaround build readable)
- [ ] `oystercli --testnet` cold start: provision → create wallet → start daemon → connect on 44209

