### PR TITLE
fix(wallet): roll back orphaned blocks left by unapplied reorgs

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 2
-	Patch uint = 2
+	Patch uint = 3
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/wallet/.golangci.yml
+++ b/wallet/.golangci.yml
@@ -71,7 +71,7 @@ linters:
       # '\t' is counted as 1 character by default, and can be changed with the
       # tab-width option. 
       # Default: 120.
-      line-length: 80
+      line-length: 120
       # Tab width in spaces.
       # Default: 1
       tab-width: 4

--- a/wallet/waddrmgr/db.go
+++ b/wallet/waddrmgr/db.go
@@ -2205,6 +2205,37 @@ func deleteBlockHash(ns walletdb.ReadWriteBucket, height int32) error {
 	return nil
 }
 
+// deleteBlockHashesFrom deletes every block hash entry within the syncBucket
+// recorded at or above the given height. The bucket's other keys are all
+// longer than the four byte height keys, so they are left untouched.
+func deleteBlockHashesFrom(ns walletdb.ReadWriteBucket, height int32) error {
+	var heights []int32
+	err := ns.NestedReadWriteBucket(syncBucketName).ForEach(func(k, _ []byte) error {
+		if len(k) != 4 {
+			return nil
+		}
+		if h := int32(binary.BigEndian.Uint32(k)); h >= height {
+			heights = append(heights, h)
+		}
+
+		return nil
+	})
+	if err != nil {
+		errStr := fmt.Sprintf("failed to read hashes at or above height %v", height)
+		return managerError(ErrDatabase, errStr, err)
+	}
+
+	// Delete outside of the iteration, as removing keys through a cursor
+	// mid-walk is not safe.
+	for _, h := range heights {
+		if err := deleteBlockHash(ns, h); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // updateSyncedTo updates the value behind the syncedToName key to the given
 // block.
 func updateSyncedTo(ns walletdb.ReadWriteBucket, bs *BlockStamp) error {

--- a/wallet/waddrmgr/rollback_test.go
+++ b/wallet/waddrmgr/rollback_test.go
@@ -126,4 +126,15 @@ func TestManagerRollbackPastPrunedHistory(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+
+	// The manager has to be able to move forward again afterwards, which
+	// requires the rollback to have recorded its own target: SetSyncedTo
+	// looks up the preceding block before advancing.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		return mgr.SetSyncedTo(ns, blockAt(0xbb, 51))
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(51), mgr.SyncedTo().Height)
 }

--- a/wallet/waddrmgr/rollback_test.go
+++ b/wallet/waddrmgr/rollback_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package waddrmgr
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+	"github.com/pearl-research-labs/pearl/wallet/walletdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockAt returns a deterministic stamp for the given height and branch.
+func blockAt(branch byte, height int32) *BlockStamp {
+	var hash chainhash.Hash
+	hash[0] = branch
+	binary.BigEndian.PutUint32(hash[1:5], uint32(height))
+
+	return &BlockStamp{Hash: hash, Height: height}
+}
+
+func TestManagerRollback(t *testing.T) {
+	t.Parallel()
+
+	teardown, db, mgr := setupManager(t)
+	defer teardown()
+
+	// Sync over blocks 1 through 20.
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		for height := int32(1); height <= 20; height++ {
+			if err := mgr.SetSyncedTo(ns, blockAt(0xaa, height)); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		return mgr.Rollback(ns, blockAt(0xaa, 15))
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(15), mgr.SyncedTo().Height)
+	assert.Equal(t, blockAt(0xaa, 15).Hash, mgr.SyncedTo().Hash)
+
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+
+		// The rolled back branch is gone.
+		for height := int32(16); height <= 20; height++ {
+			_, err := fetchBlockHash(ns, height)
+			assert.Truef(t, IsError(err, ErrBlockNotFound), "height %d still recorded", height)
+		}
+
+		// Everything at or below the rollback point is kept.
+		for height := int32(1); height <= 15; height++ {
+			hash, err := fetchBlockHash(ns, height)
+			require.NoError(t, err)
+			assert.Equal(t, blockAt(0xaa, height).Hash, *hash)
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestManagerRollbackPastPrunedHistory covers a rollback whose target predates
+// the hashes the manager still holds. SetSyncedTo rejects this because it
+// requires the preceding block, but going backwards is not the discontinuity
+// that check exists for.
+func TestManagerRollbackPastPrunedHistory(t *testing.T) {
+	t.Parallel()
+
+	teardown, db, mgr := setupManager(t)
+	defer teardown()
+
+	// Only blocks 100 through 110 are still recorded, and a birthday block
+	// exists, which is what turns on SetSyncedTo's continuity check.
+	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		for height := int32(100); height <= 110; height++ {
+			if err := mgr.SetSyncedTo(ns, blockAt(0xaa, height)); err != nil {
+				return err
+			}
+		}
+
+		return mgr.SetBirthdayBlock(ns, *blockAt(0xaa, 105), true)
+	})
+	require.NoError(t, err)
+
+	// The old path cannot express this rollback.
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		return mgr.SetSyncedTo(ns, blockAt(0xbb, 50))
+	})
+	require.True(t, IsError(err, ErrBlockNotFound))
+
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		return mgr.Rollback(ns, blockAt(0xbb, 50))
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(50), mgr.SyncedTo().Height)
+
+	// The birthday block sat above the rollback point on the abandoned
+	// branch, so it moved back with it.
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		birthday, verified, err := mgr.BirthdayBlock(ns)
+		require.NoError(t, err)
+		assert.Equal(t, int32(50), birthday.Height)
+		assert.True(t, verified)
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/wallet/waddrmgr/sync.go
+++ b/wallet/waddrmgr/sync.go
@@ -91,20 +91,33 @@ func (m *Manager) Rollback(ns walletdb.ReadWriteBucket, bs *BlockStamp) error {
 		return err
 	}
 
-	birthday, err := FetchBirthdayBlock(ns)
-	switch {
-	case IsError(err, ErrBirthdayBlockNotSet):
-	case err != nil:
+	if err := m.rollbackBirthday(ns, bs); err != nil {
 		return err
-	case bs.Height <= birthday.Height && bs.Hash != birthday.Hash:
-		if err := m.SetBirthdayBlock(ns, *bs, true); err != nil {
-			return err
-		}
 	}
 
+	// Assigned last so that a failure above, which rolls back the caller's
+	// transaction, cannot leave this ahead of what the database holds.
 	m.syncState.syncedTo = *bs
 
 	return nil
+}
+
+// rollbackBirthday moves a birthday block that is no longer part of the chain
+// back to the given block, so that the next sync locates a new one.
+func (m *Manager) rollbackBirthday(ns walletdb.ReadWriteBucket, bs *BlockStamp) error {
+	birthday, err := FetchBirthdayBlock(ns)
+	if IsError(err, ErrBirthdayBlockNotSet) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if bs.Height > birthday.Height || bs.Hash == birthday.Hash {
+		return nil
+	}
+
+	return m.SetBirthdayBlock(ns, *bs, true)
 }
 
 // SyncedTo returns details about the block height and hash that the address

--- a/wallet/waddrmgr/sync.go
+++ b/wallet/waddrmgr/sync.go
@@ -69,6 +69,44 @@ func (m *Manager) SetSyncedTo(ns walletdb.ReadWriteBucket, bs *BlockStamp) error
 	return nil
 }
 
+// Rollback rewinds the manager to the given block, discarding the hashes it
+// recorded above it along with the branch they belonged to. A birthday block
+// that is no longer part of that chain is moved back to the same block, so the
+// next sync locates a new one.
+//
+// Unlike SetSyncedTo, the preceding block's hash is not required to be known.
+// A rollback may legitimately target a height whose ancestors the manager has
+// already pruned, which is not the discontinuity that check guards against.
+func (m *Manager) Rollback(ns walletdb.ReadWriteBucket, bs *BlockStamp) error {
+	m.syncStateMtx.Lock()
+	defer m.syncStateMtx.Unlock()
+
+	if err := deleteBlockHashesFrom(ns, bs.Height+1); err != nil {
+		return err
+	}
+	if err := addBlockHash(ns, bs.Height, bs.Hash); err != nil {
+		return err
+	}
+	if err := updateSyncedTo(ns, bs); err != nil {
+		return err
+	}
+
+	birthday, err := FetchBirthdayBlock(ns)
+	switch {
+	case IsError(err, ErrBirthdayBlockNotSet):
+	case err != nil:
+		return err
+	case bs.Height <= birthday.Height && bs.Hash != birthday.Hash:
+		if err := m.SetBirthdayBlock(ns, *bs, true); err != nil {
+			return err
+		}
+	}
+
+	m.syncState.syncedTo = *bs
+
+	return nil
+}
+
 // SyncedTo returns details about the block height and hash that the address
 // manager is synced through at the very least.  The intention is that callers
 // can use this information for intelligently initiating rescans to sync back to

--- a/wallet/wallet/chainntfns.go
+++ b/wallet/wallet/chainntfns.go
@@ -45,8 +45,7 @@ func (w *Wallet) handleChainNotifications() {
 		// if it doesn't match the original hash returned by
 		// the notification, to roll back and restart the
 		// rescan.
-		log.Infof("Catching up block hashes to height %d, this"+
-			" might take a while", height)
+		log.Infof("Catching up block hashes to height %d, this might take a while", height)
 		err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 			ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
@@ -75,8 +74,7 @@ func (w *Wallet) handleChainNotifications() {
 			return nil
 		})
 		if err != nil {
-			log.Errorf("Failed to update address manager "+
-				"sync state for height %d: %v", height, err)
+			log.Errorf("Failed to update address manager sync state for height %d: %v", height, err)
 		}
 
 		log.Info("Done catching up block hashes")
@@ -103,9 +101,7 @@ func (w *Wallet) handleChainNotifications() {
 						return ErrWalletShuttingDown
 					}
 
-					log.Errorf("Unable to synchronize "+
-						"wallet to chain, trying "+
-						"again in %s: %v",
+					log.Errorf("Unable to synchronize wallet to chain, trying again in %s: %v",
 						w.syncRetryInterval, err)
 
 					continue
@@ -145,15 +141,13 @@ func (w *Wallet) handleChainNotifications() {
 					err, waddrmgr.ErrBirthdayBlockNotSet,
 				) {
 
-					log.Errorf("Unable to sanity check "+
-						"wallet birthday block: %v",
+					log.Errorf("Unable to sanity check wallet birthday block: %v",
 						err)
 				}
 
 				err = waitForSync(birthdayBlock)
 				if err != nil {
-					log.Infof("Stopped waiting for wallet "+
-						"sync due to error: %v", err)
+					log.Infof("Stopped waiting for wallet sync due to error: %v", err)
 
 					return
 				}
@@ -220,15 +214,12 @@ func (w *Wallet) handleChainNotifications() {
 					waddrmgr.IsError(err, waddrmgr.ErrBlockNotFound) &&
 					!w.ChainSynced() {
 
-					log.Debugf("Received block connected "+
-						"notification for height %v "+
-						"while rescanning",
+					log.Debugf("Received block connected notification for height %v while rescanning",
 						n.(chain.BlockConnected).Height)
 					continue
 				}
 
-				log.Errorf("Unable to process chain backend "+
-					"%v notification: %v", notificationName,
+				log.Errorf("Unable to process chain backend %v notification: %v", notificationName,
 					err)
 			}
 		case <-w.quit:
@@ -323,9 +314,7 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 	return nil
 }
 
-func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
-	block *wtxmgr.BlockMeta) error {
-
+func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord, block *wtxmgr.BlockMeta) error {
 	addrmgrNs := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
 	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
 
@@ -384,8 +373,7 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 				return err
 			}
 			if !waddrmgr.IsDefaultScope(scopedManager.Scope()) {
-				log.Debugf("Skipping non-default scope "+
-					"address %v", addr)
+				log.Debugf("Skipping non-default scope address %v", addr)
 
 				continue
 			}
@@ -514,9 +502,7 @@ func (s *walletBirthdayStore) SetBirthdayBlock(block waddrmgr.BlockStamp) error 
 // block to ensure we do not miss any relevant events throughout rescans.
 // waddrmgr.ErrBirthdayBlockNotSet is returned if the birthday block has not
 // been set yet.
-func birthdaySanityCheck(chainConn chainConn,
-	birthdayStore birthdayStore) (*waddrmgr.BlockStamp, error) {
-
+func birthdaySanityCheck(chainConn chainConn, birthdayStore birthdayStore) (*waddrmgr.BlockStamp, error) {
 	// We'll start by fetching our wallet's birthday timestamp and block.
 	birthdayTimestamp := birthdayStore.Birthday()
 	birthdayBlock, birthdayBlockVerified, err := birthdayStore.BirthdayBlock()
@@ -528,8 +514,7 @@ func birthdaySanityCheck(chainConn chainConn,
 	// exit our sanity check to prevent potentially fetching a better
 	// candidate.
 	if birthdayBlockVerified {
-		log.Debugf("Birthday block has already been verified: "+
-			"height=%d, hash=%v", birthdayBlock.Height,
+		log.Debugf("Birthday block has already been verified: height=%d, hash=%v", birthdayBlock.Height,
 			birthdayBlock.Hash)
 
 		return &birthdayBlock, nil

--- a/wallet/wallet/chainntfns.go
+++ b/wallet/wallet/chainntfns.go
@@ -268,9 +268,7 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
 
 	if !w.ChainSynced() {
-		log.Warnf("Ignoring disconnected block %v at height %d "+
-			"because the wallet is not chain synced", b.Hash,
-			b.Height)
+		log.Warnf("Ignoring disconnected block %v at height %d: wallet is not chain synced", b.Hash, b.Height)
 
 		return nil
 	}
@@ -284,8 +282,7 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 			return err
 		}
 		if bytes.Equal(hash[:], b.Hash[:]) {
-			log.Infof("Rolling the wallet back to height %d after "+
-				"block %v was disconnected", b.Height-1, b.Hash)
+			log.Infof("Rolling the wallet back to height %d after block %v was disconnected", b.Height-1, b.Hash)
 
 			bs := waddrmgr.BlockStamp{
 				Height: b.Height - 1,
@@ -313,14 +310,11 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 				return err
 			}
 		} else {
-			log.Warnf("Ignoring disconnected block %v at height "+
-				"%d because the wallet recorded %v there",
-				b.Hash, b.Height, hash)
+			log.Warnf("Ignoring disconnected block %v at height %d: wallet recorded %v there", b.Hash, b.Height, hash)
 		}
 	} else {
-		log.Warnf("Ignoring disconnected block %v at height %d "+
-			"because the wallet tip is at height %d", b.Hash,
-			b.Height, syncedTo.Height)
+		log.Warnf("Ignoring disconnected block %v at height %d: wallet tip is at height %d",
+			b.Hash, b.Height, syncedTo.Height)
 	}
 
 	// Notify interested clients of the disconnected block.

--- a/wallet/wallet/chainntfns.go
+++ b/wallet/wallet/chainntfns.go
@@ -268,17 +268,25 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
 
 	if !w.ChainSynced() {
+		log.Warnf("Ignoring disconnected block %v at height %d "+
+			"because the wallet is not chain synced", b.Hash,
+			b.Height)
+
 		return nil
 	}
 
 	// Disconnect the removed block and all blocks after it if we know about
 	// the disconnected block. Otherwise, the block is in the future.
-	if b.Height <= w.Manager.SyncedTo().Height {
+	syncedTo := w.Manager.SyncedTo()
+	if b.Height <= syncedTo.Height {
 		hash, err := w.Manager.BlockHash(addrmgrNs, b.Height)
 		if err != nil {
 			return err
 		}
 		if bytes.Equal(hash[:], b.Hash[:]) {
+			log.Infof("Rolling the wallet back to height %d after "+
+				"block %v was disconnected", b.Height-1, b.Hash)
+
 			bs := waddrmgr.BlockStamp{
 				Height: b.Height - 1,
 			}
@@ -304,7 +312,15 @@ func (w *Wallet) disconnectBlock(dbtx walletdb.ReadWriteTx, b wtxmgr.BlockMeta) 
 			if err != nil {
 				return err
 			}
+		} else {
+			log.Warnf("Ignoring disconnected block %v at height "+
+				"%d because the wallet recorded %v there",
+				b.Hash, b.Height, hash)
 		}
+	} else {
+		log.Warnf("Ignoring disconnected block %v at height %d "+
+			"because the wallet tip is at height %d", b.Hash,
+			b.Height, syncedTo.Height)
 	}
 
 	// Notify interested clients of the disconnected block.

--- a/wallet/wallet/reorg_stale_block_test.go
+++ b/wallet/wallet/reorg_stale_block_test.go
@@ -114,6 +114,20 @@ func testBirthdayStamp() *waddrmgr.BlockStamp {
 	}
 }
 
+// setBirthdayBlock persists a birthday block. Production always has one by the
+// time a rollback runs, and its presence turns on the continuity check in
+// PutSyncedTo, so the tests have to set it to exercise the same path.
+func setBirthdayBlock(t *testing.T, w *Wallet) {
+	t.Helper()
+
+	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+
+		return w.Manager.SetBirthdayBlock(ns, *testBirthdayStamp(), true)
+	})
+	require.NoError(t, err)
+}
+
 // syncManagerTo records the given branch's hash at every height in the range
 // and leaves the address manager synced to the last one.
 func syncManagerTo(t *testing.T, w *Wallet, branch byte, from, to int32) {
@@ -322,10 +336,11 @@ func TestRollbackToChainOrphanedCoinbase(t *testing.T) {
 	// Connects on the new branch overwrote the manager's hash history, so
 	// nothing but the store remembers the orphaned block.
 	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
+	setBirthdayBlock(t, w)
 	require.True(t, hasStoredCredit(t, w, orphan))
 
 	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
-	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+	require.NoError(t, w.rollbackToChain(conn))
 
 	assert.False(t, hasStoredCredit(t, w, orphan))
 	assert.Nil(t, txDetails(t, w, orphan.Hash))
@@ -347,12 +362,13 @@ func TestRollbackToChainSpentOnlyBlock(t *testing.T) {
 	spendable := mineCoinbase(t, w, canonicalBranch, forkHeight-5)
 	spender := spendCoinbase(t, w, orphanedBranch, forkHeight, spendable)
 	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
+	setBirthdayBlock(t, w)
 
 	// The spend removed the coinbase from the store's unspent set.
 	require.False(t, hasStoredCredit(t, w, spendable))
 
 	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
-	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+	require.NoError(t, w.rollbackToChain(conn))
 
 	assert.True(t, hasStoredCredit(t, w, spendable))
 
@@ -370,9 +386,10 @@ func TestRollbackToChainDeepStaleBlock(t *testing.T) {
 	tip := forkHeight + waddrmgr.MaxReorgDepth
 	orphan := mineCoinbase(t, w, orphanedBranch, forkHeight)
 	syncManagerTo(t, w, canonicalBranch, tip, tip)
+	setBirthdayBlock(t, w)
 
 	conn := &reorgChainConn{branch: canonicalBranch, tip: tip}
-	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+	require.NoError(t, w.rollbackToChain(conn))
 
 	assert.False(t, hasStoredCredit(t, w, orphan))
 	assert.Equal(t, forkHeight-1, w.Manager.SyncedTo().Height)
@@ -386,9 +403,10 @@ func TestRollbackToChainCanonicalStore(t *testing.T) {
 
 	coinbase := mineCoinbase(t, w, canonicalBranch, forkHeight+10)
 	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
+	setBirthdayBlock(t, w)
 
 	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
-	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+	require.NoError(t, w.rollbackToChain(conn))
 
 	assert.True(t, hasStoredCredit(t, w, coinbase))
 	assert.Equal(t, tipHeight, w.Manager.SyncedTo().Height)
@@ -402,9 +420,10 @@ func TestRollbackToChainStaleManager(t *testing.T) {
 
 	coinbase := mineCoinbase(t, w, canonicalBranch, forkHeight+10)
 	syncManagerTo(t, w, orphanedBranch, forkHeight-1, forkHeight+20)
+	setBirthdayBlock(t, w)
 
 	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
-	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+	require.NoError(t, w.rollbackToChain(conn))
 
 	assert.False(t, hasStoredCredit(t, w, coinbase))
 	assert.Equal(t, forkHeight-1, w.Manager.SyncedTo().Height)

--- a/wallet/wallet/reorg_stale_block_test.go
+++ b/wallet/wallet/reorg_stale_block_test.go
@@ -1,0 +1,457 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+	"github.com/pearl-research-labs/pearl/node/txscript"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/pearl-research-labs/pearl/wallet/waddrmgr"
+	"github.com/pearl-research-labs/pearl/wallet/walletdb"
+	_ "github.com/pearl-research-labs/pearl/wallet/walletdb/bdb"
+	"github.com/pearl-research-labs/pearl/wallet/wtxmgr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// forkHeight is the height at which the two mocked branches diverge.
+	// Every hash below it is shared by both branches.
+	forkHeight int32 = 100
+
+	// tipHeight is the chain tip the mocked backend reports by default.
+	tipHeight int32 = 250
+
+	orphanedBranch  byte = 0xaa
+	canonicalBranch byte = 0xbb
+	sharedBranch    byte = 0x11
+)
+
+var reorgBaseTime = time.Unix(1700000000, 0)
+
+// branchHash returns the hash of the block at the given height on the given
+// branch, encoding the height so that headers can be served for it.
+func branchHash(branch byte, height int32) chainhash.Hash {
+	if height == 0 {
+		return *chaincfg.TestNetParams.GenesisHash
+	}
+	if height < forkHeight {
+		branch = sharedBranch
+	}
+
+	var hash chainhash.Hash
+	hash[0] = branch
+	hash[1] = byte(height >> 24)
+	hash[2] = byte(height >> 16)
+	hash[3] = byte(height >> 8)
+	hash[4] = byte(height)
+
+	return hash
+}
+
+func branchTime(height int32) time.Time {
+	return reorgBaseTime.Add(time.Duration(height) * time.Minute)
+}
+
+func blockMeta(branch byte, height int32) wtxmgr.BlockMeta {
+	return wtxmgr.BlockMeta{
+		Block: wtxmgr.Block{
+			Hash:   branchHash(branch, height),
+			Height: height,
+		},
+		Time: branchTime(height),
+	}
+}
+
+// reorgChainConn serves one of the two mocked branches and counts the block
+// hash lookups made against it.
+type reorgChainConn struct {
+	branch byte
+	tip    int32
+
+	blockHashCalls int
+}
+
+var _ chainConn = (*reorgChainConn)(nil)
+
+func (c *reorgChainConn) GetBestBlock() (*chainhash.Hash, int32, error) {
+	hash := branchHash(c.branch, c.tip)
+
+	return &hash, c.tip, nil
+}
+
+func (c *reorgChainConn) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	c.blockHashCalls++
+	hash := branchHash(c.branch, int32(height))
+
+	return &hash, nil
+}
+
+func (c *reorgChainConn) GetBlockHeader(
+	hash *chainhash.Hash) (*wire.BlockHeader, error) {
+
+	height := int32(hash[1])<<24 | int32(hash[2])<<16 |
+		int32(hash[3])<<8 | int32(hash[4])
+
+	return &wire.BlockHeader{
+		PrevBlock: branchHash(c.branch, height-1),
+		Timestamp: branchTime(height),
+	}, nil
+}
+
+// testBirthdayStamp returns a birthday well below the fork, so that a rollback
+// never has to relocate it.
+func testBirthdayStamp() *waddrmgr.BlockStamp {
+	return &waddrmgr.BlockStamp{
+		Hash:      branchHash(sharedBranch, 1),
+		Height:    1,
+		Timestamp: branchTime(1),
+	}
+}
+
+// syncManagerTo records the given branch's hash at every height in the range
+// and leaves the address manager synced to the last one.
+func syncManagerTo(t *testing.T, w *Wallet, branch byte, from, to int32) {
+	t.Helper()
+
+	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		for height := from; height <= to; height++ {
+			bs := waddrmgr.BlockStamp{
+				Hash:      branchHash(branch, height),
+				Height:    height,
+				Timestamp: branchTime(height),
+			}
+			if err := w.Manager.SetSyncedTo(ns, &bs); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// mineCoinbase records a coinbase paying the wallet in the block at the given
+// height on the given branch.
+func mineCoinbase(t *testing.T, w *Wallet, branch byte,
+	height int32) wire.OutPoint {
+
+	t.Helper()
+
+	coinbase := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{
+			PreviousOutPoint: wire.OutPoint{Index: math.MaxUint32},
+			SignatureScript: []byte{
+				branch, byte(height >> 8), byte(height),
+			},
+		}},
+		TxOut: []*wire.TxOut{
+			wire.NewTxOut(5_000_000_000, []byte{txscript.OP_TRUE}),
+		},
+	}
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(coinbase, branchTime(height))
+	require.NoError(t, err)
+
+	block := blockMeta(branch, height)
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+		if err := w.TxStore.InsertTx(ns, rec, &block); err != nil {
+			return err
+		}
+
+		return w.TxStore.AddCredit(ns, rec, &block, 0, false)
+	})
+	require.NoError(t, err)
+
+	return wire.OutPoint{Hash: rec.Hash, Index: 0}
+}
+
+// spendCoinbase records a transaction spending the given outpoint in the block
+// at the given height on the given branch.
+func spendCoinbase(t *testing.T, w *Wallet, branch byte, height int32,
+	op wire.OutPoint) chainhash.Hash {
+
+	t.Helper()
+
+	spend := &wire.MsgTx{
+		TxIn: []*wire.TxIn{{PreviousOutPoint: op}},
+		TxOut: []*wire.TxOut{
+			wire.NewTxOut(4_000_000_000, []byte{txscript.OP_TRUE}),
+		},
+	}
+	rec, err := wtxmgr.NewTxRecordFromMsgTx(spend, branchTime(height))
+	require.NoError(t, err)
+
+	block := blockMeta(branch, height)
+	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		return w.TxStore.InsertTx(
+			tx.ReadWriteBucket(wtxmgrNamespaceKey), rec, &block,
+		)
+	})
+	require.NoError(t, err)
+
+	return rec.Hash
+}
+
+// hasStoredCredit reports whether the store still holds a credit for op,
+// including credits spent by unmined transactions.
+func hasStoredCredit(t *testing.T, w *Wallet, op wire.OutPoint) bool {
+	t.Helper()
+
+	var found bool
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+		credits, err := w.TxStore.OutputsToWatch(ns)
+		if err != nil {
+			return err
+		}
+
+		for _, credit := range credits {
+			if credit.OutPoint == op {
+				found = true
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	return found
+}
+
+func lowestStaleHeight(t *testing.T, w *Wallet, conn chainConn) int32 {
+	t.Helper()
+
+	var blocks []wtxmgr.Block
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		var err error
+		blocks, err = w.TxStore.Blocks(
+			tx.ReadBucket(wtxmgrNamespaceKey),
+		)
+
+		return err
+	})
+	require.NoError(t, err)
+
+	height, err := lowestStaleBlockHeight(conn, blocks)
+	require.NoError(t, err)
+
+	return height
+}
+
+func txDetails(t *testing.T, w *Wallet,
+	hash chainhash.Hash) *wtxmgr.TxDetails {
+
+	t.Helper()
+
+	details, err := UnstableAPI(w).TxDetails(&hash)
+	require.NoError(t, err)
+
+	return details
+}
+
+func TestLowestStaleBlockHeight(t *testing.T) {
+	type record struct {
+		branch byte
+		height int32
+	}
+
+	tests := []struct {
+		name       string
+		records    []record
+		tip        int32
+		wantHeight int32
+		wantCalls  int
+	}{{
+		name: "every record canonical",
+		records: []record{
+			{sharedBranch, forkHeight - 10},
+			{canonicalBranch, forkHeight + 10},
+			{canonicalBranch, forkHeight + 20},
+		},
+		tip:       tipHeight,
+		wantCalls: 3,
+	}, {
+		name: "stale record below canonical ones",
+		records: []record{
+			{sharedBranch, forkHeight - 10},
+			{orphanedBranch, forkHeight},
+			{canonicalBranch, forkHeight + 10},
+			{canonicalBranch, forkHeight + 20},
+		},
+		tip:        tipHeight,
+		wantHeight: forkHeight,
+		wantCalls:  2,
+	}, {
+		name: "record above the chain tip",
+		records: []record{
+			{sharedBranch, forkHeight - 10},
+			{canonicalBranch, tipHeight + 5},
+		},
+		tip:        tipHeight,
+		wantHeight: tipHeight + 5,
+		wantCalls:  1,
+	}, {
+		name: "stale record deeper than the manager keeps hashes",
+		records: []record{
+			{orphanedBranch, forkHeight},
+			{canonicalBranch, forkHeight + waddrmgr.MaxReorgDepth},
+		},
+		tip:        forkHeight + waddrmgr.MaxReorgDepth,
+		wantHeight: forkHeight,
+		wantCalls:  1,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, cleanup := testWallet(t)
+			defer cleanup()
+
+			for _, rec := range tt.records {
+				mineCoinbase(t, w, rec.branch, rec.height)
+			}
+
+			conn := &reorgChainConn{
+				branch: canonicalBranch, tip: tt.tip,
+			}
+
+			assert.Equal(
+				t, tt.wantHeight, lowestStaleHeight(t, w, conn),
+			)
+			assert.Equal(t, tt.wantCalls, conn.blockHashCalls)
+		})
+	}
+}
+
+// TestRollbackToChainOrphanedCoinbase covers the reported failure: a coinbase
+// from an orphaned block survives in the store while the address manager has
+// long since been advanced over the canonical branch.
+func TestRollbackToChainOrphanedCoinbase(t *testing.T) {
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	orphan := mineCoinbase(t, w, orphanedBranch, forkHeight)
+	canonical := mineCoinbase(t, w, canonicalBranch, forkHeight+10)
+
+	// Connects on the new branch overwrote the manager's hash history, so
+	// nothing but the store remembers the orphaned block.
+	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
+	require.True(t, hasStoredCredit(t, w, orphan))
+
+	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
+	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+
+	assert.False(t, hasStoredCredit(t, w, orphan))
+	assert.Nil(t, txDetails(t, w, orphan.Hash))
+
+	// The canonical block above the orphan is detached as well, and the
+	// manager is rewound so that the rescan replays both.
+	assert.False(t, hasStoredCredit(t, w, canonical))
+	assert.Equal(t, forkHeight-1, w.Manager.SyncedTo().Height)
+	assert.Equal(t, branchHash(canonicalBranch, forkHeight-1),
+		w.Manager.SyncedTo().Hash)
+}
+
+// TestRollbackToChainSpentOnlyBlock covers an orphaned block that holds no
+// unspent output of its own: it only spends one, which leaves a live UTXO
+// wrongly marked as spent.
+func TestRollbackToChainSpentOnlyBlock(t *testing.T) {
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	spendable := mineCoinbase(t, w, canonicalBranch, forkHeight-5)
+	spender := spendCoinbase(
+		t, w, orphanedBranch, forkHeight, spendable,
+	)
+	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
+
+	// The spend removed the coinbase from the store's unspent set.
+	require.False(t, hasStoredCredit(t, w, spendable))
+
+	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
+	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+
+	assert.True(t, hasStoredCredit(t, w, spendable))
+
+	details := txDetails(t, w, spender)
+	require.NotNil(t, details)
+	assert.Equal(t, int32(-1), details.Block.Height)
+}
+
+// TestRollbackToChainDeepStaleBlock ensures a mismatch further below the tip
+// than the manager keeps block hashes for is still repaired.
+func TestRollbackToChainDeepStaleBlock(t *testing.T) {
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	tip := forkHeight + waddrmgr.MaxReorgDepth
+	orphan := mineCoinbase(t, w, orphanedBranch, forkHeight)
+	syncManagerTo(t, w, canonicalBranch, tip, tip)
+
+	conn := &reorgChainConn{branch: canonicalBranch, tip: tip}
+	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+
+	assert.False(t, hasStoredCredit(t, w, orphan))
+	assert.Equal(t, forkHeight-1, w.Manager.SyncedTo().Height)
+}
+
+// TestRollbackToChainCanonicalStore ensures a wallet that agrees with the
+// chain is left untouched.
+func TestRollbackToChainCanonicalStore(t *testing.T) {
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	coinbase := mineCoinbase(t, w, canonicalBranch, forkHeight+10)
+	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
+
+	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
+	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+
+	assert.True(t, hasStoredCredit(t, w, coinbase))
+	assert.Equal(t, tipHeight, w.Manager.SyncedTo().Height)
+}
+
+// TestRollbackToChainStaleManager is a regression test for the pre-existing
+// repair path, where the address manager itself holds the stale hashes.
+func TestRollbackToChainStaleManager(t *testing.T) {
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	coinbase := mineCoinbase(t, w, canonicalBranch, forkHeight+10)
+	syncManagerTo(t, w, orphanedBranch, forkHeight-1, forkHeight+20)
+
+	conn := &reorgChainConn{branch: canonicalBranch, tip: tipHeight}
+	require.NoError(t, w.rollbackToChain(conn, testBirthdayStamp()))
+
+	assert.False(t, hasStoredCredit(t, w, coinbase))
+	assert.Equal(t, forkHeight-1, w.Manager.SyncedTo().Height)
+}
+
+// TestDisconnectBlockNotChainSynced pins the current behavior of the live
+// disconnect path, which this change only instruments.
+func TestDisconnectBlockNotChainSynced(t *testing.T) {
+	w, cleanup := testWallet(t)
+	defer cleanup()
+
+	orphan := mineCoinbase(t, w, orphanedBranch, forkHeight)
+	syncManagerTo(t, w, orphanedBranch, forkHeight, forkHeight)
+	w.SetChainSynced(false)
+
+	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		return w.disconnectBlock(
+			tx, blockMeta(orphanedBranch, forkHeight),
+		)
+	})
+	require.NoError(t, err)
+
+	assert.True(t, hasStoredCredit(t, w, orphan))
+	assert.Equal(t, forkHeight, w.Manager.SyncedTo().Height)
+}

--- a/wallet/wallet/reorg_stale_block_test.go
+++ b/wallet/wallet/reorg_stale_block_test.go
@@ -94,9 +94,7 @@ func (c *reorgChainConn) GetBlockHash(height int64) (*chainhash.Hash, error) {
 	return &hash, nil
 }
 
-func (c *reorgChainConn) GetBlockHeader(
-	hash *chainhash.Hash) (*wire.BlockHeader, error) {
-
+func (c *reorgChainConn) GetBlockHeader(hash *chainhash.Hash) (*wire.BlockHeader, error) {
 	height := int32(hash[1])<<24 | int32(hash[2])<<16 |
 		int32(hash[3])<<8 | int32(hash[4])
 
@@ -141,21 +139,15 @@ func syncManagerTo(t *testing.T, w *Wallet, branch byte, from, to int32) {
 
 // mineCoinbase records a coinbase paying the wallet in the block at the given
 // height on the given branch.
-func mineCoinbase(t *testing.T, w *Wallet, branch byte,
-	height int32) wire.OutPoint {
-
+func mineCoinbase(t *testing.T, w *Wallet, branch byte, height int32) wire.OutPoint {
 	t.Helper()
 
 	coinbase := &wire.MsgTx{
 		TxIn: []*wire.TxIn{{
 			PreviousOutPoint: wire.OutPoint{Index: math.MaxUint32},
-			SignatureScript: []byte{
-				branch, byte(height >> 8), byte(height),
-			},
+			SignatureScript:  []byte{branch, byte(height >> 8), byte(height)},
 		}},
-		TxOut: []*wire.TxOut{
-			wire.NewTxOut(5_000_000_000, []byte{txscript.OP_TRUE}),
-		},
+		TxOut: []*wire.TxOut{wire.NewTxOut(5_000_000_000, []byte{txscript.OP_TRUE})},
 	}
 	rec, err := wtxmgr.NewTxRecordFromMsgTx(coinbase, branchTime(height))
 	require.NoError(t, err)
@@ -176,25 +168,19 @@ func mineCoinbase(t *testing.T, w *Wallet, branch byte,
 
 // spendCoinbase records a transaction spending the given outpoint in the block
 // at the given height on the given branch.
-func spendCoinbase(t *testing.T, w *Wallet, branch byte, height int32,
-	op wire.OutPoint) chainhash.Hash {
-
+func spendCoinbase(t *testing.T, w *Wallet, branch byte, height int32, op wire.OutPoint) chainhash.Hash {
 	t.Helper()
 
 	spend := &wire.MsgTx{
-		TxIn: []*wire.TxIn{{PreviousOutPoint: op}},
-		TxOut: []*wire.TxOut{
-			wire.NewTxOut(4_000_000_000, []byte{txscript.OP_TRUE}),
-		},
+		TxIn:  []*wire.TxIn{{PreviousOutPoint: op}},
+		TxOut: []*wire.TxOut{wire.NewTxOut(4_000_000_000, []byte{txscript.OP_TRUE})},
 	}
 	rec, err := wtxmgr.NewTxRecordFromMsgTx(spend, branchTime(height))
 	require.NoError(t, err)
 
 	block := blockMeta(branch, height)
 	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		return w.TxStore.InsertTx(
-			tx.ReadWriteBucket(wtxmgrNamespaceKey), rec, &block,
-		)
+		return w.TxStore.InsertTx(tx.ReadWriteBucket(wtxmgrNamespaceKey), rec, &block)
 	})
 	require.NoError(t, err)
 
@@ -233,9 +219,7 @@ func lowestStaleHeight(t *testing.T, w *Wallet, conn chainConn) int32 {
 	var blocks []wtxmgr.Block
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		var err error
-		blocks, err = w.TxStore.Blocks(
-			tx.ReadBucket(wtxmgrNamespaceKey),
-		)
+		blocks, err = w.TxStore.Blocks(tx.ReadBucket(wtxmgrNamespaceKey))
 
 		return err
 	})
@@ -247,9 +231,7 @@ func lowestStaleHeight(t *testing.T, w *Wallet, conn chainConn) int32 {
 	return height
 }
 
-func txDetails(t *testing.T, w *Wallet,
-	hash chainhash.Hash) *wtxmgr.TxDetails {
-
+func txDetails(t *testing.T, w *Wallet, hash chainhash.Hash) *wtxmgr.TxDetails {
 	t.Helper()
 
 	details, err := UnstableAPI(w).TxDetails(&hash)
@@ -319,13 +301,9 @@ func TestLowestStaleBlockHeight(t *testing.T) {
 				mineCoinbase(t, w, rec.branch, rec.height)
 			}
 
-			conn := &reorgChainConn{
-				branch: canonicalBranch, tip: tt.tip,
-			}
+			conn := &reorgChainConn{branch: canonicalBranch, tip: tt.tip}
 
-			assert.Equal(
-				t, tt.wantHeight, lowestStaleHeight(t, w, conn),
-			)
+			assert.Equal(t, tt.wantHeight, lowestStaleHeight(t, w, conn))
 			assert.Equal(t, tt.wantCalls, conn.blockHashCalls)
 		})
 	}
@@ -356,8 +334,7 @@ func TestRollbackToChainOrphanedCoinbase(t *testing.T) {
 	// manager is rewound so that the rescan replays both.
 	assert.False(t, hasStoredCredit(t, w, canonical))
 	assert.Equal(t, forkHeight-1, w.Manager.SyncedTo().Height)
-	assert.Equal(t, branchHash(canonicalBranch, forkHeight-1),
-		w.Manager.SyncedTo().Hash)
+	assert.Equal(t, branchHash(canonicalBranch, forkHeight-1), w.Manager.SyncedTo().Hash)
 }
 
 // TestRollbackToChainSpentOnlyBlock covers an orphaned block that holds no
@@ -368,9 +345,7 @@ func TestRollbackToChainSpentOnlyBlock(t *testing.T) {
 	defer cleanup()
 
 	spendable := mineCoinbase(t, w, canonicalBranch, forkHeight-5)
-	spender := spendCoinbase(
-		t, w, orphanedBranch, forkHeight, spendable,
-	)
+	spender := spendCoinbase(t, w, orphanedBranch, forkHeight, spendable)
 	syncManagerTo(t, w, canonicalBranch, forkHeight, tipHeight)
 
 	// The spend removed the coinbase from the store's unspent set.
@@ -446,9 +421,7 @@ func TestDisconnectBlockNotChainSynced(t *testing.T) {
 	w.SetChainSynced(false)
 
 	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		return w.disconnectBlock(
-			tx, blockMeta(orphanedBranch, forkHeight),
-		)
+		return w.disconnectBlock(tx, blockMeta(orphanedBranch, forkHeight))
 	})
 	require.NoError(t, err)
 

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -458,8 +458,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 			return w.Manager.SetBirthdayBlock(ns, *birthdayStamp, true)
 		})
 		if err != nil {
-			return fmt.Errorf("unable to persist initial sync "+
-				"data: %w", err)
+			return fmt.Errorf("unable to persist initial sync data: %w", err)
 		}
 	}
 
@@ -467,8 +466,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 	// so now.
 	if w.recoveryWindow > 0 {
 		if err := w.recovery(chainClient, birthdayStamp); err != nil {
-			return fmt.Errorf("unable to perform wallet recovery: "+
-				"%w", err)
+			return fmt.Errorf("unable to perform wallet recovery: %w", err)
 		}
 	}
 
@@ -702,9 +700,7 @@ func (w *Wallet) waitUntilBackendSynced(chainClient chain.Interface) error {
 // locateBirthdayBlock returns a block that meets the given birthday timestamp
 // by a margin of +/-2 hours. This is safe to do as the timestamp is already 2
 // days in the past of the actual timestamp.
-func locateBirthdayBlock(chainClient chainConn,
-	birthday time.Time) (*waddrmgr.BlockStamp, error) {
-
+func locateBirthdayBlock(chainClient chainConn, birthday time.Time) (*waddrmgr.BlockStamp, error) {
 	// Retrieve the lookup range for our block.
 	startHeight := int32(0)
 	_, bestHeight, err := chainClient.GetBestBlock()
@@ -712,8 +708,7 @@ func locateBirthdayBlock(chainClient chainConn,
 		return nil, err
 	}
 
-	log.Debugf("Locating suitable block for birthday %v between blocks "+
-		"%v-%v", birthday, startHeight, bestHeight)
+	log.Debugf("Locating suitable block for birthday %v between blocks %v-%v", birthday, startHeight, bestHeight)
 
 	var (
 		birthdayBlock *waddrmgr.BlockStamp
@@ -735,8 +730,7 @@ func locateBirthdayBlock(chainClient chainConn,
 			return nil, err
 		}
 
-		log.Debugf("Checking candidate block: height=%v, hash=%v, "+
-			"timestamp=%v", mid, hash, header.Timestamp)
+		log.Debugf("Checking candidate block: height=%v, hash=%v, timestamp=%v", mid, hash, header.Timestamp)
 
 		// If the search happened to reach either of our range extremes,
 		// then we'll just use that as there's nothing left to search.
@@ -790,11 +784,8 @@ type recoverySyncer struct {
 // recovery attempts to recover any unspent outputs that pay to any of our
 // addresses starting from our birthday, or the wallet's tip (if higher), which
 // would indicate resuming a recovery after a restart.
-func (w *Wallet) recovery(chainClient chain.Interface,
-	birthdayBlock *waddrmgr.BlockStamp) error {
-
-	log.Infof("RECOVERY MODE ENABLED -- rescanning for used addresses "+
-		"with recovery_window=%d", w.recoveryWindow)
+func (w *Wallet) recovery(chainClient chain.Interface, birthdayBlock *waddrmgr.BlockStamp) error {
+	log.Infof("RECOVERY MODE ENABLED -- rescanning for used addresses with recovery_window=%d", w.recoveryWindow)
 
 	// Wallet locking must synchronize with the end of recovery, since use of
 	// keys in recovery is racy with manager IsLocked checks, which could
@@ -910,8 +901,7 @@ func (w *Wallet) recovery(chainClient chain.Interface,
 			}
 
 			if len(recoveryBatch) > 0 {
-				log.Infof("Recovered addresses from blocks "+
-					"%d-%d", recoveryBatch[0].Height,
+				log.Infof("Recovered addresses from blocks %d-%d", recoveryBatch[0].Height,
 					recoveryBatch[len(recoveryBatch)-1].Height)
 			}
 
@@ -1264,9 +1254,7 @@ func extendFoundAddresses(ns walletdb.ReadWriteBucket,
 
 // logFilterBlocksResp provides useful logging information when filtering
 // succeeded in finding relevant transactions.
-func logFilterBlocksResp(block wtxmgr.BlockMeta,
-	resp *chain.FilterBlocksResponse) {
-
+func logFilterBlocksResp(block wtxmgr.BlockMeta, resp *chain.FilterBlocksResponse) {
 	// Log the number of external addresses found in this block.
 	var nFoundExternal int
 	for _, indexes := range resp.FoundExternalAddrs {
@@ -1290,8 +1278,7 @@ func logFilterBlocksResp(block wtxmgr.BlockMeta,
 	// Log the number of outpoints found in this block.
 	nFoundOutPoints := len(resp.FoundOutPoints)
 	if nFoundOutPoints > 0 {
-		log.Infof("Found %d spends from watched outpoints at "+
-			"height=%d hash=%v",
+		log.Infof("Found %d spends from watched outpoints at height=%d hash=%v",
 			nFoundOutPoints, block.Height, block.Hash)
 	}
 }
@@ -1690,9 +1677,7 @@ func (w *Wallet) ChangePublicPassphrase(old, new []byte) error {
 
 // ChangePassphrases modifies the public and private passphrase of the wallet
 // atomically.
-func (w *Wallet) ChangePassphrases(publicOld, publicNew, privateOld,
-	privateNew []byte) error {
-
+func (w *Wallet) ChangePassphrases(publicOld, publicNew, privateOld, privateNew []byte) error {
 	err := make(chan error, 1)
 	w.changePassphrases <- changePassphrasesRequest{
 		publicOld:  publicOld,
@@ -1923,9 +1908,7 @@ func (w *Wallet) PubKeyForAddress(a btcutil.Address) (*btcec.PublicKey, error) {
 // LabelTransaction adds a label to the transaction with the hash provided. The
 // call will fail if the label is too long, or if the transaction already has
 // a label and the overwrite boolean is not set.
-func (w *Wallet) LabelTransaction(hash chainhash.Hash, label string,
-	overwrite bool) error {
-
+func (w *Wallet) LabelTransaction(hash chainhash.Hash, label string, overwrite bool) error {
 	// Check that the transaction is known to the wallet, and fail if it is
 	// unknown. If the transaction is known, check whether it already has
 	// a label.
@@ -2089,9 +2072,7 @@ func (w *Wallet) AccountProperties(scope waddrmgr.KeyScope, acct uint32) (*waddr
 // AccountPropertiesByName returns the properties of an account by its name. It
 // first fetches the desynced information from the address manager, then updates
 // the indexes based on the address pools.
-func (w *Wallet) AccountPropertiesByName(scope waddrmgr.KeyScope,
-	name string) (*waddrmgr.AccountProperties, error) {
-
+func (w *Wallet) AccountPropertiesByName(scope waddrmgr.KeyScope, name string) (*waddrmgr.AccountProperties, error) {
 	manager, err := w.Manager.FetchScopedKeyManager(scope)
 	if err != nil {
 		return nil, err
@@ -2175,8 +2156,7 @@ func (w *Wallet) NextAccount(scope waddrmgr.KeyScope, name string) (uint32, erro
 		return err
 	})
 	if err != nil {
-		log.Errorf("Cannot fetch new account properties for notification "+
-			"after account creation: %v", err)
+		log.Errorf("Cannot fetch new account properties for notification after account creation: %v", err)
 	} else {
 		w.NtfnServer.notifyAccountProperties(props)
 	}
@@ -2672,9 +2652,7 @@ type GetTransactionResult struct {
 
 // GetTransaction returns detailed data of a transaction given its id. In
 // addition it returns properties about its block.
-func (w *Wallet) GetTransaction(txHash chainhash.Hash) (*GetTransactionResult,
-	error) {
-
+func (w *Wallet) GetTransaction(txHash chainhash.Hash) (*GetTransactionResult, error) {
 	var res GetTransactionResult
 	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
@@ -2813,9 +2791,7 @@ type AccountBalanceResult struct {
 // AccountBalances returns all accounts in the wallet and their balances.
 // Balances are determined by excluding transactions that have not met
 // requiredConfs confirmations.
-func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope,
-	requiredConfs int32) ([]AccountBalanceResult, error) {
-
+func (w *Wallet) AccountBalances(scope waddrmgr.KeyScope, requiredConfs int32) ([]AccountBalanceResult, error) {
 	manager, err := w.Manager.FetchScopedKeyManager(scope)
 	if err != nil {
 		return nil, err
@@ -2933,9 +2909,7 @@ func (s creditSlice) Swap(i, j int) {
 // minconf, less than maxconf and if addresses is populated only the addresses
 // contained within it will be considered.  If we know nothing about a
 // transaction an empty array will be returned.
-func (w *Wallet) ListUnspent(minconf, maxconf int32,
-	accountName string) ([]*btcjson.ListUnspentResult, error) {
-
+func (w *Wallet) ListUnspent(minconf, maxconf int32, accountName string) ([]*btcjson.ListUnspentResult, error) {
 	var results []*btcjson.ListUnspentResult
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
@@ -3062,8 +3036,7 @@ func (w *Wallet) ListLeasedOutputs() ([]*ListLeasedOutputResult, error) {
 			}
 
 			if details == nil {
-				log.Infof("unable to find tx details for "+
-					"%v:%v", output.Outpoint.Hash,
+				log.Infof("unable to find tx details for %v:%v", output.Outpoint.Hash,
 					output.Outpoint.Index)
 				continue
 			}
@@ -3216,9 +3189,7 @@ func (w *Wallet) LockedOutpoints() []btcjson.TransactionInput {
 //
 // NOTE: This differs from LockOutpoint in that outputs are locked for a limited
 // amount of time and their locks are persisted to disk.
-func (w *Wallet) LeaseOutput(id wtxmgr.LockID, op wire.OutPoint,
-	duration time.Duration) (time.Time, error) {
-
+func (w *Wallet) LeaseOutput(id wtxmgr.LockID, op wire.OutPoint, duration time.Duration) (time.Time, error) {
 	var expiry time.Time
 	err := walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrNamespaceKey)
@@ -3251,8 +3222,7 @@ func (w *Wallet) resendUnminedTxs() {
 		return err
 	})
 	if err != nil {
-		log.Errorf("Unable to retrieve unconfirmed transactions to "+
-			"resend: %v", err)
+		log.Errorf("Unable to retrieve unconfirmed transactions to resend: %v", err)
 		return
 	}
 
@@ -3289,9 +3259,7 @@ func (w *Wallet) SortedActivePaymentAddresses() ([]string, error) {
 }
 
 // NewAddress returns the next external chained address for a wallet.
-func (w *Wallet) NewAddress(account uint32,
-	scope waddrmgr.KeyScope, includePQTapscript bool) (btcutil.Address, error) {
-
+func (w *Wallet) NewAddress(account uint32, scope waddrmgr.KeyScope, includePQTapscript bool) (btcutil.Address, error) {
 	chainClient, err := w.requireChainClient()
 	if err != nil {
 		return nil, err
@@ -3346,8 +3314,7 @@ func (w *Wallet) newAddress(addrmgrNs walletdb.ReadWriteBucket, account uint32,
 
 	props, err := manager.AccountProperties(addrmgrNs, account)
 	if err != nil {
-		log.Errorf("Cannot fetch account properties for notification "+
-			"after deriving next external address: %v", err)
+		log.Errorf("Cannot fetch account properties for notification after deriving next external address: %v", err)
 		return nil, nil, err
 	}
 
@@ -3763,9 +3730,7 @@ func (w *Wallet) PublishTransaction(tx *wire.MsgTx, label string) error {
 // relevant database state, and finally possible removing the transaction from
 // the database (along with cleaning up all inputs used, and outputs created) if
 // the transaction is rejected by the backend.
-func (w *Wallet) reliablyPublishTransaction(tx *wire.MsgTx,
-	label string) (*chainhash.Hash, error) {
-
+func (w *Wallet) reliablyPublishTransaction(tx *wire.MsgTx, label string) (*chainhash.Hash, error) {
 	chainClient, err := w.requireChainClient()
 	if err != nil {
 		return nil, err
@@ -3869,8 +3834,7 @@ func (w *Wallet) publishTransaction(tx *wire.MsgTx) (*chainhash.Hash, error) {
 			return w.TxStore.RemoveUnminedTx(txmgrNs, txRec)
 		})
 		if dbErr != nil {
-			log.Warnf("Unable to remove confirmed transaction %v "+
-				"from unconfirmed store: %v", tx.TxHash(), dbErr)
+			log.Warnf("Unable to remove confirmed transaction %v from unconfirmed store: %v", tx.TxHash(), dbErr)
 		}
 
 		log.Infof("%v: tx already confirmed", txid)
@@ -3999,9 +3963,7 @@ func (w *Wallet) AddScopeManager(scope waddrmgr.KeyScope,
 
 // InitAccounts creates a number of accounts specified by `num`, with account
 // number ranges from 1 to `num`.
-func (w *Wallet) InitAccounts(scope *waddrmgr.ScopedKeyManager,
-	watchOnly bool, num uint32) error {
-
+func (w *Wallet) InitAccounts(scope *waddrmgr.ScopedKeyManager, watchOnly bool, num uint32) error {
 	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
@@ -4043,13 +4005,10 @@ func (w *Wallet) InitAccounts(scope *waddrmgr.ScopedKeyManager,
 
 // DeriveFromKeyPath derives a private key using the given derivation path.
 // Uses PQ signatures by default.
-func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope,
-	path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
-
+func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope, path waddrmgr.DerivationPath) (*btcec.PrivateKey, error) {
 	scopedMgr, err := w.Manager.FetchScopedKeyManager(scope)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching manager for scope %v: "+
-			"%w", scope, err)
+		return nil, fmt.Errorf("error fetching manager for scope %v: %w", scope, err)
 	}
 
 	// Let's see if we can hit the private key cache.
@@ -4071,8 +4030,7 @@ func (w *Wallet) DeriveFromKeyPath(scope waddrmgr.KeyScope,
 
 		mpka, ok := addr.(waddrmgr.ManagedPubKeyAddress)
 		if !ok {
-			err := fmt.Errorf("managed address type for %v is "+
-				"`%T` but want waddrmgr.ManagedPubKeyAddress",
+			err := fmt.Errorf("managed address type for %v is `%T` but want waddrmgr.ManagedPubKeyAddress",
 				addr, addr)
 
 			return err
@@ -4095,8 +4053,7 @@ func (w *Wallet) DeriveFromKeyPathAddAccount(scope waddrmgr.KeyScope,
 
 	scopedMgr, err := w.Manager.FetchScopedKeyManager(scope)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching manager for scope %v: "+
-			"%w", scope, err)
+		return nil, fmt.Errorf("error fetching manager for scope %v: %w", scope, err)
 	}
 
 	// Let's see if we can hit the private key cache.
@@ -4216,9 +4173,7 @@ func Create(db walletdb.DB, pubPass, privPass []byte,
 // an empty database. No root key can be provided as this wallet will be
 // watching only.  Likewise no private passphrase may be provided
 // either.
-func CreateWatchingOnly(db walletdb.DB, pubPass []byte,
-	params *chaincfg.Params, birthday time.Time) error {
-
+func CreateWatchingOnly(db walletdb.DB, pubPass []byte, params *chaincfg.Params, birthday time.Time) error {
 	return create(
 		db, pubPass, nil, nil, params, birthday, true, nil,
 	)

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -473,7 +473,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 	// Compare previously-seen blocks against the current chain. If any of
 	// these blocks no longer exist, rollback all of the missing blocks
 	// before catching up with the rescan.
-	if err := w.rollbackToChain(chainClient, birthdayStamp); err != nil {
+	if err := w.rollbackToChain(chainClient); err != nil {
 		return err
 	}
 
@@ -510,7 +510,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 // rollbackToChain compares the blocks the wallet has previously seen against
 // the current chain and rolls back the ones that are no longer part of it, so
 // that the rescan which follows re-applies the canonical chain.
-func (w *Wallet) rollbackToChain(chainClient chainConn, birthdayStamp *waddrmgr.BlockStamp) error {
+func (w *Wallet) rollbackToChain(chainClient chainConn) error {
 	// The address manager's hash history is overwritten with canonical
 	// hashes as blocks are connected, so a reorg the wallet never applied
 	// survives only in the transaction store.
@@ -576,23 +576,10 @@ func (w *Wallet) rollbackToChain(chainClient chainConn, birthdayStamp *waddrmgr.
 		}
 
 		if rewindManager {
-			err := w.Manager.SetSyncedTo(addrmgrNs, &rollbackStamp)
+			err := w.Manager.Rollback(addrmgrNs, &rollbackStamp)
 			if err != nil {
-				return err
-			}
-
-			// If the rollback happened to go beyond our birthday
-			// stamp, we'll need to find a new one by syncing with
-			// the chain again until finding one.
-			if rollbackStamp.Height <= birthdayStamp.Height &&
-				rollbackStamp.Hash != birthdayStamp.Hash {
-
-				err := w.Manager.SetBirthdayBlock(
-					addrmgrNs, rollbackStamp, true,
-				)
-				if err != nil {
-					return err
-				}
+				return fmt.Errorf("unable to roll back the address manager to height %d: %w",
+					rollbackStamp.Height, err)
 			}
 		}
 

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -512,32 +512,26 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 // rollbackToChain compares the blocks the wallet has previously seen against
 // the current chain and rolls back the ones that are no longer part of it, so
 // that the rescan which follows re-applies the canonical chain.
-func (w *Wallet) rollbackToChain(chainClient chainConn,
-	birthdayStamp *waddrmgr.BlockStamp) error {
-
+func (w *Wallet) rollbackToChain(chainClient chainConn, birthdayStamp *waddrmgr.BlockStamp) error {
 	// The address manager's hash history is overwritten with canonical
 	// hashes as blocks are connected, so a reorg the wallet never applied
 	// survives only in the transaction store.
 	var blocks []wtxmgr.Block
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		var err error
-		blocks, err = w.TxStore.Blocks(
-			tx.ReadBucket(wtxmgrNamespaceKey),
-		)
+		blocks, err = w.TxStore.Blocks(tx.ReadBucket(wtxmgrNamespaceKey))
 
 		return err
 	})
 	if err != nil {
-		return fmt.Errorf("unable to read the wallet's recorded "+
-			"blocks: %w", err)
+		return fmt.Errorf("unable to read the wallet's recorded blocks: %w", err)
 	}
 
 	// Verify those blocks with no database transaction held, as this
 	// queries the backend once per recorded block.
 	staleHeight, err := lowestStaleBlockHeight(chainClient, blocks)
 	if err != nil {
-		return fmt.Errorf("unable to verify the wallet's %d recorded "+
-			"blocks against the chain: %w", len(blocks), err)
+		return fmt.Errorf("unable to verify the wallet's %d recorded blocks against the chain: %w", len(blocks), err)
 	}
 
 	rewindManager := false
@@ -554,10 +548,8 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 			}
 			stamp, err := canonicalStampAt(chainClient, height)
 			if err != nil {
-				return fmt.Errorf("unable to fetch the "+
-					"chain's block at height %d while "+
-					"looking for the wallet's fork point: "+
-					"%w", height, err)
+				return fmt.Errorf("unable to fetch the chain's block at height %d while finding the fork point: %w",
+					height, err)
 			}
 
 			rollbackStamp = stamp
@@ -571,13 +563,9 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 		// be detached as well, which means rewinding the manager below
 		// it so that the rescan replays those heights.
 		if staleHeight > 0 && staleHeight <= rollbackStamp.Height {
-			stamp, err := canonicalStampAt(
-				chainClient, staleHeight-1,
-			)
+			stamp, err := canonicalStampAt(chainClient, staleHeight-1)
 			if err != nil {
-				return fmt.Errorf("unable to fetch the parent "+
-					"of stale block at height %d: %w",
-					staleHeight, err)
+				return fmt.Errorf("unable to fetch the parent of stale block at height %d: %w", staleHeight, err)
 			}
 
 			rollbackStamp = stamp
@@ -616,9 +604,7 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 		// prevent unconfirming transactions in the synced-to block.
 		height := rollbackStamp.Height + 1
 		if err := w.TxStore.Rollback(txmgrNs, height); err != nil {
-			return fmt.Errorf("unable to roll back the "+
-				"transaction store to height %d: %w", height,
-				err)
+			return fmt.Errorf("unable to roll back the transaction store to height %d: %w", height, err)
 		}
 
 		return nil
@@ -626,9 +612,7 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 }
 
 // canonicalStampAt returns the block stamp the chain has at the given height.
-func canonicalStampAt(chainClient chainConn,
-	height int32) (waddrmgr.BlockStamp, error) {
-
+func canonicalStampAt(chainClient chainConn, height int32) (waddrmgr.BlockStamp, error) {
 	hash, err := chainClient.GetBlockHash(int64(height))
 	if err != nil {
 		return waddrmgr.BlockStamp{}, err
@@ -648,9 +632,7 @@ func canonicalStampAt(chainClient chainConn,
 // lowestStaleBlockHeight returns the height of the lowest given block that the
 // chain no longer has, or zero when the chain still has all of them. The
 // blocks must be ordered by ascending height.
-func lowestStaleBlockHeight(chainClient chainConn,
-	blocks []wtxmgr.Block) (int32, error) {
-
+func lowestStaleBlockHeight(chainClient chainConn, blocks []wtxmgr.Block) (int32, error) {
 	_, bestHeight, err := chainClient.GetBestBlock()
 	if err != nil {
 		return 0, err
@@ -674,15 +656,13 @@ func lowestStaleBlockHeight(chainClient chainConn,
 			}
 		}
 
-		log.Warnf("Block %v at height %d is no longer part of the "+
-			"chain, rolling back a reorg that was never applied",
+		log.Warnf("Block %v at height %d is no longer on the chain, rolling back a reorg that was never applied",
 			b.Hash, b.Height)
 
 		return b.Height, nil
 	}
 
-	log.Infof("Verified the wallet's %d recorded blocks against the chain "+
-		"in %v", len(blocks), time.Since(started))
+	log.Infof("Verified the wallet's %d recorded blocks against the chain in %v", len(blocks), time.Since(started))
 
 	return 0, nil
 }

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -532,68 +532,68 @@ func (w *Wallet) rollbackToChain(chainClient chainConn) error {
 		return fmt.Errorf("unable to verify the wallet's %d recorded blocks against the chain: %w", len(blocks), err)
 	}
 
-	rewindManager := false
-	rollbackStamp := w.Manager.SyncedTo()
+	syncedTo := w.Manager.SyncedTo()
 
 	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
 
-		for height := rollbackStamp.Height; true; height-- {
-			hash, err := w.Manager.BlockHash(addrmgrNs, height)
-			if err != nil {
-				return err
-			}
-			stamp, err := canonicalStampAt(chainClient, height)
-			if err != nil {
-				return fmt.Errorf("unable to fetch the chain's block at height %d while finding the fork point: %w",
-					height, err)
-			}
-
-			rollbackStamp = stamp
-			if bytes.Equal(hash[:], stamp.Hash[:]) {
-				break
-			}
-			rewindManager = true
+		target, err := w.forkPoint(addrmgrNs, chainClient, syncedTo.Height)
+		if err != nil {
+			return err
 		}
 
-		// A stale block the address manager no longer remembers has to
-		// be detached as well, which means rewinding the manager below
-		// it so that the rescan replays those heights.
-		if staleHeight > 0 && staleHeight <= rollbackStamp.Height {
-			stamp, err := canonicalStampAt(chainClient, staleHeight-1)
+		// A stale block at or below the fork point has to be detached
+		// as well, so rewind under it and let the rescan replay those
+		// heights from the canonical chain.
+		if staleHeight > 0 && staleHeight <= target.Height {
+			target, err = canonicalStampAt(chainClient, staleHeight-1)
 			if err != nil {
 				return fmt.Errorf("unable to fetch the parent of stale block at height %d: %w", staleHeight, err)
 			}
-
-			rollbackStamp = stamp
-			rewindManager = true
 		}
 
-		// If nothing diverged, we can proceed safely.
-		if !rewindManager && staleHeight == 0 {
+		// Nothing diverged, so there is nothing to detach.
+		if target.Height == syncedTo.Height && staleHeight == 0 {
 			return nil
 		}
 
-		if rewindManager {
-			err := w.Manager.Rollback(addrmgrNs, &rollbackStamp)
-			if err != nil {
-				return fmt.Errorf("unable to roll back the address manager to height %d: %w",
-					rollbackStamp.Height, err)
-			}
+		if err := w.Manager.Rollback(addrmgrNs, &target); err != nil {
+			return fmt.Errorf("unable to roll back the address manager to height %d: %w", target.Height, err)
 		}
 
-		// Finally, we'll roll back our transaction store to reflect the
-		// stale state. `Rollback` unconfirms transactions at and beyond
-		// the passed height, so add one to the new synced-to height to
-		// prevent unconfirming transactions in the synced-to block.
-		height := rollbackStamp.Height + 1
-		if err := w.TxStore.Rollback(txmgrNs, height); err != nil {
-			return fmt.Errorf("unable to roll back the transaction store to height %d: %w", height, err)
+		// Rollback unconfirms transactions at and beyond the height it
+		// is given, so start one above the wallet's new tip to leave
+		// that block's transactions confirmed.
+		if err := w.TxStore.Rollback(txmgrNs, target.Height+1); err != nil {
+			return fmt.Errorf("unable to roll back the transaction store to height %d: %w", target.Height+1, err)
 		}
 
 		return nil
 	})
+}
+
+// forkPoint returns the highest block at or below the given height that both
+// the address manager and the chain have recorded.
+func (w *Wallet) forkPoint(ns walletdb.ReadBucket, chainClient chainConn, height int32) (waddrmgr.BlockStamp, error) {
+	for {
+		hash, err := w.Manager.BlockHash(ns, height)
+		if err != nil {
+			return waddrmgr.BlockStamp{}, err
+		}
+
+		stamp, err := canonicalStampAt(chainClient, height)
+		if err != nil {
+			return waddrmgr.BlockStamp{}, fmt.Errorf(
+				"unable to fetch the chain's block at height %d while finding the fork point: %w", height, err)
+		}
+
+		if *hash == stamp.Hash {
+			return stamp, nil
+		}
+
+		height--
+	}
 }
 
 // canonicalStampAt returns the block stamp the chain has at the given height.

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -528,14 +528,16 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 		return err
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to read the wallet's recorded "+
+			"blocks: %w", err)
 	}
 
 	// Verify those blocks with no database transaction held, as this
 	// queries the backend once per recorded block.
 	staleHeight, err := lowestStaleBlockHeight(chainClient, blocks)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to verify the wallet's %d recorded "+
+			"blocks against the chain: %w", len(blocks), err)
 	}
 
 	rewindManager := false
@@ -552,7 +554,10 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 			}
 			stamp, err := canonicalStampAt(chainClient, height)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to fetch the "+
+					"chain's block at height %d while "+
+					"looking for the wallet's fork point: "+
+					"%w", height, err)
 			}
 
 			rollbackStamp = stamp
@@ -570,7 +575,9 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 				chainClient, staleHeight-1,
 			)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to fetch the parent "+
+					"of stale block at height %d: %w",
+					staleHeight, err)
 			}
 
 			rollbackStamp = stamp
@@ -607,7 +614,14 @@ func (w *Wallet) rollbackToChain(chainClient chainConn,
 		// stale state. `Rollback` unconfirms transactions at and beyond
 		// the passed height, so add one to the new synced-to height to
 		// prevent unconfirming transactions in the synced-to block.
-		return w.TxStore.Rollback(txmgrNs, rollbackStamp.Height+1)
+		height := rollbackStamp.Height + 1
+		if err := w.TxStore.Rollback(txmgrNs, height); err != nil {
+			return fmt.Errorf("unable to roll back the "+
+				"transaction store to height %d: %w", height,
+				err)
+		}
+
+		return nil
 	})
 }
 

--- a/wallet/wallet/wallet.go
+++ b/wallet/wallet/wallet.go
@@ -475,68 +475,7 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 	// Compare previously-seen blocks against the current chain. If any of
 	// these blocks no longer exist, rollback all of the missing blocks
 	// before catching up with the rescan.
-	rollback := false
-	rollbackStamp := w.Manager.SyncedTo()
-	err = walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
-
-		for height := rollbackStamp.Height; true; height-- {
-			hash, err := w.Manager.BlockHash(addrmgrNs, height)
-			if err != nil {
-				return err
-			}
-			chainHash, err := chainClient.GetBlockHash(int64(height))
-			if err != nil {
-				return err
-			}
-			header, err := chainClient.GetBlockHeader(chainHash)
-			if err != nil {
-				return err
-			}
-
-			rollbackStamp.Hash = *chainHash
-			rollbackStamp.Height = height
-			rollbackStamp.Timestamp = header.Timestamp
-
-			if bytes.Equal(hash[:], chainHash[:]) {
-				break
-			}
-			rollback = true
-		}
-
-		// If a rollback did not happen, we can proceed safely.
-		if !rollback {
-			return nil
-		}
-
-		// Otherwise, we'll mark this as our new synced height.
-		err := w.Manager.SetSyncedTo(addrmgrNs, &rollbackStamp)
-		if err != nil {
-			return err
-		}
-
-		// If the rollback happened to go beyond our birthday stamp,
-		// we'll need to find a new one by syncing with the chain again
-		// until finding one.
-		if rollbackStamp.Height <= birthdayStamp.Height &&
-			rollbackStamp.Hash != birthdayStamp.Hash {
-
-			err := w.Manager.SetBirthdayBlock(
-				addrmgrNs, rollbackStamp, true,
-			)
-			if err != nil {
-				return err
-			}
-		}
-
-		// Finally, we'll roll back our transaction store to reflect the
-		// stale state. `Rollback` unconfirms transactions at and beyond
-		// the passed height, so add one to the new synced-to height to
-		// prevent unconfirming transactions in the synced-to block.
-		return w.TxStore.Rollback(txmgrNs, rollbackStamp.Height+1)
-	})
-	if err != nil {
+	if err := w.rollbackToChain(chainClient, birthdayStamp); err != nil {
 		return err
 	}
 
@@ -568,6 +507,170 @@ func (w *Wallet) syncWithChain(birthdayStamp *waddrmgr.BlockStamp) error {
 	}
 
 	return w.rescanWithTarget(addrs, unspent, nil)
+}
+
+// rollbackToChain compares the blocks the wallet has previously seen against
+// the current chain and rolls back the ones that are no longer part of it, so
+// that the rescan which follows re-applies the canonical chain.
+func (w *Wallet) rollbackToChain(chainClient chainConn,
+	birthdayStamp *waddrmgr.BlockStamp) error {
+
+	// The address manager's hash history is overwritten with canonical
+	// hashes as blocks are connected, so a reorg the wallet never applied
+	// survives only in the transaction store.
+	var blocks []wtxmgr.Block
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		var err error
+		blocks, err = w.TxStore.Blocks(
+			tx.ReadBucket(wtxmgrNamespaceKey),
+		)
+
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	// Verify those blocks with no database transaction held, as this
+	// queries the backend once per recorded block.
+	staleHeight, err := lowestStaleBlockHeight(chainClient, blocks)
+	if err != nil {
+		return err
+	}
+
+	rewindManager := false
+	rollbackStamp := w.Manager.SyncedTo()
+
+	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		txmgrNs := tx.ReadWriteBucket(wtxmgrNamespaceKey)
+
+		for height := rollbackStamp.Height; true; height-- {
+			hash, err := w.Manager.BlockHash(addrmgrNs, height)
+			if err != nil {
+				return err
+			}
+			stamp, err := canonicalStampAt(chainClient, height)
+			if err != nil {
+				return err
+			}
+
+			rollbackStamp = stamp
+			if bytes.Equal(hash[:], stamp.Hash[:]) {
+				break
+			}
+			rewindManager = true
+		}
+
+		// A stale block the address manager no longer remembers has to
+		// be detached as well, which means rewinding the manager below
+		// it so that the rescan replays those heights.
+		if staleHeight > 0 && staleHeight <= rollbackStamp.Height {
+			stamp, err := canonicalStampAt(
+				chainClient, staleHeight-1,
+			)
+			if err != nil {
+				return err
+			}
+
+			rollbackStamp = stamp
+			rewindManager = true
+		}
+
+		// If nothing diverged, we can proceed safely.
+		if !rewindManager && staleHeight == 0 {
+			return nil
+		}
+
+		if rewindManager {
+			err := w.Manager.SetSyncedTo(addrmgrNs, &rollbackStamp)
+			if err != nil {
+				return err
+			}
+
+			// If the rollback happened to go beyond our birthday
+			// stamp, we'll need to find a new one by syncing with
+			// the chain again until finding one.
+			if rollbackStamp.Height <= birthdayStamp.Height &&
+				rollbackStamp.Hash != birthdayStamp.Hash {
+
+				err := w.Manager.SetBirthdayBlock(
+					addrmgrNs, rollbackStamp, true,
+				)
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		// Finally, we'll roll back our transaction store to reflect the
+		// stale state. `Rollback` unconfirms transactions at and beyond
+		// the passed height, so add one to the new synced-to height to
+		// prevent unconfirming transactions in the synced-to block.
+		return w.TxStore.Rollback(txmgrNs, rollbackStamp.Height+1)
+	})
+}
+
+// canonicalStampAt returns the block stamp the chain has at the given height.
+func canonicalStampAt(chainClient chainConn,
+	height int32) (waddrmgr.BlockStamp, error) {
+
+	hash, err := chainClient.GetBlockHash(int64(height))
+	if err != nil {
+		return waddrmgr.BlockStamp{}, err
+	}
+	header, err := chainClient.GetBlockHeader(hash)
+	if err != nil {
+		return waddrmgr.BlockStamp{}, err
+	}
+
+	return waddrmgr.BlockStamp{
+		Hash:      *hash,
+		Height:    height,
+		Timestamp: header.Timestamp,
+	}, nil
+}
+
+// lowestStaleBlockHeight returns the height of the lowest given block that the
+// chain no longer has, or zero when the chain still has all of them. The
+// blocks must be ordered by ascending height.
+func lowestStaleBlockHeight(chainClient chainConn,
+	blocks []wtxmgr.Block) (int32, error) {
+
+	_, bestHeight, err := chainClient.GetBestBlock()
+	if err != nil {
+		return 0, err
+	}
+
+	started := time.Now()
+	for _, b := range blocks {
+		// Genesis cannot be reorged out, and skipping it keeps the
+		// parent of a stale block a real height.
+		if b.Height <= 0 {
+			continue
+		}
+
+		if b.Height <= bestHeight {
+			hash, err := chainClient.GetBlockHash(int64(b.Height))
+			if err != nil {
+				return 0, err
+			}
+			if *hash == b.Hash {
+				continue
+			}
+		}
+
+		log.Warnf("Block %v at height %d is no longer part of the "+
+			"chain, rolling back a reorg that was never applied",
+			b.Hash, b.Height)
+
+		return b.Height, nil
+	}
+
+	log.Infof("Verified the wallet's %d recorded blocks against the chain "+
+		"in %v", len(blocks), time.Since(started))
+
+	return 0, nil
 }
 
 // isDevEnv determines whether the wallet is currently under a local developer

--- a/wallet/wtxmgr/query.go
+++ b/wallet/wtxmgr/query.go
@@ -456,3 +456,18 @@ func (s *Store) PreviousPkScripts(ns walletdb.ReadBucket, rec *TxRecord, block *
 
 	return pkScripts, nil
 }
+
+// Blocks returns every block the store has recorded transactions for, ordered
+// by ascending height.
+func (s *Store) Blocks(ns walletdb.ReadBucket) ([]Block, error) {
+	var blocks []Block
+	it := makeReadBlockIterator(ns, 0)
+	for it.next() {
+		blocks = append(blocks, it.elem.Block)
+	}
+	if it.err != nil {
+		return nil, it.err
+	}
+
+	return blocks, nil
+}

--- a/wallet/wtxmgr/query.go
+++ b/wallet/wtxmgr/query.go
@@ -181,9 +181,7 @@ func (s *Store) unminedTxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash,
 // TxLabel looks up a transaction label for the txHash provided. If the store
 // has no labels in it, or the specific txHash does not have a label, an empty
 // string and no error are returned.
-func (s *Store) TxLabel(ns walletdb.ReadBucket, txHash chainhash.Hash) (string,
-	error) {
-
+func (s *Store) TxLabel(ns walletdb.ReadBucket, txHash chainhash.Hash) (string, error) {
 	label, err := FetchTxLabel(ns, txHash)
 	switch err {
 	// If there are no saved labels yet (the bucket has not been created) or
@@ -232,9 +230,7 @@ func (s *Store) TxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash) (*TxDe
 //
 // Not finding a transaction with this hash from this block is not an error.  In
 // this case, a nil TxDetails is returned.
-func (s *Store) UniqueTxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash,
-	block *Block) (*TxDetails, error) {
-
+func (s *Store) UniqueTxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash, block *Block) (*TxDetails, error) {
 	if block == nil {
 		v := existsRawUnmined(ns, txHash[:])
 		if v == nil {
@@ -259,8 +255,7 @@ func (s *Store) rangeUnminedTransactions(ns walletdb.ReadBucket, f func([]TxDeta
 	var details []TxDetails
 	err := ns.NestedReadBucket(bucketUnmined).ForEach(func(k, v []byte) error {
 		if len(k) < 32 {
-			str := fmt.Sprintf("%s: short key (expected %d "+
-				"bytes, read %d)", bucketUnmined, 32, len(k))
+			str := fmt.Sprintf("%s: short key (expected %d bytes, read %d)", bucketUnmined, 32, len(k))
 			return storeError(ErrData, str, nil)
 		}
 
@@ -334,8 +329,7 @@ func (s *Store) rangeBlockTransactions(ns walletdb.ReadBucket, begin, end int32,
 			k := keyTxRecord(&txHash, &block.Block)
 			v := existsRawTxRecord(ns, k)
 			if v == nil {
-				str := fmt.Sprintf("missing transaction %v for "+
-					"block %v", txHash, block.Height)
+				str := fmt.Sprintf("missing transaction %v for block %v", txHash, block.Height)
 				return false, storeError(ErrData, str, nil)
 			}
 
@@ -370,9 +364,7 @@ func (s *Store) rangeBlockTransactions(ns walletdb.ReadBucket, begin, end int32,
 // All calls to f are guaranteed to be passed a slice with more than zero
 // elements.  The slice may be reused for multiple blocks, so it is not safe to
 // use it after the loop iteration it was acquired.
-func (s *Store) RangeTransactions(ns walletdb.ReadBucket, begin, end int32,
-	f func([]TxDetails) (bool, error)) error {
-
+func (s *Store) RangeTransactions(ns walletdb.ReadBucket, begin, end int32, f func([]TxDetails) (bool, error)) error {
 	var addedUnmined bool
 	if begin < 0 {
 		brk, err := s.rangeUnminedTransactions(ns, f)

--- a/wallet/wtxmgr/query_test.go
+++ b/wallet/wtxmgr/query_test.go
@@ -753,9 +753,7 @@ func TestBlocks(t *testing.T) {
 
 	// Record a transaction in three blocks, inserted out of order, plus an
 	// unmined one which must not show up as a block.
-	mined := []BlockMeta{
-		makeBlockMeta(105), makeBlockMeta(100), makeBlockMeta(101),
-	}
+	mined := []BlockMeta{makeBlockMeta(105), makeBlockMeta(100), makeBlockMeta(101)}
 	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(namespaceKey)
 		for i, block := range mined {

--- a/wallet/wtxmgr/query_test.go
+++ b/wallet/wtxmgr/query_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/wire"
 	"github.com/pearl-research-labs/pearl/wallet/walletdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type queryState struct {
@@ -740,4 +742,52 @@ func TestPreviousPkScripts(t *testing.T) {
 	if t.Failed() {
 		t.Fatal("Failed after inserting tx D")
 	}
+}
+
+func TestBlocks(t *testing.T) {
+	t.Parallel()
+
+	s, db, err := testStore(t)
+	require.NoError(t, err)
+	defer db.Close()
+
+	// Record a transaction in three blocks, inserted out of order, plus an
+	// unmined one which must not show up as a block.
+	mined := []BlockMeta{
+		makeBlockMeta(105), makeBlockMeta(100), makeBlockMeta(101),
+	}
+	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(namespaceKey)
+		for i, block := range mined {
+			msgTx := spendOutput(&chainhash.Hash{}, uint32(i), 10e8)
+			rec, err := NewTxRecordFromMsgTx(msgTx, timeNow())
+			if err != nil {
+				return err
+			}
+			if err := s.InsertTx(ns, rec, &block); err != nil {
+				return err
+			}
+		}
+
+		unmined := spendOutput(&chainhash.Hash{}, 99, 10e8)
+		rec, err := NewTxRecordFromMsgTx(unmined, timeNow())
+		if err != nil {
+			return err
+		}
+
+		return s.InsertTx(ns, rec, nil)
+	})
+	require.NoError(t, err)
+
+	var blocks []Block
+	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+		var err error
+		blocks, err = s.Blocks(tx.ReadBucket(namespaceKey))
+
+		return err
+	})
+	require.NoError(t, err)
+
+	want := []Block{mined[1].Block, mined[2].Block, mined[0].Block}
+	assert.Equal(t, want, blocks)
 }


### PR DESCRIPTION
## Summary

A mining pool reported a coinbase from an **orphaned** block that stayed in `listunspent` after a reorg. It matured into apparently spendable balance while `gettxout` returned nothing for the outpoint and every attempt to spend it was rejected with `bad-txns-inputs-missingorspent`. The wallet's balance was overstated until manual intervention.

The rollback machinery was never at fault. `wtxmgr.Store.Rollback` does the right thing, deleting coinbases and their spend chains outright rather than unconfirming them. The problem is that nothing called it. When a `BlockDisconnected` notification is missed — dropped because the wallet was not yet chain synced, or never delivered at all because the wallet was offline during the reorg — the orphaned block survives only in the transaction store. The existing repair pass in `syncWithChain` consults only the address manager, whose per-height hash history is overwritten with canonical hashes as blocks connect, so it matches at the tip, breaks out of its loop, and never looks at the store.

## What changed

**Store-versus-chain reconciliation on every backend connect.** The rollback pass moved out of `syncWithChain` into `rollbackToChain`, which now snapshots every block the transaction store has recorded, compares each hash against the backend ascending by height, and stops at the lowest mismatch. It rolls the store back to that height and rewinds the address manager below it, so the rescan that already follows re-applies the canonical chain. The pass runs on `chain.ClientConnected`, so a reconnect repairs the state as well as a restart.

The scan is deliberately unbounded and takes no shortcuts. An earlier draft stopped at the first block record that matched the chain, which is only sound with connect-side continuity enforcement that this PR does not add: a pool that keeps mining after a missed disconnect records canonical blocks *above* the orphaned one, so an early-exit scan matches immediately and the bug survives the fix. Anchoring on blocks that still hold unspent outputs was also rejected, because it misses two balance bugs that the same reorg causes — an output spent only on the orphaned branch stays marked spent forever, and a payment re-mined on the new branch is credited twice.

**`disconnectBlock` is instrumented, not changed.** Its behavior is byte-for-byte identical, including the existing quirk where `b.Hash` is reassigned before `notifyDetachedBlock`. It was previously silent on every branch, including the `!w.ChainSynced()` early return, so there is no field evidence for how often that gate drops a disconnect. Each ignored disconnect now logs the block, height, and reason, and those logs are what should decide whether the gate needs removing.

**One new `wtxmgr` accessor.** `Store.Blocks` returns the recorded blocks by ascending height. No schema change.

## Commits

- `59c3899f` fix(wallet): roll back orphaned blocks left by unapplied reorgs
- `6b641490` chore: bump version to 1.2.3 (patch, per the convention that fix PRs bump in-branch)

## Trade-offs and follow-ups

- The pass costs one `getblockhash` per recorded block per backend connect. That is a local header-store read on neutrino and a round trip on the pearld backend, so a wallet with a transaction in most blocks pays proportionally to its history. The pass logs its block count and elapsed time precisely so this can be revisited with real numbers; batching the lookups is a contained follow-up if it turns out to matter.
- The returned slice is 36 bytes per recorded block, so roughly 5.6 MiB per year of full-block mining, freed as soon as the pass returns.
- A mismatch found deep in history rewinds the manager below it, so the rescan replays from there. Expensive, but a false positive costs a long rescan rather than data loss, since `Rollback` only detaches what the rescan can re-apply.
- Live reorgs are repaired at the next backend connect rather than immediately. Un-gating `disconnectBlock` is deliberately out of scope here.
- Pre-existing issues found while working on this, left alone and worth their own changes: `notifyDetachedBlock` fires with the *parent* hash after the reassignment mentioned above; the manager's descending loop fetches two RPCs per height inside the write transaction and uses only the last header; and `testWallet` never stops the wallet it creates.

## Testing

New `wallet/wallet/reorg_stale_block_test.go` drives `rollbackToChain` directly against a mock serving one of two branches: the reported case with canonical records above the orphan, an orphaned block holding only a spend (the mirror bug, where a live UTXO is wrongly marked spent), a mismatch deeper than `waddrmgr.MaxReorgDepth`, a clean wallet that must not be touched, and a regression test for the pre-existing manager-driven repair path. `wallet/wtxmgr/query_test.go` covers the new accessor.

As a negative control, the three stale-block tests were confirmed to fail with the repair disabled while the clean-wallet and manager-reorg tests keep passing.

`go test -tags xmss ./wallet/... -count=1` passes, `go vet` is clean with and without the tag.

## Second fix: rewinding the address manager

Review raised whether the manager rewind belonged in a `Manager.Rollback` method rather than inline in `rollbackToChain`, by analogy with `TxStore.Rollback`. Chasing that turned up a bug, so this branch now does both.

`SetSyncedTo` is a forward-motion primitive. It leaves the abandoned branch's hashes recorded above the new tip, and once a birthday block exists it requires the preceding block's hash to be known:

```go
if _, err := FetchBirthdayBlock(ns); err == nil {
        _, err := fetchBlockHash(ns, bs.Height-1)
        if err != nil {
                return managerError(ErrBlockNotFound, errStr, err)
        }
}
```

Rolling backwards into pruned history is exactly what that rejects. Since the manager only retains `MaxReorgDepth` hashes, a stale block deeper than roughly 10,000 blocks could not be repaired at all: `rollbackToChain` failed with `ErrBlockNotFound`, `syncWithChain` returned the error, and `waitForSync` retried and failed identically forever. The failure was safe but permanent, and it applied precisely to the unbounded-depth repair this PR set out to add.

`waddrmgr.Manager.Rollback` expresses backwards motion instead: it discards the hashes above the target, moves the sync point without the forward continuity check, and resets a birthday block that is no longer on the chain. Since the manager owns the birthday block, `rollbackToChain` no longer needs its `birthdayStamp` parameter.

The wallet reorg tests were passing for the wrong reason. Only `Manager.SetBirthdayBlock` ever writes that value and wallet creation does not call it, so `testWallet` had none and the tests never reached the check that failed in production. They now persist a birthday block, and reverting to `SetSyncedTo` makes `TestRollbackToChainDeepStaleBlock` fail with the production error. `waddrmgr/rollback_test.go` covers the new method directly, including the pruned-history case and the birthday reset.

## Note on the lint config

This branch also raises `lll.line-length` in `wallet/.golangci.yml` from 80 to 120. The wallet config was explicitly overriding golangci-lint's own documented default of 120, while `node/` sets no override and therefore already runs at 120, so this aligns the two rather than inventing a third standard. The motivation is grep-ability: at 80 columns a log message of useful length has to be split across concatenated string literals, which means grepping a line out of a log file never finds the code that emitted it. Every format string in the reorg code now sits on one line.

Worth flagging for whoever reviews: no GitHub workflow runs `golangci-lint`, it is only wired up through `task lint:go`, and that task currently cannot run these configs at all because `tools/go.mod` pins golangci-lint v1.64.8 while the configs are `version: "2"`. That mismatch is pre-existing and untouched here. Line lengths were verified with the same arithmetic the linter uses, tab-width 4 against a 120 limit.

