### PR TITLE
fix(blockchain): validate witness commitment regardless of BFFastAdd

### DIFF
--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -734,6 +734,8 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		return err
 	}
 
+	// Witness data is outside the header's merkle root, so checkpoints cannot
+	// authenticate it (runs regardless of BFFastAdd).
 	if err := ValidateWitnessCommitment(block); err != nil {
 		return err
 	}

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -734,6 +734,10 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		return err
 	}
 
+	if err := ValidateWitnessCommitment(block); err != nil {
+		return err
+	}
+
 	fastAdd := flags&BFFastAdd == BFFastAdd
 	if !fastAdd {
 		blockTime := CalcPastMedianTime(prevNode)
@@ -752,17 +756,6 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		coinbaseTx := block.Transactions()[0]
 		// BIP-34 is enforced for all blocks; this validates correct height encoding.
 		if err := CheckSerializedHeight(coinbaseTx, blockHeight); err != nil {
-			return err
-		}
-
-		// Validate the witness commitment (if any) within the
-		// block.  This involves asserting that if the coinbase
-		// contains the special commitment output, then this
-		// merkle root matches a computed merkle root of all
-		// the wtxid's of the transactions within the block. In
-		// addition, various other checks against the
-		// coinbase's witness stack.
-		if err := ValidateWitnessCommitment(block); err != nil {
 			return err
 		}
 

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 2
-	Patch uint = 1
+	Patch uint = 2
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

`checkBlockContext` only ran `ValidateWitnessCommitment` when `BFFastAdd` was unset, and headers-first sync sets that flag for every block up to the last checkpoint (height 50000 on mainnet). Witness data is excluded from txids and so from the header merkle root, so the checkpointed block hash doesn't cover it and nothing verified it against its commitment over that range.

The commitment sits in a coinbase output and is already authenticated through the coinbase txid — it just wasn't being compared against the witness data. Verifying it unconditionally closes the gap for one merkle computation per block. Signature verification remains checkpoint-gated.

Only nodes performing an initial block download were affected, and only over the range below the last checkpoint. Txids, outputs and the UTXO set are pinned by the checkpointed block hash, so consensus state was never affected.

## Changes

- `node/blockchain/validate.go`: move `ValidateWitnessCommitment` out of the `!fastAdd` branch, ahead of the witness-measuring vsize check.
- `version/version.go`: patch bump `1.2.1` → `1.2.2`.

## Credit

Thanks to @C3Pool for reporting this.