### PR TITLE
docs(security): add discretionary bug bounty reward tiers

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,9 +49,10 @@ Indicative reward ranges by severity (as determined by us):
 
 | Severity | Reward |
 | --- | --- |
-| Low | 250 PRL |
-| Medium | 500 PRL |
-| High | 1,000 PRL |
+| Low | 500 PRL |
+| Medium | 1,000 PRL |
+| High | 2,000 PRL |
+| Critical | 10,000 PRL |
 
 ### Terms
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,40 @@ initial report before publicly disclosing any findings, so we have time to
 develop and release a fix. We will credit reporters in the release notes
 unless anonymity is requested.
 
+## Bug Bounty
+
+Pearl Research Labs may, at its sole discretion, offer rewards in PRL for
+qualifying security reports. This is a voluntary recognition program, not a
+contractual offer, contest, or guarantee of payment.
+
+### Reward guidelines
+
+Indicative reward ranges by severity (as determined by us):
+
+| Severity | Reward |
+| --- | --- |
+| Low | 250 PRL |
+| Medium | 500 PRL |
+| High | 1,000 PRL |
+
+### Terms
+
+- **Internal triage.** We assess severity, validity, novelty, and impact
+  internally. Our classification is final.
+- **Discretionary awards.** Whether to reward a report, at what severity
+  tier, and in what amount is entirely at our discretion. The guidelines
+  above are non-binding and may be adjusted or withheld for any reason.
+- **Basis for reward.** An award, if any, may be based on responsible
+  disclosure, assistance with remediation, demonstration of a fix, or any
+  other contribution we consider valuable. There is no single required
+  trigger for payment.
+- **No entitlement.** Submission of a report does not create any right,
+  claim, or expectation to a reward. Duplicate, out-of-scope, low-quality,
+  or previously known issues may receive no award.
+
+Submit reports through the process described in
+[Reporting a Vulnerability](#reporting-a-vulnerability).
+
 ## Contact
 
 - [Report a vulnerability](https://github.com/pearl-research-labs/pearl/security/advisories/new)


### PR DESCRIPTION
## Summary
- Add a discretionary Bug Bounty section to `SECURITY.md` with Low / Medium / High / Critical reward guidelines (500 / 1,000 / 2,000 / 10,000 PRL)
- Clarify internal triage, non-binding awards, flexible reward basis, and no entitlement from submission

## Test plan
- [ ] Confirm https://github.com/pearl-research-labs/pearl/security shows the new section after merge to `master`
- [ ] Skim wording for legal/comms comfort with the discretionary framing


Made with [Cursor](https://cursor.com)