### PR TITLE
fix: complete testnet2 support and SPV seed discovery on test networks

### DIFF
--- a/node/chaincfg/genesis.go
+++ b/node/chaincfg/genesis.go
@@ -222,7 +222,7 @@ var testNetGenesisBlock = wire.MsgBlock{
 }
 
 // testNet2GenesisHash is the hash of the first block in the block chain for the
-// test network v2 (fresh genesis).
+// test network v2.
 var testNet2GenesisHash = chainhash.Hash([chainhash.HashSize]byte{
 	0x96, 0x6f, 0x33, 0xa0, 0x2e, 0x2e, 0x5f, 0x2b,
 	0xd8, 0xd5, 0x11, 0x38, 0x41, 0xce, 0xee, 0x29,

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -561,8 +561,8 @@ var TestNetParams = Params{
 	HDCoinType: HDCoinTypeTestnet,
 }
 
-// TestNet2Params defines the network parameters for the Pearl test network v2.
-// Based on TestNetParams but with a fresh genesis block.
+// TestNet2Params defines the network parameters for the Pearl test network v2,
+// a restart of the test network from its own genesis block.
 var TestNet2Params = Params{
 	Name:        "testnet2",
 	Net:         wire.TestNet2,

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -479,9 +479,9 @@ var TestNetParams = Params{
 	Net:         wire.TestNet,
 	DefaultPort: "44110",
 	DNSSeeds: []DNSSeed{
-		{"seeder1.internal.pearlresearch.ai", true},
-		{"seeder2.internal.pearlresearch.ai", true},
-		{"seeder3.internal.pearlresearch.ai", true},
+		{"seeder1.internal.pearlresearch.ai", false},
+		{"seeder2.internal.pearlresearch.ai", false},
+		{"seeder3.internal.pearlresearch.ai", false},
 	},
 
 	// Chain parameters
@@ -568,9 +568,9 @@ var TestNet2Params = Params{
 	Net:         wire.TestNet2,
 	DefaultPort: "44112",
 	DNSSeeds: []DNSSeed{
-		{"seeder1.testnet.pearlresearch.ai", true},
-		{"seeder2.testnet.pearlresearch.ai", true},
-		{"seeder3.testnet.pearlresearch.ai", true},
+		{"seeder1.testnet.pearlresearch.ai", false},
+		{"seeder2.testnet.pearlresearch.ai", false},
+		{"seeder3.testnet.pearlresearch.ai", false},
 	},
 
 	// Chain parameters

--- a/node/cmd/addblock/config.go
+++ b/node/cmd/addblock/config.go
@@ -42,6 +42,7 @@ type config struct {
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
 	TestNet        bool   `long:"testnet" description:"Use the test network"`
+	TestNet2       bool   `long:"testnet2" description:"Use the test network v2"`
 	TxIndex        bool   `long:"txindex" description:"Build a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
 }
 
@@ -93,6 +94,10 @@ func loadConfig() (*config, []string, error) {
 	if cfg.TestNet {
 		numNets++
 		activeNetParams = &chaincfg.TestNetParams
+	}
+	if cfg.TestNet2 {
+		numNets++
+		activeNetParams = &chaincfg.TestNet2Params
 	}
 	if cfg.RegressionTest {
 		numNets++

--- a/node/cmd/findcheckpoint/config.go
+++ b/node/cmd/findcheckpoint/config.go
@@ -42,6 +42,7 @@ type config struct {
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
 	TestNet        bool   `long:"testnet" description:"Use the test network"`
+	TestNet2       bool   `long:"testnet2" description:"Use the test network v2"`
 }
 
 // validDbType returns whether or not dbType is a supported database type.
@@ -81,6 +82,10 @@ func loadConfig() (*config, []string, error) {
 	if cfg.TestNet {
 		numNets++
 		activeNetParams = &chaincfg.TestNetParams
+	}
+	if cfg.TestNet2 {
+		numNets++
+		activeNetParams = &chaincfg.TestNet2Params
 	}
 	if cfg.RegressionTest {
 		numNets++

--- a/node/config.go
+++ b/node/config.go
@@ -169,7 +169,7 @@ type config struct {
 	SigNetChallenge          string        `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
 	SigNetSeedNode           []string      `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
 	TestNet                  bool          `long:"testnet" description:"Use the test network"`
-	TestNet2                 bool          `long:"testnet2" description:"Use the test network v2 (fresh genesis)"`
+	TestNet2                 bool          `long:"testnet2" description:"Use the test network v2"`
 	TorIsolation             bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
 	TrickleInterval          time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
 	UtxoCacheMaxSizeMiB      uint          `long:"utxocachemaxsize" description:"The maximum size in MiB of the UTXO cache"`

--- a/node/database/cmd/dbtool/globalconfig.go
+++ b/node/database/cmd/dbtool/globalconfig.go
@@ -36,6 +36,7 @@ type config struct {
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
 	TestNet        bool   `long:"testnet" description:"Use the test network"`
+	TestNet2       bool   `long:"testnet2" description:"Use the test network v2"`
 }
 
 // fileExists reports whether the named file or directory exists.
@@ -69,6 +70,10 @@ func setupGlobalConfig() error {
 	if cfg.TestNet {
 		numNets++
 		activeNetParams = &chaincfg.TestNetParams
+	}
+	if cfg.TestNet2 {
+		numNets++
+		activeNetParams = &chaincfg.TestNet2Params
 	}
 	if cfg.RegressionTest {
 		numNets++

--- a/node/integration/rpctest/rpc_harness.go
+++ b/node/integration/rpctest/rpc_harness.go
@@ -120,6 +120,8 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 		// No extra flags since mainnet is the default
 	case wire.TestNet:
 		extraArgs = append(extraArgs, "--testnet")
+	case wire.TestNet2:
+		extraArgs = append(extraArgs, "--testnet2")
 	case wire.RegTest:
 		extraArgs = append(extraArgs, "--regtest")
 	case wire.SimNet:

--- a/node/rpcclient/infrastructure.go
+++ b/node/rpcclient/infrastructure.go
@@ -1557,6 +1557,8 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 		client.chainParams = &chaincfg.MainNetParams
 	case chaincfg.TestNetParams.Name:
 		client.chainParams = &chaincfg.TestNetParams
+	case chaincfg.TestNet2Params.Name:
+		client.chainParams = &chaincfg.TestNet2Params
 	case chaincfg.RegressionNetParams.Name:
 		client.chainParams = &chaincfg.RegressionNetParams
 	case chaincfg.SigNetParams.Name:

--- a/node/sample-pearld.conf
+++ b/node/sample-pearld.conf
@@ -27,6 +27,9 @@
 ; Use testnet.
 ; testnet=1
 
+; Use testnet v2 (fresh genesis).
+; testnet2=1
+
 ; Connect via a SOCKS5 proxy.  NOTE: Specifying a proxy will disable listening
 ; for incoming connections unless listen addresses are provided via the 'listen'
 ; option.

--- a/node/sample-pearld.conf
+++ b/node/sample-pearld.conf
@@ -27,7 +27,7 @@
 ; Use testnet.
 ; testnet=1
 
-; Use testnet v2 (fresh genesis).
+; Use testnet v2.
 ; testnet2=1
 
 ; Connect via a SOCKS5 proxy.  NOTE: Specifying a proxy will disable listening

--- a/node/wire/protocol.go
+++ b/node/wire/protocol.go
@@ -140,7 +140,7 @@ const (
 	// TestNet represents the Pearl test network.
 	TestNet PearlNet = 0x50524C31 // "PRL1" in ASCII
 
-	// TestNet2 represents the Pearl test network v2 (fresh genesis).
+	// TestNet2 represents the Pearl test network v2.
 	TestNet2 PearlNet = 0x50524C32 // "PRL2" in ASCII
 
 	// SigNet represents the public default SigNet. For custom signets,

--- a/wallet/cmd/sweepaccount/main.go
+++ b/wallet/cmd/sweepaccount/main.go
@@ -42,6 +42,7 @@ func errContext(err error, context string) error {
 // Flags.
 var opts = struct {
 	TestNet               bool                `long:"testnet" description:"Use the test Pearl network"`
+	TestNet2              bool                `long:"testnet2" description:"Use the test Pearl network v2"`
 	SimNet                bool                `long:"simnet" description:"Use the simulation Pearl network"`
 	RegressionNet         bool                `long:"regtest" description:"Use the regression Pearl network"`
 	RPCConnect            string              `short:"c" long:"connect" description:"Hostname[:port] of wallet RPC server"`
@@ -53,6 +54,7 @@ var opts = struct {
 	RequiredConfirmations int64               `long:"minconf" description:"Required confirmations to include an output"`
 }{
 	TestNet:               false,
+	TestNet2:              false,
 	SimNet:                false,
 	RegressionNet:         false,
 	RPCConnect:            "localhost",
@@ -85,6 +87,9 @@ func init() {
 	if opts.TestNet {
 		numNets++
 	}
+	if opts.TestNet2 {
+		numNets++
+	}
 	if opts.SimNet {
 		numNets++
 	}
@@ -97,6 +102,8 @@ func init() {
 	var activeNet = &netparams.MainNetParams
 	if opts.TestNet {
 		activeNet = &netparams.TestNetParams
+	} else if opts.TestNet2 {
+		activeNet = &netparams.TestNet2Params
 	} else if opts.SimNet {
 		activeNet = &netparams.SimNetParams
 	} else if opts.RegressionNet {

--- a/wallet/sample-oyster.conf
+++ b/wallet/sample-oyster.conf
@@ -7,7 +7,7 @@
 ; Use testnet (cannot be used with simnet=1 or regtest=1).
 ; testnet=0
 
-; Use testnet v2, fresh genesis (cannot be used with other networks).
+; Use testnet v2 (cannot be used with other networks).
 ; testnet2=0
 
 ; Use simnet (cannot be used with testnet=1 or regtest=1).

--- a/wallet/sample-oyster.conf
+++ b/wallet/sample-oyster.conf
@@ -7,6 +7,9 @@
 ; Use testnet (cannot be used with simnet=1 or regtest=1).
 ; testnet=0
 
+; Use testnet v2, fresh genesis (cannot be used with other networks).
+; testnet2=0
+
 ; Use simnet (cannot be used with testnet=1 or regtest=1).
 ; simnet=0
 


### PR DESCRIPTION
## Summary

`oystercli --testnet2` failed before dialing with `rpcclient.New: Unknown chain testnet2`, which prompted a repo-wide sweep for network enumerations that predate testnet2. Two commits:

### rpcclient (`c1c19f88`)

The chain-name switch in `rpcclient.New` — the single place mapping `Params` strings for rpcclient consumers — never learned testnet2, so any client passing `"testnet2"` was rejected before any network I/O. The gap went unnoticed because nothing else exercises the path: prlctl posts raw HTTP without rpcclient, and oyster's chain client is bypassed in SPV mode. The missing case also unblocks oyster's RPC-mode chain client against a testnet2 pearld.

### Remaining enumerations (`d317b12a`)

Swept every place that enumerates networks (by params var, flag, name string, or wire magic) and fixed the stragglers:

- `sweepaccount`, `addblock`, `findcheckpoint`, `dbtool`: `--testnet2` flag + params selection (previously silently fell back to mainnet ports/params)
- `rpctest` harness: passes `--testnet2` through to the spawned pearld
- `sample-pearld.conf` / `sample-oyster.conf`: document the option

Verified already complete and untouched: pearld, oyster, prlctl, oystercli, dnsseeder, `netparams`, `chaincfg` registration, `wire` magic/BIP44 coin types, and the peer package (its testnet reference is a nil-params fallback, not an enumeration).

### DNS seeding for SPV clients (`794a6dc5`)

The testnet and testnet2 seed entries were marked `HasFiltering`, so SPV clients (requiring witness+CF services, mask `0x49`) queried `x49.<seed>` subdomains that the deployed seeders do not serve — every lookup returned NXDOMAIN and a fresh SPV wallet on those networks discovered zero peers (verified live: plain seed hostnames resolve, `x49.` variants do not). pearld was unaffected since it only requires `SFNodeNetwork`, which uses the unfiltered path. The entries now match mainnet's (`false`); neutrino still filters peers by advertised services after connecting.

## Test plan

- [x] `go build ./node/... ./wallet/...`; `go vet` on all touched packages; gofmt clean
- [x] `./bin/oystercli --testnet2` smoke: passes rpcclient, resolves `localhost:44211`, reaches normal cold-start triage instead of the chain error
