### PR TITLE
fix(consensus): treat only larger-than-dense proofs as MoE and postpone dense-only fork

### DIFF
--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -238,4 +238,42 @@ func TestCheckCertificateVersionDenseOnlyFork(t *testing.T) {
 	require.NoError(t, CheckCertificateVersion(dense, denseOnlyTestHeight, params))
 	requireRuleError(t, CheckCertificateVersion(moe, denseOnlyTestHeight, params),
 		ErrDisallowedCertVersion)
+
+	// The zero-length placeholder proof used by block templates is not MoE
+	// and must stay valid at and after the fork. Regression guard for the
+	// template-generation failure caused by detecting MoE-ness with "!=".
+	placeholder := &wire.CertificateV2{}
+	require.NoError(t, CheckCertificateVersion(placeholder, denseOnlyTestHeight, params))
+}
+
+// TestDenseOnlyForkAcceptsTemplatesAndBlocks builds a SimNet chain across the
+// dense-only activation height. SolveBlock emits V2 certificates with a
+// zero-length (placeholder) proof on SimNet; both freshly built templates and
+// processed blocks must be accepted under the dense-only rule, since a
+// placeholder is not a MoE proof. This reproduces the "failed to create new
+// block template" failure observed once the fork activated.
+func TestDenseOnlyForkAcceptsTemplatesAndBlocks(t *testing.T) {
+	params := moeSimNetParams()
+	params.DenseOnlyForkHeight = moeForkTestHeight + 2
+	chain, teardown, err := chainSetup("dense_only_template", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	// Extend past the dense-only fork height; every block must be accepted
+	// (its placeholder V2 certificate is non-MoE).
+	for h := int32(1); h <= params.DenseOnlyForkHeight+1; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoErrorf(t, err,
+			"block at height %d must be accepted after the dense-only fork", h)
+		tip = block
+	}
+
+	// A fresh template on top of a post-fork tip must also be accepted.
+	template, _, err := newBlock(chain, tip, nil)
+	require.NoError(t, err)
+	require.NoError(t, chain.CheckConnectBlockTemplate(template),
+		"post-fork block template must be accepted")
 }

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -332,7 +332,7 @@ var MainNetParams = Params{
 	MoEForkHeight: 71935,
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
-	DenseOnlyForkHeight: 91600,
+	DenseOnlyForkHeight: 91630,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -516,7 +516,7 @@ var TestNetParams = Params{
 	MoEForkHeight: 1,
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
-	DenseOnlyForkHeight: 28235,
+	DenseOnlyForkHeight: 28262,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
@@ -608,7 +608,7 @@ var TestNet2Params = Params{
 	MoEForkHeight: 54869,
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
-	DenseOnlyForkHeight: 75104,
+	DenseOnlyForkHeight: 75122,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,

--- a/node/wire/certificate_v2.go
+++ b/node/wire/certificate_v2.go
@@ -37,8 +37,12 @@ func (c *CertificateV2) Version() CertificateVersion {
 	return CertificateVersionV2
 }
 
+// IsMoE reports whether the certificate carries a MoE proof. MoE proofs are
+// strictly larger than a dense proof (PublicDataSizeDenseV2); using ">" rather
+// than "!=" keeps the zero-length placeholder proof used in block templates
+// valid under the dense-only fork.
 func (c *CertificateV2) IsMoE() bool {
-	return c.PublicDataLen != PublicDataSizeDenseV2
+	return c.PublicDataLen > PublicDataSizeDenseV2
 }
 
 func (c *CertificateV2) BlockHash() chainhash.Hash {

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 2
-	Patch uint = 0
+	Patch uint = 1
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

Once the dense-only fork activated, block-template generation failed with `MoE certificate is not allowed at height N`. `NewBlockTemplate` builds a placeholder V2 certificate with an empty proof (`PublicDataLen == 0`), which `IsMoE()` misclassified as MoE (`!= PublicDataSizeDenseV2`), so `CheckConnectBlockTemplate` rejected every template. This treats only proofs strictly larger than a dense proof as MoE, and postpones the activation heights by ~1h for a coordinated rollout of the fixed binary.

## Type

fix

## Scope

node (consensus, wire, chaincfg)

## Changes

- `wire.CertificateV2.IsMoE()`: `PublicDataLen > PublicDataSizeDenseV2` instead of `!=`, so dense proofs (164) and the zero-length template placeholder stay non-MoE while real MoE proofs (strictly larger) are still rejected.
- Postpone `DenseOnlyForkHeight` ~1h: mainnet 91600 -> 91630, testnet 28235 -> 28262, testnet2 75104 -> 75122.
- Bump version 1.2.0 -> 1.2.1.
- Tests: placeholder proof accepted post-fork; new SimNet test builds blocks across the fork and checks `CheckConnectBlockTemplate` (reproduces the failure on the old logic).

## Test plan

- [x] `go test ./node/blockchain -run 'CheckCertificateVersion|DenseOnlyFork|MoEFork'`
- [x] Verified the new test fails on the old `!=` logic with the same error class (`MoE certificate is not allowed at height N`)

## Rollout note

testnet and testnet2 already activated the fork at the original heights on the previously-deployed binary; new-binary nodes will not re-activate until 28262 / 75122. This is safe as long as miners keep producing dense blocks (the old binary already rejects MoE) and the fixed binary is deployed before the new heights. Mainnet has not activated yet.