### PR TITLE
chore(wallet): bump pearl-desktop-wallet to 2.0.3

### DIFF
--- a/apps/apps/pearl-desktop-wallet/package.json
+++ b/apps/apps/pearl-desktop-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearl/pearl-desktop-wallet",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Pearl Desktop Wallet - A modern cryptocurrency wallet application",
   "author": {
     "name": "Pearl Research Labs",


### PR DESCRIPTION
## Summary

Bumps the pearl-desktop-wallet package version from 2.0.2 to 2.0.3 to reflect recently merged bug fixes.

## Type

chore

## Scope

wallet

## Changes

- Bump `@pearl/pearl-desktop-wallet` version from `2.0.2` to `2.0.3`

## Test plan

- [x] Version field updated correctly in package.json