### PR TITLE
chore(wallet): bump pearl-desktop-wallet to 2.0.2

### DIFF
--- a/apps/apps/pearl-desktop-wallet/package.json
+++ b/apps/apps/pearl-desktop-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearl/pearl-desktop-wallet",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Pearl Desktop Wallet - A modern cryptocurrency wallet application",
   "author": {
     "name": "Pearl Research Labs",


### PR DESCRIPTION
## Summary

Bumps the Pearl Desktop Wallet version from 2.0.1 to 2.0.2.

## Type

chore

## Scope

wallet

## Changes

- Bump `@pearl/pearl-desktop-wallet` version in `apps/apps/pearl-desktop-wallet/package.json` from 2.0.1 to 2.0.2.

## Test plan

- [ ] Existing tests pass (`task test`)