### PR TITLE
fix(wallet,oystercli): make the full transaction history reachable

### DIFF
--- a/wallet/cmd/oystercli/transactions.go
+++ b/wallet/cmd/oystercli/transactions.go
@@ -22,30 +22,37 @@ const (
 
 // transactionsScreen pages through the wallet history; selecting an entry
 // shows its full detail.
+//
+// listtransactions pages in transactions but answers in entries: a spent
+// output contributes both a receive and a send row, so a page of 15
+// transactions can be twice that many rows. Paging therefore counts
+// transactions, and asks for one beyond the page to learn whether older
+// history exists without a second round trip.
 func transactionsScreen(c *client) error {
 	offset := 0
 	for {
-		var page []btcjson.ListTransactionsResult
+		var entries []btcjson.ListTransactionsResult
 		err := withSpinner("Loading transactions...", func() error {
 			var listErr error
-			page, listErr = c.listTransactions(txPageSize, offset)
+			entries, listErr = c.listTransactions(txPageSize+1, offset)
 			return listErr
 		})
 		if err != nil {
 			return err
 		}
 
+		page, shown, hasOlder := txPage(entries, txPageSize)
 		if len(page) == 0 && offset == 0 {
 			printWarn("No transactions in this wallet yet.")
 			return nil
 		}
 
+		// The wallet answers newest first, which is the order to show.
 		opts := make([]huh.Option[string], 0, len(page)+3)
-		// listtransactions returns oldest first within the page.
-		for i := len(page) - 1; i >= 0; i-- {
-			opts = append(opts, huh.NewOption(txRow(page[i]), page[i].TxID))
+		for _, entry := range page {
+			opts = append(opts, huh.NewOption(txRow(entry), entry.TxID))
 		}
-		if len(page) == txPageSize {
+		if hasOlder {
 			opts = append(opts, huh.NewOption(th.subtle.Render("→ Older transactions"), txNavNext))
 		}
 		if offset > 0 {
@@ -58,7 +65,7 @@ func transactionsScreen(c *client) error {
 		selected := opts[0].Value
 		form := newForm(huh.NewGroup(
 			huh.NewSelect[string]().
-				Title(fmt.Sprintf("Transactions (%d-%d)", offset+1, offset+len(page))).
+				Title(fmt.Sprintf("Transactions %d-%d", offset+1, offset+shown)).
 				Description("Type / to filter, enter for details.").
 				Options(opts...).
 				Height(txPageSize + 5).
@@ -74,18 +81,35 @@ func transactionsScreen(c *client) error {
 
 		switch selected {
 		case txNavNext:
-			offset += txPageSize
+			offset += shown
 		case txNavPrev:
-			offset -= txPageSize
-			if offset < 0 {
-				offset = 0
-			}
+			offset = max(offset-txPageSize, 0)
 		default:
 			if err := showTransactionDetail(c, selected); err != nil {
 				printError(err)
 			}
 		}
 	}
+}
+
+// txPage trims entries to at most size transactions, reporting how many
+// transactions were kept and whether the reply ran past the page. All entries
+// for one transaction arrive together, so a change of txid starts a new one.
+func txPage(entries []btcjson.ListTransactionsResult, size int) (
+	page []btcjson.ListTransactionsResult, shown int, hasMore bool) {
+
+	var current string
+	for i, entry := range entries {
+		if entry.TxID == current {
+			continue
+		}
+		if shown == size {
+			return entries[:i], shown, true
+		}
+		shown++
+		current = entry.TxID
+	}
+	return entries, shown, false
 }
 
 // showTransactionDetail prints the full record for one transaction.

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -2296,6 +2296,12 @@ func (w *Wallet) ListSinceBlock(start, end, syncHeight int32) ([]btcjson.ListTra
 // ListTransactions returns a slice of objects with details about a recorded
 // transaction.  This is intended to be used for listtransactions RPC
 // replies.
+//
+// Results are newest first. from and count are counted in transactions, but
+// the reply holds one entry per transaction category, and a spent output
+// contributes both a receive and a send entry, so len(result) is not count.
+// Callers paging through history must advance from by transactions rather
+// than by the number of entries they received.
 func (w *Wallet) ListTransactions(from, count int) ([]btcjson.ListTransactionsResult, error) {
 	txList := []btcjson.ListTransactionsResult{}
 
@@ -2330,10 +2336,6 @@ func (w *Wallet) ListTransactions(from, count int) ([]btcjson.ListTransactionsRe
 				jsonResults := listTransactions(tx, &details[i],
 					w.Manager, syncBlock.Height, w.chainParams)
 				txList = append(txList, jsonResults...)
-
-				if len(jsonResults) > 0 {
-					n++
-				}
 			}
 
 			return false, nil


### PR DESCRIPTION
## Summary

The Transactions screen showed only the newest 8 entries with no way to reach anything older. On a wallet with 28,959 transactions that hid 99.97% of the history.

Two bugs stacked on top of each other.

**`ListTransactions` returned half of what was asked for.** It incremented its counter once before the limit check and again after appending results, so any transaction producing at least one entry advanced the counter by two and the range bailed at `ceil(count/2)`. Measured against the wallet above:

| requested `count` | transactions returned |
|---|---|
| 1 | 1 |
| 5 | 3 |
| 15 | 8 |
| 30 | 15 |
| 100 | 50 |

**oystercli gated its nav row on an exact length match.** `if len(page) == txPageSize` never held, because it asked for 15 and received 8, so "Older transactions" never rendered.

## The unit mismatch

Fixing `count` alone would not have been enough. `from` and `count` are counted in transactions, but the reply holds one entry per transaction category, and a spent output contributes both a `receive` and a `send` entry. So the entries-per-transaction ratio drifts between 1 and 2 depending on how much of the history has been spent — on the wallet above, 56,977 entries across 28,959 transactions, while the newest 8 transactions yield exactly 8 entries because their outputs are still unspent.

Any paging arithmetic keyed on `len(reply)` is therefore wrong by a factor that changes as you scroll. The old `offset += txPageSize` was wrong for the same reason: the first page covered transactions 0-7 and the next jumped to 15, silently skipping 8-14. I verified that boundary directly — the transaction at index 15 appears as the last row of the `from=8` page and the first row of the `from=15` page.

Paging now asks for one transaction beyond the page, groups the reply by txid to decide whether older history exists, and advances the offset by transactions consumed rather than rows received. `ListTransactions` gained a doc comment spelling out the units, since this is a trap for any caller.

## Also

Dropped a reversal that contradicted its own comment. The wallet answers newest first, so reversing the slice put the oldest row at the top while the code immediately below selected `opts[0]` as "the newest transaction".

## Notes

The `count` change affects every `listtransactions` caller, the desktop wallet included: clients now receive up to the number of transactions they asked for instead of half. That is the documented intent of the parameter, and the in-tree caller is updated here.

Verified by build, vet and the oystercli package tests, plus direct RPC measurement against a live testnet2 wallet for the numbers above. The `ceil(count/2)` arithmetic makes the counter fix deterministic, but end-to-end confirmation needs a restart of oyster onto the new binary, which I did not do against the running daemon.