### PR TITLE
Fix wallet seed recovery across lock cycles

### DIFF
--- a/apps/apps/pearl-desktop-wallet/src/main/services/manager-service.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/services/manager-service.ts
@@ -105,9 +105,12 @@ class ManagerService implements ManagerApi {
   }
 
   async lockWallet() {
-    if (this.walletService) {
-      await this.walletService.lockWallet();
-    }
+    // Locking from the desktop always tears down the daemon. Calling the
+    // walletlock RPC first can block behind an active seed-recovery batch,
+    // preventing the process from ever receiving the shutdown signal that
+    // cleanly interrupts recovery. Stopping the daemon clears private key
+    // material from memory and lets recovery resume from its last committed
+    // batch on the next unlock.
     await this.stopWalletProcess();
     this.currentWallet = null;
   }
@@ -163,17 +166,8 @@ class ManagerService implements ManagerApi {
       console.log('Failed to stop wallet process:', error);
     }
 
-    try {
-      await this.loadWallet(walletName, 'open');
-    } catch (error) {
-      console.log('Failed to load wallet:', error);
-    }
-
-    try {
-      await this.startWalletProcess();
-    } catch (error) {
-      console.log('Failed to start wallet process:', error);
-    }
+    await this.loadWallet(walletName, 'open');
+    await this.startWalletProcess();
 
     this.currentWallet = { name: walletName };
   }

--- a/apps/apps/pearl-desktop-wallet/src/main/services/wallet-process.ts
+++ b/apps/apps/pearl-desktop-wallet/src/main/services/wallet-process.ts
@@ -314,7 +314,14 @@ class WalletProcess {
             const elapsed = Date.now() - startTime;
 
             try {
-              await this.walletService.getBalance('*', 0);
+              // Balance reads require a bbolt read transaction. During seed
+              // recovery the wallet intentionally holds a write transaction
+              // while scanning a batch, so using getbalance as a readiness
+              // probe can block until the RPC timeout and make a healthy
+              // recovering wallet look wedged. Sync progress is served from
+              // the in-memory chain/recovery state and remains responsive
+              // while those batches are being committed.
+              await this.walletService.getSyncProgress();
               if (!isResolved) {
                 isResolved = true;
                 this.isProcessRunning = true;

--- a/apps/apps/pearl-desktop-wallet/src/renderer/src/pages/WalletDashboard.tsx
+++ b/apps/apps/pearl-desktop-wallet/src/renderer/src/pages/WalletDashboard.tsx
@@ -41,16 +41,7 @@ export default function WalletDashboard() {
     clearWalletData();
 
     try {
-      // During birthday recovery the Go wallet holds a bolt write txn for the
-      // duration of the current 2000-block batch, which makes the polite
-      // `walletlock` RPC hang for up to a minute. Fall back to a force-stop
-      // (SIGKILL) so the UI stays responsive. bbolt commits are atomic at txn
-      // boundaries, so a mid-batch kill just replays the batch on next open.
-      if (syncPhase === 'blocks') {
-        await window.appBridge.wallet.forceLockWallet();
-      } else {
-        await window.appBridge.wallet.lockWallet();
-      }
+      await window.appBridge.wallet.lockWallet();
       console.log('✅ Wallet locked successfully');
     } catch (err) {
       console.error('❌ Exception during wallet lock:', err);

--- a/apps/apps/pearl-desktop-wallet/test/recovery-lifecycle.test.mjs
+++ b/apps/apps/pearl-desktop-wallet/test/recovery-lifecycle.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const appDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function source(path) {
+  return readFileSync(join(appDir, path), 'utf8');
+}
+
+test('daemon readiness does not wait for a balance DB read during seed recovery', () => {
+  const walletProcess = source('src/main/services/wallet-process.ts');
+  const readinessBlock = walletProcess.slice(
+    walletProcess.indexOf('const startPolling'),
+    walletProcess.indexOf("this.process.on('error'"),
+  );
+
+  assert.match(readinessBlock, /getSyncProgress\(\)/);
+  assert.doesNotMatch(readinessBlock, /getBalance\(/);
+});
+
+test('desktop lock stops the daemon without blocking on walletlock RPC', () => {
+  const manager = source('src/main/services/manager-service.ts');
+  const lockMethod = manager.slice(
+    manager.indexOf('async lockWallet()'),
+    manager.indexOf('async forceLockWallet()'),
+  );
+
+  assert.match(lockMethod, /stopWalletProcess\(\)/);
+  assert.doesNotMatch(lockMethod, /walletService\.lockWallet/);
+});
+
+test('wallet selection propagates startup failure instead of entering a broken session', () => {
+  const manager = source('src/main/services/manager-service.ts');
+  const selectMethod = manager.slice(
+    manager.indexOf('async selectWallet('),
+    manager.indexOf('async create('),
+  );
+
+  assert.match(selectMethod, /await this\.startWalletProcess\(\)/);
+  assert.doesNotMatch(selectMethod, /Failed to start wallet process/);
+});


### PR DESCRIPTION
## Summary

- use sync progress instead of a balance database read to detect daemon readiness during seed recovery
- stop the daemon directly when locking so recovery can shut down and resume cleanly
- propagate wallet startup failures instead of entering a broken session
- add regression coverage for recovery startup, locking, and failure propagation

## Root cause

Seed recovery holds a bbolt write transaction while scanning each block batch. The desktop process used `getbalance` as its readiness probe, which needs a read transaction and could therefore wait until the RPC timeout. Locking also called `walletlock` before stopping the daemon, allowing the same recovery batch to block shutdown. Finally, wallet selection swallowed startup errors and continued into an unusable session.

Together, these behaviors could leave a restored wallet displaying a partial balance and unable to resume recovery after a lock/unlock cycle.

## User impact

Restored wallets can continue scanning all derived receive addresses across lock/unlock cycles, and startup failures now produce an actionable error instead of an indefinite balance spinner.

## Validation

- `pnpm --filter @pearl/pearl-desktop-wallet build`
- `node --test apps/apps/pearl-desktop-wallet/test/recovery-lifecycle.test.mjs`

Fixes #255
