### PR TITLE
feat(consensus): add dense-only softfork rejecting MoE certificates

### DIFF
--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -215,3 +215,27 @@ func TestCheckCertificateVersion(t *testing.T) {
 	requireRuleError(t, CheckCertificateVersion(nil, 1, enabled),
 		ErrCertificateMissing)
 }
+
+// TestCheckCertificateVersionDenseOnlyFork exercises the dense-only fork: at
+// and after DenseOnlyForkHeight a V2 certificate must carry a dense (non-MoE)
+// proof. MoE-ness is detected by the public data length (dense proofs are
+// exactly wire.PublicDataSizeDenseV2 bytes, MoE proofs are longer).
+func TestCheckCertificateVersionDenseOnlyFork(t *testing.T) {
+	const denseOnlyTestHeight = moeForkTestHeight + 2
+	params := &chaincfg.Params{
+		MoEForkHeight:       moeForkTestHeight,
+		DenseOnlyForkHeight: denseOnlyTestHeight,
+	}
+
+	dense := &wire.CertificateV2{PublicDataLen: wire.PublicDataSizeDenseV2}
+	moe := &wire.CertificateV2{PublicDataLen: wire.PublicDataSizeDenseV2 + 1}
+
+	// Before the dense-only fork both proof kinds are accepted.
+	require.NoError(t, CheckCertificateVersion(dense, denseOnlyTestHeight-1, params))
+	require.NoError(t, CheckCertificateVersion(moe, denseOnlyTestHeight-1, params))
+
+	// At and after the fork only dense proofs are accepted.
+	require.NoError(t, CheckCertificateVersion(dense, denseOnlyTestHeight, params))
+	requireRuleError(t, CheckCertificateVersion(moe, denseOnlyTestHeight, params),
+		ErrDisallowedCertVersion)
+}

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -512,9 +512,11 @@ func CheckBlockSanity(block *btcutil.Block, chainParams *chaincfg.Params, timeSo
 	return checkBlockSanity(block, chainParams, timeSource, BFNone)
 }
 
-// CheckCertificateVersion enforces the MoE certificate fork:
-//   - At and after MoEForkHeight: only V2 accepted
-//   - Before MoEForkHeight (or fork disabled): only V1 accepted
+// CheckCertificateVersion enforces the certificate fork schedule:
+//   - Before MoEForkHeight (or with the fork disabled): only V1 accepted
+//   - At and after MoEForkHeight (hardfork): only V2 accepted
+//   - At and after DenseOnlyForkHeight (softfork): V2 certificates must
+//     carry a dense (non-MoE) proof
 func CheckCertificateVersion(cert wire.BlockCertificate, height int32, params *chaincfg.Params) error {
 	if cert == nil {
 		return ruleError(ErrCertificateMissing, "block has no certificate")
@@ -523,6 +525,13 @@ func CheckCertificateVersion(cert wire.BlockCertificate, height int32, params *c
 	if cert.Version() != want {
 		str := fmt.Sprintf("certificate version %d is not allowed at height %d "+
 			"(require version %d)", cert.Version(), height, want)
+		return ruleError(ErrDisallowedCertVersion, str)
+	}
+	if c, ok := cert.(*wire.CertificateV2); ok && c.IsMoE() &&
+		params.IsDenseOnlyForkActive(height) {
+		str := fmt.Sprintf("MoE certificate is not allowed at height %d "+
+			"(dense-only fork active from height %d)",
+			height, params.DenseOnlyForkHeight)
 		return ruleError(ErrDisallowedCertVersion, str)
 	}
 	return nil

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -256,6 +256,13 @@ type Params struct {
 	// every height).
 	MoEForkHeight int32
 
+	// DenseOnlyForkHeight is the block height at which the dense-only
+	// softfork activates. At and after this height V2 certificates must
+	// carry a dense (non-MoE) proof; the rule only tightens V2 validity,
+	// so pre-fork nodes accept every post-fork block. A value of 0
+	// disables the fork.
+	DenseOnlyForkHeight int32
+
 	// Mempool parameters
 	RelayNonStdTxs bool
 
@@ -279,6 +286,12 @@ type Params struct {
 // height. The fork is disabled when MoEForkHeight is 0.
 func (p *Params) IsMoEForkActive(height int32) bool {
 	return p.MoEForkHeight != 0 && height >= p.MoEForkHeight
+}
+
+// IsDenseOnlyForkActive reports whether the dense-only softfork is active at
+// the given block height. The fork is disabled when DenseOnlyForkHeight is 0.
+func (p *Params) IsDenseOnlyForkActive(height int32) bool {
+	return p.DenseOnlyForkHeight != 0 && height >= p.DenseOnlyForkHeight
 }
 
 // RequiredCertVersion returns the block certificate version that a block at the
@@ -317,6 +330,9 @@ var MainNetParams = Params{
 	MaxTimeOffsetMinutes: 5,
 
 	MoEForkHeight: 71935,
+
+	// Dense-only softfork: MoE proofs are rejected from this height on.
+	DenseOnlyForkHeight: 91600,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -499,6 +515,9 @@ var TestNetParams = Params{
 
 	MoEForkHeight: 1,
 
+	// Dense-only softfork: MoE proofs are rejected from this height on.
+	DenseOnlyForkHeight: 28235,
+
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
 
@@ -587,6 +606,9 @@ var TestNet2Params = Params{
 	MaxTimeOffsetMinutes: 5,
 
 	MoEForkHeight: 54869,
+
+	// Dense-only softfork: MoE proofs are rejected from this height on.
+	DenseOnlyForkHeight: 75104,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,

--- a/node/wire/certificate_v2.go
+++ b/node/wire/certificate_v2.go
@@ -16,6 +16,11 @@ import (
 // Must match PublicProofParams::MAX_WIRE_SIZE in zk-pow/src/api/proof_utils.rs.
 const PublicDataMaxSizeV2 = 4807
 
+// PublicDataSizeDenseV2 is the exact PublicData size of a dense (non-MoE) V2
+// proof. Must match PublicProofParams::WIRE_SIZE in zk-pow/src/api/proof_utils.rs;
+// MoE proofs are strictly longer.
+const PublicDataSizeDenseV2 = 164
+
 // CertificateV2 is a version-2 (V2) block certificate. It supports MoE (Mixture-of-Experts)
 // proofs as well as standard non-MoE proofs. PublicData is variable-length; PublicDataLen
 // tracks how many bytes are meaningful.
@@ -30,6 +35,10 @@ type CertificateV2 struct {
 
 func (c *CertificateV2) Version() CertificateVersion {
 	return CertificateVersionV2
+}
+
+func (c *CertificateV2) IsMoE() bool {
+	return c.PublicDataLen != PublicDataSizeDenseV2
 }
 
 func (c *CertificateV2) BlockHash() chainhash.Hash {

--- a/version/version.go
+++ b/version/version.go
@@ -19,8 +19,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	Major uint = 1
-	Minor uint = 1
-	Patch uint = 6
+	Minor uint = 2
+	Patch uint = 0
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

Adds a dense-only softfork: at and after `DenseOnlyForkHeight`, a V2 block certificate must carry a dense (non-MoE) proof. MoE certificates are rejected from the activation height on.

## Changes

- Add `Params.DenseOnlyForkHeight` + `Params.IsDenseOnlyForkActive(height)` (0 = disabled).
- Activation heights: mainnet 91600, testnet 28235, testnet2 75104.
- Add `CertificateV2.IsMoE()` and the `PublicDataSizeDenseV2` (164) constant to distinguish dense proofs from MoE proofs by public-data length.
- Enforce the rule in `CheckCertificateVersion`: an MoE V2 certificate at/after the fork height is rejected with `ErrDisallowedCertVersion`.
- Bump version 1.1.6 -> 1.2.0.

## Test plan

- [x] Existing tests pass (`go test ./node/blockchain/ -run TestCheckCertificateVersion`)
- [x] New tests added: `TestCheckCertificateVersionDenseOnlyFork` (accepts both proofs pre-fork; rejects MoE at/after fork)