### PR TITLE
feat(wallet): use DNS seeders for peer discovery with optional custom peer

### DIFF
--- a/apps/apps/pearl-desktop-wallet/src/main/config/consts.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/config/consts.ts
@@ -1,5 +1,32 @@
-export const MAINNET_DEFAULT_PEER_ADDRESSES = ['wallet-node0.pearlresearch.ai', 'wallet-node1.pearlresearch.ai', 'wallet-node2.pearlresearch.ai', 'wallet-node3.pearlresearch.ai', 'wallet-node4.pearlresearch.ai'];
-export const TESTNET_DEFAULT_PEER_ADDRESSES = ['node1.testnet.pearlresearch.ai', 'node2.testnet.pearlresearch.ai', 'node3.testnet.pearlresearch.ai'];
+// DNS seeders used by the oyster daemon for automatic peer discovery.
+// These match the DNSSeeds in node/chaincfg/params.go and are queried by the
+// node itself at startup — no --addpeer flag is needed.
+export const MAINNET_DNS_SEEDERS = [
+  'seeder1.pearlresearch.ai',
+  'seeder2.pearlresearch.ai',
+  'seeder3.pearlresearch.ai',
+];
+export const TESTNET_DNS_SEEDERS = [
+  'seeder1.testnet.pearlresearch.ai',
+  'seeder2.testnet.pearlresearch.ai',
+  'seeder3.testnet.pearlresearch.ai',
+];
+
+// Legacy hardcoded peer hosts from older wallet versions. Kept only so stale
+// peer-settings.json entries (saved as custom --addpeer targets) are detected
+// and ignored, falling back to DNS-seeder-based discovery.
+export const LEGACY_MAINNET_PEER_ADDRESSES = [
+  'wallet-node0.pearlresearch.ai',
+  'wallet-node1.pearlresearch.ai',
+  'wallet-node2.pearlresearch.ai',
+  'wallet-node3.pearlresearch.ai',
+  'wallet-node4.pearlresearch.ai',
+];
+export const LEGACY_TESTNET_PEER_ADDRESSES = [
+  'node1.testnet.pearlresearch.ai',
+  'node2.testnet.pearlresearch.ai',
+  'node3.testnet.pearlresearch.ai',
+];
 
 export const UPDATE_REPO_OWNER = 'pearl-research-labs';
 export const UPDATE_REPO_NAME = 'pearl';

--- a/apps/apps/pearl-desktop-wallet/src/main/config/consts.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/config/consts.ts
@@ -1,17 +1,3 @@
-// DNS seeders used by the oyster daemon for automatic peer discovery.
-// These match the DNSSeeds in node/chaincfg/params.go and are queried by the
-// node itself at startup — no --addpeer flag is needed.
-export const MAINNET_DNS_SEEDERS = [
-  'seeder1.pearlresearch.ai',
-  'seeder2.pearlresearch.ai',
-  'seeder3.pearlresearch.ai',
-];
-export const TESTNET_DNS_SEEDERS = [
-  'seeder1.testnet.pearlresearch.ai',
-  'seeder2.testnet.pearlresearch.ai',
-  'seeder3.testnet.pearlresearch.ai',
-];
-
 // Legacy hardcoded peer hosts from older wallet versions. Kept only so stale
 // peer-settings.json entries (saved as custom --addpeer targets) are detected
 // and ignored, falling back to DNS-seeder-based discovery.

--- a/apps/apps/pearl-desktop-wallet/src/main/config/network-config.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/config/network-config.ts
@@ -3,7 +3,7 @@
  * All network-specific settings should be consumed from here
  */
 
-import { MAINNET_DEFAULT_PEER_ADDRESSES, TESTNET_DEFAULT_PEER_ADDRESSES } from "./consts";
+import { MAINNET_DNS_SEEDERS, TESTNET_DNS_SEEDERS } from "./consts";
 
 export type Network = 'mainnet' | 'testnet';
 
@@ -14,19 +14,8 @@ export interface NetworkConfig {
     walletFlag: string;
     dataSubdir: string;
     addressPrefix: string;
-    defaultPeerAddress: string;
-    defaultPeerPort: number;
+    dnsSeeders: string[];
 }
-
-// Pick a random default peer per network. The two lists can differ in length,
-// so index into each independently using its own length instead of sharing a
-// single `Math.random() * 3` index (which never selected peers beyond the
-// third entry, and reused one index across both lists).
-const pickRandomPeer = (peers: readonly string[]): string =>
-    peers[Math.floor(Math.random() * peers.length)];
-
-const mainnetDefaultPeerAddress = pickRandomPeer(MAINNET_DEFAULT_PEER_ADDRESSES);
-const testnetDefaultPeerAddress = pickRandomPeer(TESTNET_DEFAULT_PEER_ADDRESSES);
 
 const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
     mainnet: {
@@ -36,8 +25,7 @@ const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
         walletFlag: '',  // No flag for mainnet (default)
         dataSubdir: 'mainnet',
         addressPrefix: 'prl1',
-        defaultPeerAddress: mainnetDefaultPeerAddress,
-        defaultPeerPort: 44108,
+        dnsSeeders: MAINNET_DNS_SEEDERS,
     },
     testnet: {
         name: 'testnet',
@@ -46,8 +34,7 @@ const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
         walletFlag: '--testnet2',
         dataSubdir: 'testnet2',
         addressPrefix: 'tprl1',
-        defaultPeerAddress: testnetDefaultPeerAddress,
-        defaultPeerPort: 44112,
+        dnsSeeders: TESTNET_DNS_SEEDERS,
     },
 };
 

--- a/apps/apps/pearl-desktop-wallet/src/main/config/network-config.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/config/network-config.ts
@@ -3,8 +3,6 @@
  * All network-specific settings should be consumed from here
  */
 
-import { MAINNET_DNS_SEEDERS, TESTNET_DNS_SEEDERS } from "./consts";
-
 export type Network = 'mainnet' | 'testnet';
 
 export interface NetworkConfig {
@@ -14,7 +12,6 @@ export interface NetworkConfig {
     walletFlag: string;
     dataSubdir: string;
     addressPrefix: string;
-    dnsSeeders: string[];
 }
 
 const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
@@ -25,7 +22,6 @@ const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
         walletFlag: '',  // No flag for mainnet (default)
         dataSubdir: 'mainnet',
         addressPrefix: 'prl1',
-        dnsSeeders: MAINNET_DNS_SEEDERS,
     },
     testnet: {
         name: 'testnet',
@@ -34,7 +30,6 @@ const NETWORK_CONFIGS: Record<Network, NetworkConfig> = {
         walletFlag: '--testnet2',
         dataSubdir: 'testnet2',
         addressPrefix: 'tprl1',
-        dnsSeeders: TESTNET_DNS_SEEDERS,
     },
 };
 

--- a/apps/apps/pearl-desktop-wallet/src/main/config/peer-settings.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/config/peer-settings.ts
@@ -1,11 +1,16 @@
 /**
- * Peer settings management - allows users to configure custom peer addresses per network
+ * Peer settings management.
+ *
+ * By default the wallet relies on the oyster daemon's built-in DNS seeding
+ * (seeder1/2/3.pearlresearch.ai) — no --addpeer flag is passed. Users can
+ * optionally configure a custom peer (IPv4 or CNAME) that is forwarded to the
+ * daemon via --addpeer, matching the legacy behaviour.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { getCurrentNetwork, getCurrentNetworkConfig } from './network-config';
-import { MAINNET_DEFAULT_PEER_ADDRESSES, TESTNET_DEFAULT_PEER_ADDRESSES } from './consts';
+import { LEGACY_MAINNET_PEER_ADDRESSES, LEGACY_TESTNET_PEER_ADDRESSES } from './consts';
 
 interface NetworkPeerSettings {
   customPeerAddress?: string;
@@ -66,26 +71,33 @@ function savePeerSettings(settings: NetworkPeerSettings) {
   }
 }
 
-// Get current peer address (custom or default) for active network
-export function getPeerAddress(): string {
-  const settings = loadPeerSettings();
-  if (settings.customPeerAddress) {
-    return settings.customPeerAddress;
-  }
-
-  const networkConfig = getCurrentNetworkConfig();
-  return networkConfig.defaultPeerAddress;
+// Returns true when the saved custom peer is one of the legacy hardcoded
+// hosts. Those addresses are no longer valid defaults, so we treat them as
+// "no custom peer" and fall back to DNS-seeder-based discovery.
+function isLegacyPeer(address: string): boolean {
+  const network = getCurrentNetwork();
+  const legacy =
+    network === 'mainnet' ? LEGACY_MAINNET_PEER_ADDRESSES : LEGACY_TESTNET_PEER_ADDRESSES;
+  return legacy.includes(address);
 }
 
-// Get current peer port (custom or default) for active network
-export function getPeerPort(): number {
+export interface CustomPeer {
+  address: string;
+  port: number;
+}
+
+// Get the user-configured custom peer, or null when none is set (in which case
+// the daemon falls back to DNS seeding).
+export function getCustomPeer(): CustomPeer | null {
   const settings = loadPeerSettings();
-  if (settings.customPeerPort) {
-    return settings.customPeerPort;
+  const address = settings.customPeerAddress?.trim();
+  const port = settings.customPeerPort;
+
+  if (!address || !port || isLegacyPeer(address)) {
+    return null;
   }
 
-  const networkConfig = getCurrentNetworkConfig();
-  return networkConfig.defaultPeerPort;
+  return { address, port };
 }
 
 // Set custom peer address for the active network only
@@ -96,7 +108,7 @@ export function setCustomPeer(address: string, port: number) {
   savePeerSettings(settings);
 }
 
-// Reset to default peer for the active network only
+// Reset to default (DNS seeders) for the active network only
 export function resetToDefaultPeer() {
   const settings = loadPeerSettings();
   delete settings.customPeerAddress;
@@ -108,18 +120,13 @@ export function resetToDefaultPeer() {
 export function getPeerSettings() {
   const network = getCurrentNetwork();
   const networkConfig = getCurrentNetworkConfig();
-  const settings = loadPeerSettings();
-
-  const defaultAddresses =
-    network === 'mainnet' ? MAINNET_DEFAULT_PEER_ADDRESSES : TESTNET_DEFAULT_PEER_ADDRESSES;
-  const isDefaultFoundationNode = defaultAddresses.includes(settings.customPeerAddress ?? '');
+  const customPeer = getCustomPeer();
 
   return {
     network,
-    currentAddress: getPeerAddress(),
-    currentPort: getPeerPort(),
-    defaultAddress: networkConfig.defaultPeerAddress,
-    defaultPort: networkConfig.defaultPeerPort,
-    isCustom: (settings.customPeerAddress && !isDefaultFoundationNode) || false,
+    dnsSeeders: networkConfig.dnsSeeders,
+    customPeerAddress: customPeer?.address ?? '',
+    customPeerPort: customPeer?.port,
+    isCustom: customPeer !== null,
   };
 }

--- a/apps/apps/pearl-desktop-wallet/src/main/config/peer-settings.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/config/peer-settings.ts
@@ -2,14 +2,13 @@
  * Peer settings management.
  *
  * By default the wallet relies on the oyster daemon's built-in DNS seeding
- * (seeder1/2/3.pearlresearch.ai) — no --addpeer flag is passed. Users can
- * optionally configure a custom peer (IPv4 or CNAME) that is forwarded to the
- * daemon via --addpeer, matching the legacy behaviour.
+ * — no --addpeer flag is passed. Users can optionally configure a custom peer
+ * (IPv4 or CNAME) that is forwarded to the daemon via --addpeer.
  */
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
-import { getCurrentNetwork, getCurrentNetworkConfig } from './network-config';
+import { getCurrentNetwork } from './network-config';
 import { LEGACY_MAINNET_PEER_ADDRESSES, LEGACY_TESTNET_PEER_ADDRESSES } from './consts';
 
 interface NetworkPeerSettings {
@@ -32,6 +31,16 @@ function ensureSettingsDir() {
   }
 }
 
+// Returns true when the saved custom peer is one of the legacy hardcoded
+// hosts. Those addresses are no longer valid defaults, so stale
+// peer-settings.json entries are cleared on load (migration).
+function isLegacyPeer(address: string): boolean {
+  const network = getCurrentNetwork();
+  const legacy =
+    network === 'mainnet' ? LEGACY_MAINNET_PEER_ADDRESSES : LEGACY_TESTNET_PEER_ADDRESSES;
+  return legacy.includes(address);
+}
+
 function loadAllNetworksPeerSettings(): AllNetworksPeerSettings {
   ensureSettingsDir();
 
@@ -51,10 +60,20 @@ function loadAllNetworksPeerSettings(): AllNetworksPeerSettings {
   return { mainnet: {}, testnet: {} };
 }
 
-// Load peer settings for the current network
+// Load peer settings for the current network, migrating stale legacy entries.
 function loadPeerSettings(): NetworkPeerSettings {
-  const peerSettings = loadAllNetworksPeerSettings();
-  return peerSettings[getCurrentNetwork()] ?? {};
+  const allSettings = loadAllNetworksPeerSettings();
+  const settings = allSettings[getCurrentNetwork()] ?? {};
+
+  // Migration: if the saved custom peer is a legacy hardcoded host, clear it
+  // so the wallet falls back to DNS seeding. This only runs on load — the
+  // user can still intentionally save any address afterwards.
+  if (settings.customPeerAddress && isLegacyPeer(settings.customPeerAddress)) {
+    delete settings.customPeerAddress;
+    delete settings.customPeerPort;
+  }
+
+  return settings;
 }
 
 // Save peer settings for the current network
@@ -71,16 +90,6 @@ function savePeerSettings(settings: NetworkPeerSettings) {
   }
 }
 
-// Returns true when the saved custom peer is one of the legacy hardcoded
-// hosts. Those addresses are no longer valid defaults, so we treat them as
-// "no custom peer" and fall back to DNS-seeder-based discovery.
-function isLegacyPeer(address: string): boolean {
-  const network = getCurrentNetwork();
-  const legacy =
-    network === 'mainnet' ? LEGACY_MAINNET_PEER_ADDRESSES : LEGACY_TESTNET_PEER_ADDRESSES;
-  return legacy.includes(address);
-}
-
 export interface CustomPeer {
   address: string;
   port: number;
@@ -93,7 +102,7 @@ export function getCustomPeer(): CustomPeer | null {
   const address = settings.customPeerAddress?.trim();
   const port = settings.customPeerPort;
 
-  if (!address || !port || isLegacyPeer(address)) {
+  if (!address || !port) {
     return null;
   }
 
@@ -119,12 +128,10 @@ export function resetToDefaultPeer() {
 // Get peer settings info for the active network
 export function getPeerSettings() {
   const network = getCurrentNetwork();
-  const networkConfig = getCurrentNetworkConfig();
   const customPeer = getCustomPeer();
 
   return {
     network,
-    dnsSeeders: networkConfig.dnsSeeders,
     customPeerAddress: customPeer?.address ?? '',
     customPeerPort: customPeer?.port,
     isCustom: customPeer !== null,

--- a/apps/apps/pearl-desktop-wallet/src/main/services/manager-service.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/services/manager-service.ts
@@ -9,7 +9,7 @@ import { WalletService } from './wallet-service/wallet-service.ts';
 import { WalletProcess } from './wallet-process.ts';
 import { displayToFs, fsToDisplay } from '../../utils/filename-utils.ts';
 import { getCurrentNetworkConfig, getCurrentNetwork, setCurrentNetwork, getAllNetworks, type Network } from '../config/network-config';
-import { getPeerAddress, getPeerPort, getPeerSettings as getConfigPeerSettings, setCustomPeer, resetToDefaultPeer } from '../config/peer-settings';
+import { getCustomPeer, getPeerSettings as getConfigPeerSettings, setCustomPeer, resetToDefaultPeer } from '../config/peer-settings';
 import { randomBytes } from 'crypto';
 
 
@@ -34,13 +34,14 @@ const baseWalletDir = path.join(os.homedir(), '.pearl-wallet', 'wallet-data');
 
 function getBaseConfig() {
   const networkConfig = getCurrentNetworkConfig();
+  const customPeer = getCustomPeer();
   return {
     rpcHost: 'http://127.0.0.1',
     ...getSessionRpcCreds(),
     rpcPort: networkConfig.rpcPort,
     network: networkConfig.name,
-    peerAddress: getPeerAddress(),
-    peerPort: getPeerPort(),
+    peerAddress: customPeer?.address,
+    peerPort: customPeer?.port,
   };
 }
 
@@ -136,19 +137,24 @@ class ManagerService implements ManagerApi {
   }
 
   async selectWallet(walletName: string) {
-    // Validate peer before starting wallet
-    const peerAddress = getPeerAddress();
-    const peerPort = getPeerPort();
+    // Validate custom peer before starting wallet (if one is configured).
+    // When no custom peer is set the daemon falls back to DNS seeding, so
+    // there is nothing to pre-validate here.
+    const customPeer = getCustomPeer();
 
-    console.log(`[ManagerService] Validating peer before starting wallet: ${peerAddress}:${peerPort}`);
-    const validation = await this.validatePeerAddress(peerAddress, peerPort);
+    if (customPeer) {
+      console.log(`[ManagerService] Validating custom peer before starting wallet: ${customPeer.address}:${customPeer.port}`);
+      const validation = await this.validatePeerAddress(customPeer.address, customPeer.port);
 
-    if (!validation.valid) {
-      console.error(`[ManagerService] ❌ Peer validation failed: ${validation.error}`);
-      throw new Error(validation.error || 'Cannot connect to peer node');
+      if (!validation.valid) {
+        console.error(`[ManagerService] ❌ Peer validation failed: ${validation.error}`);
+        throw new Error(validation.error || 'Cannot connect to peer node');
+      }
+
+      console.log(`[ManagerService] ✅ Peer validation passed, starting wallet...`);
+    } else {
+      console.log(`[ManagerService] No custom peer configured — relying on DNS seeders for peer discovery`);
     }
-
-    console.log(`[ManagerService] ✅ Peer validation passed, starting wallet...`);
 
     try {
       await this.stopWalletProcess();

--- a/apps/apps/pearl-desktop-wallet/src/main/services/manager-service.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/services/manager-service.ts
@@ -139,7 +139,9 @@ class ManagerService implements ManagerApi {
   async selectWallet(walletName: string) {
     // Validate custom peer before starting wallet (if one is configured).
     // When no custom peer is set the daemon falls back to DNS seeding, so
-    // there is nothing to pre-validate here.
+    // there is nothing to pre-validate here. If a custom peer is set but
+    // unreachable, we warn and continue — the daemon still discovers peers
+    // via DNS seeding.
     const customPeer = getCustomPeer();
 
     if (customPeer) {
@@ -147,11 +149,10 @@ class ManagerService implements ManagerApi {
       const validation = await this.validatePeerAddress(customPeer.address, customPeer.port);
 
       if (!validation.valid) {
-        console.error(`[ManagerService] ❌ Peer validation failed: ${validation.error}`);
-        throw new Error(validation.error || 'Cannot connect to peer node');
+        console.warn(`[ManagerService] ⚠️ Custom peer unreachable: ${validation.error}. Falling back to DNS seeders.`);
+      } else {
+        console.log(`[ManagerService] ✅ Peer validation passed, starting wallet...`);
       }
-
-      console.log(`[ManagerService] ✅ Peer validation passed, starting wallet...`);
     } else {
       console.log(`[ManagerService] No custom peer configured — relying on DNS seeders for peer discovery`);
     }

--- a/apps/apps/pearl-desktop-wallet/src/main/services/wallet-process.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/services/wallet-process.ts
@@ -26,8 +26,8 @@ interface WalletProcessConfig {
   dataDir: string;
   rpcUser: string;
   rpcPassword: string;
-  peerAddress: string;
-  peerPort: number;
+  peerAddress?: string;
+  peerPort?: number;
 }
 
 class WalletProcess {
@@ -86,7 +86,6 @@ class WalletProcess {
     const networkConfig = getCurrentNetworkConfig();
     const args = [
       '--usespv',
-      `--addpeer=${this.config.peerAddress}:${this.config.peerPort}`,
       `--appdata=${this.config.dataDir}`,
       `--username=${this.config.rpcUser}`,
       `--password=${this.config.rpcPassword}`,
@@ -94,9 +93,16 @@ class WalletProcess {
       '--noservertls',
     ];
 
+    // Only pass --addpeer when the user has configured a custom peer.
+    // Otherwise the daemon falls back to its built-in DNS seeding
+    // (seeder1/2/3.pearlresearch.ai — see node/chaincfg/params.go).
+    if (this.config.peerAddress && this.config.peerPort) {
+      args.push(`--addpeer=${this.config.peerAddress}:${this.config.peerPort}`);
+    }
+
     // Add network flag if not mainnet
     if (networkConfig.walletFlag) {
-      args.splice(2, 0, networkConfig.walletFlag);
+      args.splice(1, 0, networkConfig.walletFlag);
     }
 
     return args;

--- a/apps/apps/pearl-desktop-wallet/src/renderer/src/components/PeerSettingsModal.tsx
+++ b/apps/apps/pearl-desktop-wallet/src/renderer/src/components/PeerSettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { X, RotateCcw, Save } from 'lucide-react';
+import { X, RotateCcw, Save, Globe, Server } from 'lucide-react';
 import { Button } from '@pearl/ui/components/button';
 
 interface PeerSettingsModalProps {
@@ -10,8 +10,7 @@ interface PeerSettingsModalProps {
 export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
     const [peerAddress, setPeerAddress] = useState('');
     const [peerPort, setPeerPort] = useState('');
-    const [defaultAddress, setDefaultAddress] = useState('');
-    const [defaultPort, setDefaultPort] = useState('');
+    const [dnsSeeders, setDnsSeeders] = useState<string[]>([]);
     const [isCustom, setIsCustom] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [network, setNetwork] = useState('');
@@ -25,10 +24,9 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
     const loadPeerSettings = async () => {
         try {
             const settings = await window.appBridge.manager.getPeerSettings();
-            setPeerAddress(settings.currentAddress);
-            setPeerPort(String(settings.currentPort));
-            setDefaultAddress(settings.defaultAddress);
-            setDefaultPort(String(settings.defaultPort));
+            setPeerAddress(settings.customPeerAddress ?? '');
+            setPeerPort(settings.customPeerPort ? String(settings.customPeerPort) : '');
+            setDnsSeeders(settings.dnsSeeders ?? []);
             setIsCustom(settings.isCustom);
             setNetwork(settings.network);
         } catch (error) {
@@ -37,15 +35,42 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
     };
 
     const handleSave = async () => {
+        const address = peerAddress.trim();
+        const portStr = peerPort.trim();
+
+        // Both fields empty → clear the custom peer and fall back to DNS seeders
+        if (!address && !portStr) {
+            setIsSaving(true);
+            try {
+                await window.appBridge.manager.resetPeerToDefault();
+                await loadPeerSettings();
+                alert('Custom peer cleared. DNS seeders will be used. Please restart the wallet for changes to take effect.');
+                onClose();
+            } catch (error) {
+                console.error('Failed to clear peer settings:', error);
+                alert('Failed to clear settings');
+            } finally {
+                setIsSaving(false);
+            }
+            return;
+        }
+
+        // If one field is filled, the other must be too
+        if (!address || !portStr) {
+            alert('Please fill in both peer address and port, or leave both empty to use DNS seeders.');
+            return;
+        }
+
+        const port = parseInt(portStr, 10);
+        if (isNaN(port) || port < 1 || port > 65535) {
+            alert('Invalid port number');
+            return;
+        }
+
         setIsSaving(true);
         try {
-            const port = parseInt(peerPort, 10);
-            if (isNaN(port) || port < 1 || port > 65535) {
-                alert('Invalid port number');
-                return;
-            }
-
-            await window.appBridge.manager.setCustomPeerAddress(peerAddress, port);
+            await window.appBridge.manager.setCustomPeerAddress(address, port);
+            await loadPeerSettings();
             alert('Peer settings saved! Please restart the wallet for changes to take effect.');
             onClose();
         } catch (error) {
@@ -61,7 +86,7 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
         try {
             await window.appBridge.manager.resetPeerToDefault();
             await loadPeerSettings();
-            alert('Peer settings reset to default! Please restart the wallet for changes to take effect.');
+            alert('Reset to DNS seeders. Please restart the wallet for changes to take effect.');
         } catch (error) {
             console.error('Failed to reset peer settings:', error);
             alert('Failed to reset settings');
@@ -95,32 +120,56 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
 
                 {/* Form */}
                 <div className="space-y-4">
-                    <div>
-                        <label className="mb-1 block text-sm font-medium text-gray-700">Peer Address</label>
-                        <input
-                            type="text"
-                            value={peerAddress}
-                            onChange={(e) => setPeerAddress(e.target.value)}
-                            placeholder="127.0.0.1 or IP address"
-                            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500/20"
-                        />
+                    {/* DNS Seeders (default discovery) */}
+                    <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+                        <div className="mb-2 flex items-center gap-2">
+                            <Globe className="h-4 w-4 text-green-600" />
+                            <span className="text-sm font-semibold text-gray-700">Default Peer Discovery</span>
+                        </div>
+                        <p className="mb-2 text-xs text-gray-500">
+                            The wallet automatically discovers peers via Pearl DNS seeders:
+                        </p>
+                        <ul className="space-y-1">
+                            {dnsSeeders.map((seeder) => (
+                                <li key={seeder} className="flex items-center gap-2 text-xs text-gray-600">
+                                    <span className="h-1 w-1 rounded-full bg-gray-400" />
+                                    {seeder}
+                                </li>
+                            ))}
+                        </ul>
                     </div>
 
+                    {/* Custom Peer (optional) */}
                     <div>
-                        <label className="mb-1 block text-sm font-medium text-gray-700">Peer Port</label>
-                        <input
-                            type="number"
-                            value={peerPort}
-                            onChange={(e) => setPeerPort(e.target.value)}
-                            placeholder="8333"
-                            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500/20"
-                        />
+                        <div className="mb-2 flex items-center gap-2">
+                            <Server className="h-4 w-4 text-gray-500" />
+                            <label className="text-sm font-medium text-gray-700">Custom Peer (optional)</label>
+                        </div>
+                        <p className="mb-2 text-xs text-gray-500">
+                            Add a specific peer (IP address or hostname) to connect to at startup. Leave empty to use DNS seeders.
+                        </p>
+                        <div className="space-y-2">
+                            <input
+                                type="text"
+                                value={peerAddress}
+                                onChange={(e) => setPeerAddress(e.target.value)}
+                                placeholder="e.g. 192.168.1.1 or my-node.example.com"
+                                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500/20"
+                            />
+                            <input
+                                type="number"
+                                value={peerPort}
+                                onChange={(e) => setPeerPort(e.target.value)}
+                                placeholder="Port (e.g. 44108)"
+                                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 focus:border-green-500 focus:outline-none focus:ring-2 focus:ring-green-500/20"
+                            />
+                        </div>
                     </div>
 
                     {isCustom && (
                         <div className="rounded-lg bg-blue-50 p-3">
                             <p className="text-sm text-blue-700">
-                                <strong>Default:</strong> {defaultAddress}:{defaultPort}
+                                A custom peer is currently configured. The wallet will connect to it in addition to DNS-discovered peers.
                             </p>
                         </div>
                     )}
@@ -130,16 +179,16 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
                         <Button
                             onClick={handleReset}
                             variant="outline"
-                            disabled={isSaving}
+                            disabled={isSaving || !isCustom}
                             className="flex-1"
                         >
                             <RotateCcw className="mr-2 h-4 w-4" />
-                            Reset to Default
+                            Use DNS Seeders
                         </Button>
 
                         <Button
                             onClick={handleSave}
-                            disabled={isSaving || !peerAddress.trim() || !peerPort.trim()}
+                            disabled={isSaving}
                             className="flex-1 bg-green-600 hover:bg-green-700"
                         >
                             <Save className="mr-2 h-4 w-4" />
@@ -155,4 +204,3 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
         </div>
     );
 }
-

--- a/apps/apps/pearl-desktop-wallet/src/renderer/src/components/PeerSettingsModal.tsx
+++ b/apps/apps/pearl-desktop-wallet/src/renderer/src/components/PeerSettingsModal.tsx
@@ -10,7 +10,6 @@ interface PeerSettingsModalProps {
 export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
     const [peerAddress, setPeerAddress] = useState('');
     const [peerPort, setPeerPort] = useState('');
-    const [dnsSeeders, setDnsSeeders] = useState<string[]>([]);
     const [isCustom, setIsCustom] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
     const [network, setNetwork] = useState('');
@@ -26,7 +25,6 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
             const settings = await window.appBridge.manager.getPeerSettings();
             setPeerAddress(settings.customPeerAddress ?? '');
             setPeerPort(settings.customPeerPort ? String(settings.customPeerPort) : '');
-            setDnsSeeders(settings.dnsSeeders ?? []);
             setIsCustom(settings.isCustom);
             setNetwork(settings.network);
         } catch (error) {
@@ -44,7 +42,7 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
             try {
                 await window.appBridge.manager.resetPeerToDefault();
                 await loadPeerSettings();
-                alert('Custom peer cleared. DNS seeders will be used. Please restart the wallet for changes to take effect.');
+                alert('Custom peer cleared. Peers will be discovered automatically via DNS seeders. Please restart the wallet for changes to take effect.');
                 onClose();
             } catch (error) {
                 console.error('Failed to clear peer settings:', error);
@@ -57,7 +55,7 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
 
         // If one field is filled, the other must be too
         if (!address || !portStr) {
-            alert('Please fill in both peer address and port, or leave both empty to use DNS seeders.');
+            alert('Please fill in both peer address and port, or leave both empty to use automatic discovery.');
             return;
         }
 
@@ -86,7 +84,7 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
         try {
             await window.appBridge.manager.resetPeerToDefault();
             await loadPeerSettings();
-            alert('Reset to DNS seeders. Please restart the wallet for changes to take effect.');
+            alert('Reset to automatic discovery. Please restart the wallet for changes to take effect.');
         } catch (error) {
             console.error('Failed to reset peer settings:', error);
             alert('Failed to reset settings');
@@ -120,23 +118,15 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
 
                 {/* Form */}
                 <div className="space-y-4">
-                    {/* DNS Seeders (default discovery) */}
+                    {/* Default Peer Discovery */}
                     <div className="rounded-lg border border-gray-200 bg-gray-50 p-3">
-                        <div className="mb-2 flex items-center gap-2">
+                        <div className="mb-1 flex items-center gap-2">
                             <Globe className="h-4 w-4 text-green-600" />
                             <span className="text-sm font-semibold text-gray-700">Default Peer Discovery</span>
                         </div>
-                        <p className="mb-2 text-xs text-gray-500">
-                            The wallet automatically discovers peers via Pearl DNS seeders:
+                        <p className="text-xs text-gray-500">
+                            By default, the wallet automatically discovers peers via Pearl DNS seeders.
                         </p>
-                        <ul className="space-y-1">
-                            {dnsSeeders.map((seeder) => (
-                                <li key={seeder} className="flex items-center gap-2 text-xs text-gray-600">
-                                    <span className="h-1 w-1 rounded-full bg-gray-400" />
-                                    {seeder}
-                                </li>
-                            ))}
-                        </ul>
                     </div>
 
                     {/* Custom Peer (optional) */}
@@ -146,7 +136,7 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
                             <label className="text-sm font-medium text-gray-700">Custom Peer (optional)</label>
                         </div>
                         <p className="mb-2 text-xs text-gray-500">
-                            Add a specific peer (IP address or hostname) to connect to at startup. Leave empty to use DNS seeders.
+                            Add a specific peer (IP address or hostname) to connect to at startup. Leave empty to use automatic discovery.
                         </p>
                         <div className="space-y-2">
                             <input
@@ -183,7 +173,7 @@ export function PeerSettingsModal({ isOpen, onClose }: PeerSettingsModalProps) {
                             className="flex-1"
                         >
                             <RotateCcw className="mr-2 h-4 w-4" />
-                            Use DNS Seeders
+                            Use Automatic Discovery
                         </Button>
 
                         <Button

--- a/apps/apps/pearl-desktop-wallet/src/types/app-bridge.ts
+++ b/apps/apps/pearl-desktop-wallet/src/types/app-bridge.ts
@@ -85,7 +85,6 @@ interface ManagerApi {
 
   getPeerSettings: () => Promise<{
     network: string;
-    dnsSeeders: string[];
     customPeerAddress: string;
     customPeerPort?: number;
     isCustom: boolean;

--- a/apps/apps/pearl-desktop-wallet/src/types/app-bridge.ts
+++ b/apps/apps/pearl-desktop-wallet/src/types/app-bridge.ts
@@ -85,10 +85,9 @@ interface ManagerApi {
 
   getPeerSettings: () => Promise<{
     network: string;
-    currentAddress: string;
-    currentPort: number;
-    defaultAddress: string;
-    defaultPort: number;
+    dnsSeeders: string[];
+    customPeerAddress: string;
+    customPeerPort?: number;
     isCustom: boolean;
   }>;
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded `wallet-node0/1/2/3/4.pearlresearch.ai` peer addresses with the Pearl DNS seeders (`seeder1/2/3.pearlresearch.ai`) for automatic peer discovery, and adds an optional custom peer field in Settings for users who want to connect to a specific node.

## Type

feat

## Scope

wallet

## Changes

- Removed hardcoded `wallet-node0-4.pearlresearch.ai` mainnet peers and `node1-3.testnet.pearlresearch.ai` testnet peers; the oyster daemon now relies on its built-in DNS seeding (matching `chaincfg.Params.DNSSeeds`)
- `wallet-process.ts` only passes `--addpeer` when a custom peer is configured; otherwise the daemon falls back to DNS seeders automatically
- `peer-settings.ts` introduces `getCustomPeer()` returning `null` when no custom peer is set; legacy saved peers are detected and ignored for backwards compatibility
- `manager-service.ts` skips peer validation when no custom peer is configured (DNS seeders are self-validating)
- Redesigned `PeerSettingsModal.tsx` to show the DNS seeders as the default discovery method with an optional custom peer (IP/hostname + port) input
- Updated `app-bridge.ts` types and `network-config.ts` to reflect the new `dnsSeeders` field

## Test plan

- [ ] Existing tests pass (`task test`)
- [ ] Verified wallet launches and discovers peers via all 3 DNS seeders (25 peers each) in dev mode
- [ ] Verified custom peer field accepts IP/hostname + port and passes `--addpeer` to the daemon
- [ ] Verified clearing the custom peer field falls back to DNS seeders