### PR TITLE
chore(wallet): bump pearl-desktop-wallet to 2.0.4

### DIFF
--- a/apps/apps/pearl-desktop-wallet/package.json
+++ b/apps/apps/pearl-desktop-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearl/pearl-desktop-wallet",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Pearl Desktop Wallet - A modern cryptocurrency wallet application",
   "author": {
     "name": "Pearl Research Labs",


### PR DESCRIPTION
## Summary

Bump `@pearl/pearl-desktop-wallet` version to 2.0.4 for release after the security audit dependency fixes (#267).

## Type

chore

## Scope

wallet

## Changes

- Bump `pearl-desktop-wallet` version `2.0.3` -> `2.0.4` in `apps/apps/pearl-desktop-wallet/package.json`

## Test plan

- [ ] Existing tests pass (`task test`)
