### PR TITLE
feat(consensus): rank-penalty softfork

### DIFF
--- a/miner/conftest.py
+++ b/miner/conftest.py
@@ -21,7 +21,7 @@ from pearl_gateway.comm.dataclasses import (
     OpenedBlockInfo,
 )
 from pearl_gateway.config import MinerRpcConfig, PearlConfig
-from pearl_mining import MatrixMerkleProof, MerkleProof, PlainProof, ZKProof
+from pearl_mining import MatrixMerkleProof, MerkleProof, PlainProof, ZKProof, penalized_target_bound
 
 
 @pytest.fixture(scope="session")
@@ -343,7 +343,10 @@ def _adjust_mining_job_target(
     mining_config: MiningConfiguration,
     target: int,
 ) -> MiningJob:
-    target //= MiningJob._get_difficulty_adjustment_factor(mining_config)
+    bound = penalized_target_bound(1, mining_config)
+    if bound is None:
+        raise ValueError("degenerate mining config in test scaffolding")
+    target //= bound
     return MiningJob(incomplete_header_bytes=incomplete_header_bytes, target=target)
 
 

--- a/miner/miner-base/src/miner_base/settings.py
+++ b/miner/miner-base/src/miner_base/settings.py
@@ -1,3 +1,5 @@
+from pearl_mining import PENALTY_BASE_RANK
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -34,3 +36,13 @@ class MinerSettings(BaseSettings):
     no_vllm_plugin: bool = False
 
     enable_async_cuda_event_processing: bool = True
+
+    @field_validator("noise_rank")
+    @classmethod
+    def _noise_rank_at_least_base(cls, noise_rank: int) -> int:
+        if noise_rank < PENALTY_BASE_RANK:
+            raise ValueError(
+                f"noise_rank {noise_rank} is below the minimum {PENALTY_BASE_RANK}; "
+                f"blocks would be rejected by consensus"
+            )
+        return noise_rank

--- a/miner/pearl-gateway/src/pearl_gateway/comm/dataclasses.py
+++ b/miner/pearl-gateway/src/pearl_gateway/comm/dataclasses.py
@@ -19,7 +19,7 @@ from pearl_gateway.comm.mining_configuration import (
 from pearl_gateway.rpc_types import (
     GetBlockTemplateResponse,
 )
-from pearl_mining import IncompleteBlockHeader
+from pearl_mining import PENALTY_BASE_RANK, IncompleteBlockHeader, penalized_target_bound
 
 
 def get_bytes(data: str | bytes) -> bytes:
@@ -182,9 +182,6 @@ class MiningJob:
     # Certificate version required for this block;
     cert_version: CertificateVersion = CertificateVersion.ZK_MOE
 
-    INNER_HASH_LIMIT: ClassVar[int] = 42
-    MAX_TARGET: ClassVar[int] = 2**256 - 1
-
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON-RPC response."""
         return {
@@ -192,12 +189,6 @@ class MiningJob:
             "target": self.target,
             "cert_version": int(self.cert_version),
         }
-
-    @staticmethod
-    def _get_difficulty_adjustment_factor(mining_config: MiningConfiguration) -> int:
-        return (
-            mining_config.hash_tile_h * mining_config.hash_tile_w * mining_config.rounded_common_dim
-        )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MiningJob":
@@ -219,18 +210,19 @@ class MiningJob:
         )
 
     def adjust_target(self, mining_config: MiningConfiguration) -> int:
-        """Calculate the adjusted PoW target for the mining job.
-
-        The target is scaled based on the work represented by the hash tile dimensions
-        and noise rank.
-        """
-        # We reduce difficulty for larger hash tiles (as they represent more work)
-        # and for larger rank (as it's the k dimension of the hash tile)
-        difficulty_adjustment_factor = self._get_difficulty_adjustment_factor(mining_config)
-        adjusted_target = self.target * difficulty_adjustment_factor
-        if adjusted_target > self.MAX_TARGET:
-            raise ValueError(f"Target is too easy: {self.target=}, {adjusted_target=}")
-        return adjusted_target
+        """Calculate the rank-penalized PoW target for the mining job."""
+        if mining_config.rank < PENALTY_BASE_RANK:
+            raise ValueError(
+                f"noise rank {mining_config.rank} is below the minimum "
+                f"{PENALTY_BASE_RANK}; blocks would be rejected by consensus"
+            )
+        bound = penalized_target_bound(self.target, mining_config)
+        if bound is None:
+            raise ValueError(
+                f"no penalized target for {self.target=} at rank "
+                f"{mining_config.rank}: degenerate config or target too easy"
+            )
+        return bound
 
 
 class MiningPausedError(Exception):

--- a/miner/pearl-gateway/tests/test_comm_dataclasses.py
+++ b/miner/pearl-gateway/tests/test_comm_dataclasses.py
@@ -1,3 +1,4 @@
+import pytest
 from pearl_gateway.blockchain_utils.zk_certificate import CertificateVersion
 from pearl_gateway.comm.dataclasses import (
     BlockTemplate,
@@ -5,6 +6,8 @@ from pearl_gateway.comm.dataclasses import (
     b64_decode,
     b64_encode,
 )
+from pearl_gateway.comm.mining_configuration import PearlMiningConfigurationFactory
+from pearl_mining import PENALTY_BASE_RANK
 
 
 class TestMiningJob:
@@ -67,6 +70,69 @@ class TestMiningJob:
         )
         assert job.target == sample_block_template.target
         assert job.cert_version == sample_block_template.required_cert_version
+
+
+class TestAdjustTarget:
+    """The rank penalty applied when turning a block target into a mining target."""
+
+    ROW_INDICES = [0, 8, 64, 72]
+    COL_INDICES = [0, 1, 8, 9, 32, 33, 40, 41]
+    BLOCK_TARGET = 2**64
+    # Valid for every rank exercised here: 16 * rank <= COMMON_DIM <= 4 * rank**2.
+    COMMON_DIM = 8192
+
+    def _mining_config(self, rank: int):
+        return PearlMiningConfigurationFactory.create(
+            common_dim=self.COMMON_DIM,
+            rank=rank,
+            row_indices=self.ROW_INDICES,
+            col_indices=self.COL_INDICES,
+        )
+
+    def _adjusted_target(self, rank: int) -> int:
+        job = MiningJob(incomplete_header_bytes=b"", target=self.BLOCK_TARGET)
+        return job.adjust_target(self._mining_config(rank))
+
+    def test_base_rank_is_unpenalized(self):
+        """A miner at the base rank searches the plain hash-tile-scaled target."""
+        config = self._mining_config(PENALTY_BASE_RANK)
+        expected = (
+            self.BLOCK_TARGET * config.hash_tile_h * config.hash_tile_w * config.rounded_common_dim
+        )
+        assert self._adjusted_target(PENALTY_BASE_RANK) == expected
+
+    def test_larger_rank_gets_a_proportionally_smaller_target(self):
+        """Doubling the rank halves the target, cancelling the nesting advantage."""
+        base = self._adjusted_target(PENALTY_BASE_RANK)
+        for multiple in (2, 4):
+            adjusted = self._adjusted_target(PENALTY_BASE_RANK * multiple)
+            assert adjusted == base // multiple
+
+    def test_rank_below_base_is_rejected(self):
+        with pytest.raises(ValueError, match="below the minimum"):
+            self._adjusted_target(PENALTY_BASE_RANK // 2)
+
+    def test_degenerate_config_is_rejected(self):
+        """A config whose common_dim is below the rank yields a zero adjustment
+        factor; adjust_target must surface that as a ValueError rather than
+        returning a zero bound."""
+        config = PearlMiningConfigurationFactory.create(
+            common_dim=PENALTY_BASE_RANK // 2,
+            rank=PENALTY_BASE_RANK,
+            row_indices=self.ROW_INDICES,
+            col_indices=self.COL_INDICES,
+        )
+        job = MiningJob(incomplete_header_bytes=b"", target=self.BLOCK_TARGET)
+        with pytest.raises(ValueError, match="degenerate"):
+            job.adjust_target(config)
+
+    def test_target_too_easy_is_rejected(self):
+        """A target whose penalized bound exceeds 256 bits must raise. Clamping it
+        to the maximum target would have the miner search a target every hash
+        satisfies."""
+        job = MiningJob(incomplete_header_bytes=b"", target=2**240)
+        with pytest.raises(ValueError, match="too easy"):
+            job.adjust_target(self._mining_config(PENALTY_BASE_RANK))
 
 
 class TestBlockTemplateCertVersion:

--- a/node/blockchain/chain.go
+++ b/node/blockchain/chain.go
@@ -2215,6 +2215,16 @@ func New(config *Config) (*BlockChain, error) {
 	if config.ChainParams.MoEForkHeight < 0 {
 		return nil, AssertError("blockchain.New MoEForkHeight must be >= 0")
 	}
+	if config.ChainParams.RankPenaltyForkHeight < 0 {
+		return nil, AssertError("blockchain.New RankPenaltyForkHeight must be >= 0")
+	}
+	// Only V2 certificates carry a noise rank, so the rank-penalty rule cannot
+	// start before the V2 cutover.
+	if config.ChainParams.RankPenaltyForkHeight != 0 &&
+		config.ChainParams.RankPenaltyForkHeight < config.ChainParams.MoEForkHeight {
+		return nil, AssertError("blockchain.New RankPenaltyForkHeight must not " +
+			"precede MoEForkHeight")
+	}
 
 	// Generate a checkpoint by height map from the provided checkpoints
 	// and assert the provided checkpoints are sorted by height as required.

--- a/node/blockchain/error.go
+++ b/node/blockchain/error.go
@@ -230,6 +230,11 @@ const (
 	// ErrTimewarpAttack indicates a timewarp attack i.e.
 	// when block's timestamp is too early on diff adjustment block.
 	ErrTimewarpAttack
+
+	// ErrRankPenalty indicates the block certificate violates the rank-penalty
+	// rule: its noise rank is below the minimum, or its jackpot does not meet
+	// the difficulty bound scaled for that rank.
+	ErrRankPenalty
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
@@ -278,6 +283,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrPreviousBlockUnknown:      "ErrPreviousBlockUnknown",
 	ErrInvalidAncestorBlock:      "ErrInvalidAncestorBlock",
 	ErrPrevBlockNotBest:          "ErrPrevBlockNotBest",
+	ErrRankPenalty:               "ErrRankPenalty",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -26,6 +26,15 @@ func moeSimNetParams() chaincfg.Params {
 	return params
 }
 
+// checkCertVersion exercises the certificate version and dense-only rules
+// alone. Only the rank-penalty rule reads the header and the flags, so params
+// must leave that fork disabled.
+func checkCertVersion(cert wire.BlockCertificate, height int32,
+	params *chaincfg.Params) error {
+
+	return CheckCertificateRules(&wire.BlockHeader{}, cert, height, params, BFNone)
+}
+
 // newBlockForcedCert builds (but does not process) the next block on top of
 // prev and replaces its certificate with the provided one, regardless of the
 // version SolveBlock would have chosen for the height. Used to drive
@@ -189,9 +198,9 @@ func TestMoEForkBlockTemplateVersion(t *testing.T) {
 		ErrDisallowedCertVersion)
 }
 
-// TestCheckCertificateVersion exercises the policy helper directly, including
-// the disabled-fork case and the nil-certificate guard.
-func TestCheckCertificateVersion(t *testing.T) {
+// TestCheckCertificateRulesVersion exercises the version cutover directly,
+// including the disabled-fork case and the nil-certificate guard.
+func TestCheckCertificateRulesVersion(t *testing.T) {
 	enabled := &chaincfg.Params{MoEForkHeight: moeForkTestHeight}
 	disabled := &chaincfg.Params{MoEForkHeight: 0}
 
@@ -199,28 +208,28 @@ func TestCheckCertificateVersion(t *testing.T) {
 	moe := &wire.CertificateV2{}
 
 	// Disabled fork: V1 always valid, V2 never valid.
-	require.NoError(t, CheckCertificateVersion(zk, 1_000_000, disabled))
-	requireRuleError(t, CheckCertificateVersion(moe, 1_000_000, disabled),
+	require.NoError(t, checkCertVersion(zk, 1_000_000, disabled))
+	requireRuleError(t, checkCertVersion(moe, 1_000_000, disabled),
 		ErrDisallowedCertVersion)
 
 	// Enabled fork: strict cutover at the activation height.
-	require.NoError(t, CheckCertificateVersion(zk, moeForkTestHeight-1, enabled))
-	require.NoError(t, CheckCertificateVersion(moe, moeForkTestHeight, enabled))
-	requireRuleError(t, CheckCertificateVersion(moe, moeForkTestHeight-1, enabled),
+	require.NoError(t, checkCertVersion(zk, moeForkTestHeight-1, enabled))
+	require.NoError(t, checkCertVersion(moe, moeForkTestHeight, enabled))
+	requireRuleError(t, checkCertVersion(moe, moeForkTestHeight-1, enabled),
 		ErrDisallowedCertVersion)
-	requireRuleError(t, CheckCertificateVersion(zk, moeForkTestHeight, enabled),
+	requireRuleError(t, checkCertVersion(zk, moeForkTestHeight, enabled),
 		ErrDisallowedCertVersion)
 
 	// Missing certificate.
-	requireRuleError(t, CheckCertificateVersion(nil, 1, enabled),
+	requireRuleError(t, checkCertVersion(nil, 1, enabled),
 		ErrCertificateMissing)
 }
 
-// TestCheckCertificateVersionDenseOnlyFork exercises the dense-only fork: at
+// TestCheckCertificateRulesDenseOnlyFork exercises the dense-only fork: at
 // and after DenseOnlyForkHeight a V2 certificate must carry a dense (non-MoE)
 // proof. MoE-ness is detected by the public data length (dense proofs are
 // exactly wire.PublicDataSizeDenseV2 bytes, MoE proofs are longer).
-func TestCheckCertificateVersionDenseOnlyFork(t *testing.T) {
+func TestCheckCertificateRulesDenseOnlyFork(t *testing.T) {
 	const denseOnlyTestHeight = moeForkTestHeight + 2
 	params := &chaincfg.Params{
 		MoEForkHeight:       moeForkTestHeight,
@@ -231,19 +240,19 @@ func TestCheckCertificateVersionDenseOnlyFork(t *testing.T) {
 	moe := &wire.CertificateV2{PublicDataLen: wire.PublicDataSizeDenseV2 + 1}
 
 	// Before the dense-only fork both proof kinds are accepted.
-	require.NoError(t, CheckCertificateVersion(dense, denseOnlyTestHeight-1, params))
-	require.NoError(t, CheckCertificateVersion(moe, denseOnlyTestHeight-1, params))
+	require.NoError(t, checkCertVersion(dense, denseOnlyTestHeight-1, params))
+	require.NoError(t, checkCertVersion(moe, denseOnlyTestHeight-1, params))
 
 	// At and after the fork only dense proofs are accepted.
-	require.NoError(t, CheckCertificateVersion(dense, denseOnlyTestHeight, params))
-	requireRuleError(t, CheckCertificateVersion(moe, denseOnlyTestHeight, params),
+	require.NoError(t, checkCertVersion(dense, denseOnlyTestHeight, params))
+	requireRuleError(t, checkCertVersion(moe, denseOnlyTestHeight, params),
 		ErrDisallowedCertVersion)
 
 	// The zero-length placeholder proof used by block templates is not MoE
 	// and must stay valid at and after the fork. Regression guard for the
 	// template-generation failure caused by detecting MoE-ness with "!=".
 	placeholder := &wire.CertificateV2{}
-	require.NoError(t, CheckCertificateVersion(placeholder, denseOnlyTestHeight, params))
+	require.NoError(t, checkCertVersion(placeholder, denseOnlyTestHeight, params))
 }
 
 // TestDenseOnlyForkAcceptsTemplatesAndBlocks builds a SimNet chain across the

--- a/node/blockchain/process.go
+++ b/node/blockchain/process.go
@@ -9,8 +9,10 @@ import (
 	"time"
 
 	"github.com/pearl-research-labs/pearl/node/btcutil"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/database"
+	"github.com/pearl-research-labs/pearl/node/wire"
 )
 
 // BehaviorFlags is a bitmask defining tweaks to the normal behavior when
@@ -32,6 +34,16 @@ const (
 	// BFNone is a convenience value to specifically indicate no flags.
 	BFNone BehaviorFlags = 0
 )
+
+// NetBehaviorFlags returns the behavior flags the network parameters imply.
+// SimNet mines the placeholder certificates emitted by SolveBlock, so it can
+// neither verify proof of work nor enforce any rule that reads a proof.
+func NetBehaviorFlags(params *chaincfg.Params) BehaviorFlags {
+	if params.Net == wire.SimNet {
+		return BFNoPoWCheck
+	}
+	return BFNone
+}
 
 // blockExists determines whether a block with the given hash exists either in
 // the main chain or any side chains.

--- a/node/blockchain/rank_penalty_fork_test.go
+++ b/node/blockchain/rank_penalty_fork_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/pearl-research-labs/pearl/node/btcutil"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover when the rank-penalty rule is applied. The rule itself (the
+// rank floor and the rank-scaled jackpot bound) lives in Rust and is tested in
+// zk-pow/src/api/sanity_checks.rs and node/zkpow/rank_penalty_test.go, since it
+// needs the proof verification backend.
+
+const rankPenaltyTestHeight = int32(10)
+
+func rankPenaltyParams(net wire.PearlNet) *chaincfg.Params {
+	return &chaincfg.Params{
+		Net:                   net,
+		MoEForkHeight:         1,
+		RankPenaltyForkHeight: rankPenaltyTestHeight,
+	}
+}
+
+// TestCheckCertificateRulesRankPenalty covers when the rank-penalty rule is
+// applied: at and after the activation height, and only where proof of work is
+// verified.
+func TestCheckCertificateRulesRankPenalty(t *testing.T) {
+	header := &wire.BlockHeader{Bits: 0x1e01ffff}
+	// A dense V2 certificate whose public data is all zeros: valid in length but
+	// not a rank the rule accepts, so reaching the rule means rejection.
+	denseCert := &wire.CertificateV2{PublicDataLen: wire.PublicDataSizeDenseV2}
+	regTest := rankPenaltyParams(wire.RegTest)
+
+	t.Run("BeforeActivation", func(t *testing.T) {
+		require.NoError(t, CheckCertificateRules(header, denseCert,
+			rankPenaltyTestHeight-1, regTest, BFNone))
+	})
+
+	t.Run("NoPoWCheck", func(t *testing.T) {
+		require.NoError(t, CheckCertificateRules(header, denseCert,
+			rankPenaltyTestHeight, regTest, BFNoPoWCheck))
+	})
+
+	t.Run("SimNet", func(t *testing.T) {
+		// SimNet is skipped by the flag its parameters imply, not by the rule
+		// inspecting the network.
+		simNet := rankPenaltyParams(wire.SimNet)
+		require.NoError(t, CheckCertificateRules(header, denseCert,
+			rankPenaltyTestHeight, simNet, NetBehaviorFlags(simNet)))
+	})
+
+	t.Run("BlockTemplate", func(t *testing.T) {
+		// mining.NewBlockTemplate attaches a placeholder certificate with no
+		// public data. Templates are checked with BFNoPoWCheck; without it
+		// getblocktemplate would fail from the activation height on.
+		placeholder := &wire.CertificateV2{}
+		require.NoError(t, CheckCertificateRules(header, placeholder,
+			rankPenaltyTestHeight, regTest, BFNoPoWCheck))
+		requireRuleError(t, CheckCertificateRules(header, placeholder,
+			rankPenaltyTestHeight, regTest, BFNone), ErrRankPenalty)
+	})
+
+	t.Run("V1Certificate", func(t *testing.T) {
+		// V1 certificates have no noise rank, and the version rule rejects them
+		// at this height before the rank-penalty rule is reached.
+		requireRuleError(t, CheckCertificateRules(header, &wire.CertificateV1{},
+			rankPenaltyTestHeight, regTest, BFNone), ErrDisallowedCertVersion)
+	})
+
+	t.Run("AtActivation", func(t *testing.T) {
+		// In non-zkpow builds the zkpow.CheckRankPenalty stub returns a generic
+		// error that still maps to ErrRankPenalty, so this gates activation, not
+		// the rule itself; the rule is exercised under the zkpow build tag in
+		// node/zkpow/rank_penalty_test.go.
+		requireRuleError(t, CheckCertificateRules(header, denseCert,
+			rankPenaltyTestHeight, regTest, BFNone), ErrRankPenalty)
+	})
+
+	t.Run("MissingCertificate", func(t *testing.T) {
+		requireRuleError(t, CheckCertificateRules(header, nil,
+			rankPenaltyTestHeight, regTest, BFNone), ErrCertificateMissing)
+	})
+}
+
+// TestRankPenaltyForkAcceptsTemplatesAndBlocks builds a SimNet chain across the
+// activation height. SimNet does not verify proofs and SolveBlock emits
+// placeholder certificates there, so enabling the fork must not start rejecting
+// blocks or templates. Guards against the template-generation breakage the
+// dense-only fork once caused.
+func TestRankPenaltyForkAcceptsTemplatesAndBlocks(t *testing.T) {
+	params := moeSimNetParams()
+	params.RankPenaltyForkHeight = moeForkTestHeight + 2
+	chain, teardown, err := chainSetup("rank_penalty_template", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	for h := int32(1); h <= params.RankPenaltyForkHeight+1; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoErrorf(t, err,
+			"block at height %d must be accepted after the rank-penalty fork", h)
+		tip = block
+	}
+
+	template, _, err := newBlock(chain, tip, nil)
+	require.NoError(t, err)
+	require.NoError(t, chain.CheckConnectBlockTemplate(template),
+		"post-fork block template must be accepted")
+}
+
+// TestNewRejectsRankPenaltyBeforeMoEFork pins the params invariant the rule
+// depends on: only V2 certificates carry a noise rank.
+func TestNewRejectsRankPenaltyBeforeMoEFork(t *testing.T) {
+	params := moeSimNetParams()
+	params.RankPenaltyForkHeight = params.MoEForkHeight - 1
+	_, _, err := chainSetup("rank_penalty_ordering", &params)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "RankPenaltyForkHeight")
+}

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -417,10 +417,7 @@ func checkBlockSanity(block *btcutil.Block, chainParams *chaincfg.Params, timeSo
 	header := msgBlock.BlockHeader()
 	cert := msgBlock.BlockCertificate()
 
-	// Skip proof of work verification on simnet, to enable fast no-op mining in tests.
-	if chainParams.Net == wire.SimNet {
-		flags |= BFNoPoWCheck
-	}
+	flags |= NetBehaviorFlags(chainParams)
 
 	err := CheckBlockHeaderSanity(header, cert, chainParams.PowLimit, timeSource, chainParams.MaxTimeOffsetMinutes, flags)
 	if err != nil {
@@ -512,12 +509,29 @@ func CheckBlockSanity(block *btcutil.Block, chainParams *chaincfg.Params, timeSo
 	return checkBlockSanity(block, chainParams, timeSource, BFNone)
 }
 
-// CheckCertificateVersion enforces the certificate fork schedule:
+// CheckCertificateRules enforces the height-gated rules a block certificate
+// must satisfy:
 //   - Before MoEForkHeight (or with the fork disabled): only V1 accepted
 //   - At and after MoEForkHeight (hardfork): only V2 accepted
 //   - At and after DenseOnlyForkHeight (softfork): V2 certificates must
 //     carry a dense (non-MoE) proof
-func CheckCertificateVersion(cert wire.BlockCertificate, height int32, params *chaincfg.Params) error {
+//   - At and after RankPenaltyForkHeight (softfork): the proof's noise rank
+//     must meet a minimum and its jackpot must meet a difficulty bound scaled
+//     for that rank
+//
+// These rules run here rather than alongside the proof verification in
+// checkProofOfWork because activation depends on the block height, which the
+// context-free sanity checks do not have. Reading the certificate apart from
+// its proof is sound: the header's proof commitment covers the certificate
+// version and public data, so the proof verified there binds everything these
+// rules read.
+//
+// The rank-penalty rule reads the proof's public data, so it is skipped
+// whenever proof of work is not verified (BFNoPoWCheck), which covers block
+// templates and the networks NetBehaviorFlags exempts.
+func CheckCertificateRules(header *wire.BlockHeader, cert wire.BlockCertificate,
+	height int32, params *chaincfg.Params, flags BehaviorFlags) error {
+
 	if cert == nil {
 		return ruleError(ErrCertificateMissing, "block has no certificate")
 	}
@@ -527,13 +541,29 @@ func CheckCertificateVersion(cert wire.BlockCertificate, height int32, params *c
 			"(require version %d)", cert.Version(), height, want)
 		return ruleError(ErrDisallowedCertVersion, str)
 	}
-	if c, ok := cert.(*wire.CertificateV2); ok && c.IsMoE() &&
-		params.IsDenseOnlyForkActive(height) {
+
+	// The remaining rules read fields only a V2 certificate has.
+	c, ok := cert.(*wire.CertificateV2)
+	if !ok {
+		return nil
+	}
+
+	if c.IsMoE() && params.IsDenseOnlyForkActive(height) {
 		str := fmt.Sprintf("MoE certificate is not allowed at height %d "+
 			"(dense-only fork active from height %d)",
 			height, params.DenseOnlyForkHeight)
 		return ruleError(ErrDisallowedCertVersion, str)
 	}
+
+	if params.IsRankPenaltyForkActive(height) && flags&BFNoPoWCheck != BFNoPoWCheck {
+		if err := zkpow.CheckRankPenalty(header.Bits, c.PublicDataBytes()); err != nil {
+			str := fmt.Sprintf("certificate fails the rank penalty rule at "+
+				"height %d (fork active from height %d): %v",
+				height, params.RankPenaltyForkHeight, err)
+			return ruleError(ErrRankPenalty, str)
+		}
+	}
+
 	return nil
 }
 
@@ -719,6 +749,8 @@ func CheckBlockHeaderContext(header *wire.BlockHeader, prevNode chaincfg.HeaderC
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode, flags BehaviorFlags) error {
+	flags |= NetBehaviorFlags(b.chainParams)
+
 	// Perform all block header related validation checks.
 	header := block.MsgBlock().BlockHeader()
 	err := CheckBlockHeaderContext(header, prevNode, flags, b, false)
@@ -726,11 +758,13 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		return err
 	}
 
-	// Enforce the V1/V2 certificate version policy (consensus-critical,
-	// runs regardless of BFFastAdd).
+	// Enforce the height-gated certificate rules (consensus-critical, run
+	// regardless of BFFastAdd).
 	blockHeight := prevNode.height + 1
-	if err := CheckCertificateVersion(block.MsgBlock().BlockCertificate(),
-		blockHeight, b.chainParams); err != nil {
+	cert := block.MsgBlock().BlockCertificate()
+	if err := CheckCertificateRules(
+		header, cert, blockHeight, b.chainParams, flags,
+	); err != nil {
 		return err
 	}
 
@@ -1139,24 +1173,16 @@ func (b *BlockChain) ChainParams() *chaincfg.Params {
 }
 
 // CheckHeaderSanity is the header-only equivalent of CheckBlockSanity,
-// wired with the chain's own time source and chain parameters. It mirrors
-// checkBlockSanity's SimNet special-case so that headers-only validation
-// stays consistent with full-block validation: SimNet uses dummy
-// certificates from SolveBlock and depends on PoW verification being
-// skipped at the validation layer.
+// wired with the chain's own time source and chain parameters.
 func (b *BlockChain) CheckHeaderSanity(header *wire.BlockHeader,
 	cert wire.BlockCertificate) error {
 
-	flags := BFNone
-	if b.chainParams.Net == wire.SimNet {
-		flags |= BFNoPoWCheck
-	}
 	return CheckBlockHeaderSanity(
 		header, cert,
 		b.chainParams.PowLimit,
 		b.timeSource,
 		b.chainParams.MaxTimeOffsetMinutes,
-		flags,
+		NetBehaviorFlags(b.chainParams),
 	)
 }
 

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -539,7 +539,7 @@ var TestNetParams = Params{
 	// Dense-only softfork: MoE proofs are rejected from this height on.
 	DenseOnlyForkHeight: 28262,
 
-	RankPenaltyForkHeight: 36757,
+	RankPenaltyForkHeight: 36761,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
@@ -633,7 +633,7 @@ var TestNet2Params = Params{
 	// Dense-only softfork: MoE proofs are rejected from this height on.
 	DenseOnlyForkHeight: 75122,
 
-	RankPenaltyForkHeight: 80638,
+	RankPenaltyForkHeight: 80627,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -263,6 +263,16 @@ type Params struct {
 	// disables the fork.
 	DenseOnlyForkHeight int32
 
+	// RankPenaltyForkHeight is the block height at which the rank-penalty
+	// softfork activates. At and after this height a proof's noise rank must
+	// meet a minimum and its jackpot must meet a difficulty bound scaled down
+	// in proportion to that rank; the rule only tightens validity, so pre-fork
+	// nodes accept every post-fork block. A value of 0 disables the fork.
+	//
+	// Must not activate before MoEForkHeight: only V2 certificates carry a
+	// noise rank (enforced in blockchain.New).
+	RankPenaltyForkHeight int32
+
 	// Mempool parameters
 	RelayNonStdTxs bool
 
@@ -292,6 +302,12 @@ func (p *Params) IsMoEForkActive(height int32) bool {
 // the given block height. The fork is disabled when DenseOnlyForkHeight is 0.
 func (p *Params) IsDenseOnlyForkActive(height int32) bool {
 	return p.DenseOnlyForkHeight != 0 && height >= p.DenseOnlyForkHeight
+}
+
+// IsRankPenaltyForkActive reports whether the rank-penalty softfork is active at
+// the given block height. The fork is disabled when RankPenaltyForkHeight is 0.
+func (p *Params) IsRankPenaltyForkActive(height int32) bool {
+	return p.RankPenaltyForkHeight != 0 && height >= p.RankPenaltyForkHeight
 }
 
 // RequiredCertVersion returns the block certificate version that a block at the
@@ -333,6 +349,8 @@ var MainNetParams = Params{
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
 	DenseOnlyForkHeight: 91630,
+
+	RankPenaltyForkHeight: 96251,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -411,6 +429,9 @@ var RegressionNetParams = Params{
 	// MoE hardfork active from genesis on local test networks so the gateway's
 	// V2 (MoE) certificates are accepted at every mined height.
 	MoEForkHeight: 1,
+
+	// Active from genesis because regtest verifies proofs.
+	RankPenaltyForkHeight: 1,
 
 	// Chain parameters
 	GenesisBlock:         &regTestGenesisBlock,
@@ -518,6 +539,8 @@ var TestNetParams = Params{
 	// Dense-only softfork: MoE proofs are rejected from this height on.
 	DenseOnlyForkHeight: 28262,
 
+	RankPenaltyForkHeight: 36757,
+
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
 
@@ -609,6 +632,8 @@ var TestNet2Params = Params{
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
 	DenseOnlyForkHeight: 75122,
+
+	RankPenaltyForkHeight: 80638,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,

--- a/node/chaincfg/params_test.go
+++ b/node/chaincfg/params_test.go
@@ -135,6 +135,54 @@ func TestMoEForkDisabled(t *testing.T) {
 	}
 }
 
+// TestRankPenaltyForkActivation verifies the activation boundary of the
+// rank-penalty softfork, including the disabled case.
+func TestRankPenaltyForkActivation(t *testing.T) {
+	const forkHeight = int32(100)
+	enabled := Params{RankPenaltyForkHeight: forkHeight}
+
+	tests := []struct {
+		name       string
+		height     int32
+		wantActive bool
+	}{
+		{"genesis", 0, false},
+		{"just before fork", forkHeight - 1, false},
+		{"at fork height", forkHeight, true},
+		{"after fork height", forkHeight + 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantActive, enabled.IsRankPenaltyForkActive(tt.height))
+		})
+	}
+
+	disabled := Params{RankPenaltyForkHeight: 0}
+	for _, height := range []int32{0, 1, 100, 1_000_000} {
+		require.False(t, disabled.IsRankPenaltyForkActive(height))
+	}
+}
+
+// TestShippedNetworksRankPenaltyOrdering asserts the invariant the rule relies
+// on: only V2 certificates carry a noise rank, so the rank-penalty softfork must
+// never activate before the V2 cutover. blockchain.New rejects params that
+// violate this.
+func TestShippedNetworksRankPenaltyOrdering(t *testing.T) {
+	for name, params := range map[string]*Params{
+		"mainnet":  &MainNetParams,
+		"testnet":  &TestNetParams,
+		"testnet2": &TestNet2Params,
+		"regtest":  &RegressionNetParams,
+		"simnet":   &SimNetParams,
+	} {
+		if params.RankPenaltyForkHeight == 0 {
+			continue
+		}
+		require.GreaterOrEqualf(t, params.RankPenaltyForkHeight, params.MoEForkHeight,
+			"%s must not activate the rank-penalty fork before the MoE fork", name)
+	}
+}
+
 // TestShippedNetworksMoEForkHeights pins the MoE hardfork activation heights
 // for the shipped networks so they cannot change accidentally.
 func TestShippedNetworksMoEForkHeights(t *testing.T) {

--- a/node/mining/mining_test.go
+++ b/node/mining/mining_test.go
@@ -72,17 +72,14 @@ func (e *emptyTxSource) LastUpdated() time.Time               { return time.Time
 func (e *emptyTxSource) MiningDescs() []*TxDesc               { return nil }
 func (e *emptyTxSource) HaveTransaction(*chainhash.Hash) bool { return false }
 
-// TestNewBlockTemplateNilAddress exercises the full NewBlockTemplate code path
-// with no mining address (payToAddress == nil). This is the exact path taken by
-// the getblocktemplate RPC when useCoinbaseValue is true (the default), which
-// builds a placeholder coinbase that is later replaced by external mining
-// software. The coinbase must comply with Taproot-only consensus rules.
-func TestNewBlockTemplateNilAddress(t *testing.T) {
-	params := chaincfg.SimNetParams
+// newTestGenerator builds a template generator on a fresh chain holding only
+// the genesis block, so the next template sits at height 1.
+func newTestGenerator(t *testing.T, params *chaincfg.Params) *BlkTmplGenerator {
+	t.Helper()
 
-	db, err := database.Create("ffldb", t.TempDir(), wire.SimNet)
+	db, err := database.Create("ffldb", t.TempDir(), params.Net)
 	require.NoError(t, err)
-	defer db.Close()
+	t.Cleanup(func() { db.Close() })
 
 	timeSource := blockchain.NewMedianTime()
 	sigCache := txscript.NewSigCache(100)
@@ -90,25 +87,35 @@ func TestNewBlockTemplateNilAddress(t *testing.T) {
 
 	chain, err := blockchain.New(&blockchain.Config{
 		DB:          db,
-		ChainParams: &params,
+		ChainParams: params,
 		TimeSource:  timeSource,
 		SigCache:    sigCache,
 		HashCache:   hashCache,
 	})
 	require.NoError(t, err)
 
-	generator := NewBlkTmplGenerator(
+	return NewBlkTmplGenerator(
 		&Policy{
 			BlockMinVsize: 0,
 			BlockMaxVsize: blockchain.MaxBlockVsize,
 		},
-		&params,
+		params,
 		&emptyTxSource{},
 		chain,
 		timeSource,
 		sigCache,
 		hashCache,
 	)
+}
+
+// TestNewBlockTemplateNilAddress exercises the full NewBlockTemplate code path
+// with no mining address (payToAddress == nil). This is the exact path taken by
+// the getblocktemplate RPC when useCoinbaseValue is true (the default), which
+// builds a placeholder coinbase that is later replaced by external mining
+// software. The coinbase must comply with Taproot-only consensus rules.
+func TestNewBlockTemplateNilAddress(t *testing.T) {
+	params := chaincfg.SimNetParams
+	generator := newTestGenerator(t, &params)
 
 	template, err := generator.NewBlockTemplate(nil)
 	require.NoError(t, err, "NewBlockTemplate(nil) should succeed with a placeholder coinbase")
@@ -118,4 +125,28 @@ func TestNewBlockTemplateNilAddress(t *testing.T) {
 	coinbaseTx := btcutil.NewTx(template.Block.Transactions[0])
 	require.NoError(t, blockchain.CheckTransactionSanity(coinbaseTx),
 		"placeholder coinbase must pass Taproot-only consensus validation")
+}
+
+// TestNewBlockTemplateForkRulesActive builds a template on regtest, which
+// verifies proofs and activates the MoE and rank-penalty forks from height 1.
+// The template carries a placeholder certificate with no proof in it, so it is
+// only accepted because CheckConnectBlockTemplate passes BFNoPoWCheck down to
+// the certificate rules. Without that, getblocktemplate returns an internal
+// error from the activation height on and every miner on the network stalls,
+// which is how the dense-only fork broke once already.
+func TestNewBlockTemplateForkRulesActive(t *testing.T) {
+	params := chaincfg.RegressionNetParams
+	require.NotEqual(t, wire.SimNet, params.Net,
+		"the network under test must be one that verifies proofs")
+	require.True(t, params.IsMoEForkActive(1))
+	require.True(t, params.IsRankPenaltyForkActive(1))
+
+	generator := newTestGenerator(t, &params)
+
+	template, err := generator.NewBlockTemplate(nil)
+	require.NoError(t, err,
+		"template generation must survive the rank-penalty fork activation")
+	require.Equal(t, int32(1), template.Height)
+	require.Equal(t, wire.CertificateVersionV2,
+		template.Block.BlockCertificate().Version())
 }

--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -1084,13 +1084,14 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 		if prevNode.hash.IsEqual(&blockHeader.PrevBlock) {
 			node.height = prevNode.height + 1
 
-			if err := blockchain.CheckCertificateVersion(
-				msgHeader.BlockCertificate(), node.height,
+			if err := blockchain.CheckCertificateRules(
+				blockHeader, msgHeader.BlockCertificate(), node.height,
 				sm.chainParams,
+				blockchain.NetBehaviorFlags(sm.chainParams),
 			); err != nil {
-				log.Warnf("Header from peer %s has a disallowed "+
-					"certificate version: %v -- disconnecting",
-					peer.Addr(), err)
+				log.Warnf("Header from peer %s has a certificate that "+
+					"violates the rules at height %d: %v -- disconnecting",
+					peer.Addr(), node.height, err)
 				peer.Disconnect()
 				return
 			}

--- a/node/wire/certificate_v2.go
+++ b/node/wire/certificate_v2.go
@@ -49,11 +49,20 @@ func (c *CertificateV2) BlockHash() chainhash.Hash {
 	return c.Hash
 }
 
+// PublicDataBytes returns the meaningful prefix of PublicData. Every producer
+// bounds PublicDataLen against the array (Deserialize here, Mine and MineMoE in
+// the zkpow package), so a larger value is a corrupt struct and left for the
+// bounds check to catch.
+func (c *CertificateV2) PublicDataBytes() []byte {
+	return c.PublicData[:c.PublicDataLen]
+}
+
 // ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData[:PublicDataLen]).
 func (c *CertificateV2) ProofCommitment() chainhash.Hash {
-	buf := make([]byte, 4+c.PublicDataLen)
+	publicData := c.PublicDataBytes()
+	buf := make([]byte, 4+len(publicData))
 	binary.LittleEndian.PutUint32(buf[:4], uint32(c.Version()))
-	copy(buf[4:], c.PublicData[:c.PublicDataLen])
+	copy(buf[4:], publicData)
 	return chainhash.DoubleHashH(buf)
 }
 
@@ -66,7 +75,7 @@ func (c *CertificateV2) Serialize(w io.Writer) error {
 	if err := binary.Write(w, binary.LittleEndian, c.PublicDataLen); err != nil {
 		return err
 	}
-	if _, err := w.Write(c.PublicData[:c.PublicDataLen]); err != nil {
+	if _, err := w.Write(c.PublicDataBytes()); err != nil {
 		return err
 	}
 	if err := binary.Write(w, binary.LittleEndian, uint32(len(c.ProofData))); err != nil {

--- a/node/zkpow/miner.go
+++ b/node/zkpow/miner.go
@@ -23,30 +23,35 @@ import (
 )
 
 const (
-	DefaultNBits     = 0x1E01FFFF
-	DefaultM         = 256
-	DefaultN         = 512
-	DefaultNoiseRank = 32
-	DefaultMMAType   = 0
+	DefaultNBits = 0x1E01FFFF
+	DefaultM     = 256
+	DefaultN     = 512
 )
 
 // ================================================================================
 // MINER (Rust FFI)
 // ================================================================================
 
-// miningConfigSize matches MINING_CONFIG_SERIALIZED_SIZE in the FFI header.
-const miningConfigSize = 52
+const miningConfigSize = C.MINING_CONFIG_SERIALIZED_SIZE
 
-// defaultMiningConfigV1 is the serialized MiningConfiguration passed to the Rust FFI.
-// Corresponds to: common_dim=1024, rank=32, mma_type=Int7xInt7ToInt32,
-// rows_pattern=[0,8,64,72], cols_pattern=[0,1,8,9,32,33,40,41]
-var defaultMiningConfigV1 = [miningConfigSize]byte{
-	0x00, 0x04, 0x00, 0x00, // common_dim = 1024
-	0x20, 0x00, // rank = 32
-	0x00, 0x00, // mma_type = 0
-	0x07, 0x01, 0x03, 0x01, 0x00, 0x00, // rows_pattern
-	0x00, 0x01, 0x03, 0x01, 0x01, 0x01, // cols_pattern
-	// reserved (32 bytes) are zero
+// defaultMiningConfig retrieves Rust's canonical serialized mining configuration.
+//
+// e == 0 selects a standard job; otherwise it selects a GROUPED_GEMM (MoE) job
+// routing each token to topK experts.
+func defaultMiningConfig(e, topK uint32) ([miningConfigSize]byte, error) {
+	var config [miningConfigSize]byte
+	var errorBuf [C.ERROR_MSG_MAX_SIZE]C.char
+
+	result := C.default_mining_config(
+		C.uint16_t(e), C.uint16_t(topK),
+		(*[miningConfigSize]C.uint8_t)(unsafe.Pointer(&config)),
+		&errorBuf[0],
+	)
+	if result != 0 {
+		return config, fmt.Errorf("building mining config failed (code %d): %s",
+			result, C.GoString(&errorBuf[0]))
+	}
+	return config, nil
 }
 
 // Mine mines a standard (non-MoE) block using the default dimensions.
@@ -99,16 +104,9 @@ func MineMoE(header *wire.BlockHeader, m, n, e, topK uint32) (*wire.CertificateV
 // callMineFFI invokes the Rust mine function and returns the public data and proof data as Go slices.
 // No C types or raw pointers escape this function.
 func callMineFFI(cHeader C.IncompleteBlockHeader, m, n, e, topK uint32) (publicData, proofData []byte, err error) {
-	// The MoE config is committed in the mining config trailer (and thus the
-	// job_key). Trailer layout: [20:22] e (u16 LE), [22:24] top_k (u16 LE), [24:52] zero padding.
-	// e doubles as the mode discriminant: e == 0 is a standard job, e > 0 is GROUPED_GEMM.
-	// miningConfig is a value copy of the package default.
-	miningConfig := defaultMiningConfigV1
-	if e != 0 {
-		miningConfig[20] = byte(e)
-		miningConfig[21] = byte(e >> 8)
-		miningConfig[22] = byte(topK)
-		miningConfig[23] = byte(topK >> 8)
+	miningConfig, err := defaultMiningConfig(e, topK)
+	if err != nil {
+		return nil, nil, err
 	}
 	cMiningConfig := (*[miningConfigSize]C.uint8_t)(unsafe.Pointer(&miningConfig))
 

--- a/node/zkpow/rank_penalty_test.go
+++ b/node/zkpow/rank_penalty_test.go
@@ -1,0 +1,135 @@
+//go:build zkpow
+
+// Copyright (c) 2025-2026 The Pearl Research Labs developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package zkpow
+
+import (
+	"encoding/binary"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Dense PublicData prefix layout, mirrored from zk-pow/src/api/proof_utils.rs.
+const (
+	densePublicDataSize = 164
+	jackpotOffset       = 116
+	jackpotSize         = 32
+)
+
+// hashTileSize is h*w for the index patterns of the default mining configuration.
+// A mismatch makes the bound expectations below fail rather than silently pass.
+const hashTileSize = 4 * 8
+
+// Byte offsets of the two mining configuration fields these tests vary, mirrored
+// from MiningConfiguration::to_bytes in zk-pow/src/api/proof_utils.rs.
+const (
+	commonDimOffset = 0
+	rankOffset      = 4
+)
+
+// rankPenaltyPublicData builds dense public data with a rank, common dimension, and
+// jackpot. It starts from the default configuration so the index patterns keep the
+// canonical encoding the Rust parser round-trips against, and patches the two fields
+// under test.
+func rankPenaltyPublicData(t *testing.T, rank uint16, commonDim uint32, jackpot []byte) []byte {
+	t.Helper()
+	config, err := defaultMiningConfig(0, 0)
+	require.NoError(t, err)
+	binary.LittleEndian.PutUint32(config[commonDimOffset:], commonDim)
+	binary.LittleEndian.PutUint16(config[rankOffset:], rank)
+
+	data := make([]byte, densePublicDataSize)
+	copy(data, config[:])
+	copy(data[jackpotOffset:jackpotOffset+jackpotSize], jackpot)
+	return data
+}
+
+// compactToTarget converts a compact difficulty encoding to its target value.
+// Mirrors blockchain/internal/workmath.CompactToBig, which is not importable
+// from this package.
+func compactToTarget(bits uint32) *big.Int {
+	mantissa := int64(bits & 0x007fffff)
+	exponent := uint(bits >> 24)
+	if exponent <= 3 {
+		return big.NewInt(mantissa >> (8 * (3 - exponent)))
+	}
+	return new(big.Int).Lsh(big.NewInt(mantissa), 8*(exponent-3))
+}
+
+// penalizedBound is the largest jackpot value the rank-penalty rule accepts:
+// target * h * w * (k / rank) * MinNoiseRank.
+func penalizedBound(bits uint32, rank uint16, commonDim uint32) *big.Int {
+	reductions := int64(commonDim) / int64(rank)
+	factor := big.NewInt(hashTileSize * reductions * MinNoiseRank)
+	return new(big.Int).Mul(compactToTarget(bits), factor)
+}
+
+// jackpotFor encodes a value as a jackpot hash, which the rule reads as a
+// little-endian 256-bit integer.
+func jackpotFor(value *big.Int) []byte {
+	bytes := value.Bytes()
+	jackpot := make([]byte, jackpotSize)
+	for i, b := range bytes {
+		jackpot[len(bytes)-1-i] = b
+	}
+	return jackpot
+}
+
+// TestCheckRankPenaltyRankFloor rejects ranks below MinNoiseRank.
+func TestCheckRankPenaltyRankFloor(t *testing.T) {
+	bestPossibleJackpot := make([]byte, jackpotSize)
+
+	for _, rank := range []uint16{MinNoiseRank / 4, MinNoiseRank / 2} {
+		data := rankPenaltyPublicData(t, rank, 16*uint32(rank), bestPossibleJackpot)
+		require.Errorf(t, CheckRankPenalty(DefaultNBits, data),
+			"rank %d is below the minimum and must be rejected", rank)
+	}
+
+	data := rankPenaltyPublicData(t, MinNoiseRank, 16*MinNoiseRank, bestPossibleJackpot)
+	require.NoError(t, CheckRankPenalty(DefaultNBits, data),
+		"rank %d is the minimum and must be accepted", MinNoiseRank)
+}
+
+// TestCheckRankPenaltyBound independently computes the rank-penalized bounds,
+// pinning the Rust rule to a Go implementation of the same formula. Testing each
+// rank at its own bound also covers the property the fork exists for: a jackpot
+// that wins at the base rank is rejected at a larger one, since an unpenalized
+// comparison would accept bound+1 there.
+func TestCheckRankPenaltyBound(t *testing.T) {
+	// Ranks valid for this k: 16 * rank <= commonDim <= 4 * rank^2.
+	const commonDim = uint32(8192)
+
+	for _, rank := range []uint16{MinNoiseRank, 2 * MinNoiseRank, 4 * MinNoiseRank} {
+		bound := penalizedBound(DefaultNBits, rank, commonDim)
+
+		atBound := rankPenaltyPublicData(t, rank, commonDim, jackpotFor(bound))
+		require.NoErrorf(t, CheckRankPenalty(DefaultNBits, atBound),
+			"rank %d: a jackpot exactly at the bound must be accepted", rank)
+
+		aboveBound := rankPenaltyPublicData(t, rank, commonDim,
+			jackpotFor(new(big.Int).Add(bound, big.NewInt(1))))
+		require.Errorf(t, CheckRankPenalty(DefaultNBits, aboveBound),
+			"rank %d: a jackpot above the bound must be rejected", rank)
+	}
+}
+
+// TestCheckRankPenaltyRejectsMalformedPublicData covers the guards on input the
+// rule cannot parse: the empty slice the Go wrapper checks before indexing, a
+// length the Rust parser rejects, and the zero-filled dense blob that block
+// templates carry (rank 0).
+func TestCheckRankPenaltyRejectsMalformedPublicData(t *testing.T) {
+	for name, data := range map[string][]byte{
+		"empty":     {},
+		"truncated": make([]byte, densePublicDataSize-1),
+		"all zero":  make([]byte, densePublicDataSize),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Error(t, CheckRankPenalty(DefaultNBits, data))
+		})
+	}
+}

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -25,6 +25,11 @@ import (
 	"github.com/pearl-research-labs/pearl/node/wire"
 )
 
+// MinNoiseRank is the minimum accepted by the rank-penalty rule, taken from the
+// Rust implementation of the rule, which asserts at compile time that the value it
+// exports matches the one it enforces.
+const MinNoiseRank = C.MIN_NOISE_RANK
+
 // ================================================================================
 // CERTIFICATE VERIFICATION
 // ================================================================================
@@ -96,12 +101,8 @@ func verifyCertificateV1(header *wire.BlockHeader, c *wire.CertificateV1) error 
 // ================================================================================
 
 func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error {
-	// Guard against directly-constructed structs that bypassed Deserialize.
-	if c.PublicDataLen > wire.PublicDataMaxSizeV2 {
-		return fmt.Errorf("invalid public_data_len %d (max %d)", c.PublicDataLen, wire.PublicDataMaxSizeV2)
-	}
-	publicData := c.PublicData[:c.PublicDataLen]
-	return VerifyZKProofFFI(header, c.Hash, c.ProofCommitment(), publicData, c.ProofData, nil)
+	return VerifyZKProofFFI(header, c.Hash, c.ProofCommitment(), c.PublicDataBytes(),
+		c.ProofData, nil)
 }
 
 func VerifyZKProofFFI(
@@ -164,6 +165,35 @@ func VerifyZKProofFFI(
 		return fmt.Errorf("verification system error: %s", msg)
 	default:
 		return fmt.Errorf("unknown verification result %d: %s", result, msg)
+	}
+}
+
+// CheckRankPenalty checks public data against the rank-penalty rule, measuring the
+// jackpot against bits: a block header's Bits for consensus, or a share target for
+// pool accounting. Callers decide whether the height-gated rule is active.
+func CheckRankPenalty(bits uint32, publicData []byte) error {
+	if len(publicData) == 0 { // avoid publicData[0] index below
+		return fmt.Errorf("empty public data")
+	}
+
+	var errorBuf [C.ERROR_MSG_MAX_SIZE]C.char
+	result := C.check_rank_penalty(
+		C.uint32_t(bits),
+		(*C.uint8_t)(unsafe.Pointer(&publicData[0])),
+		C.uintptr_t(len(publicData)),
+		&errorBuf[0],
+	)
+	msg := C.GoString(&errorBuf[0])
+
+	switch result {
+	case 0:
+		return nil
+	case 1:
+		return fmt.Errorf("rank penalty rule violated: %s", msg)
+	case 2:
+		return fmt.Errorf("rank penalty check system error: %s", msg)
+	default:
+		return fmt.Errorf("unknown rank penalty check result %d: %s", result, msg)
 	}
 }
 

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -9,12 +9,13 @@ import (
 	"github.com/pearl-research-labs/pearl/node/wire"
 )
 
+// Mining parameters the node passes to the miner. The rest of the mining
+// configuration, including the noise rank, comes from the Rust FFI and so is only
+// available in the zkpow build.
 const (
-	DefaultNBits     = 0x1E01FFFF
-	DefaultM         = 256
-	DefaultN         = 512
-	DefaultNoiseRank = 32
-	DefaultMMAType   = 0
+	DefaultNBits = 0x1E01FFFF
+	DefaultM     = 256
+	DefaultN     = 512
 )
 
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
@@ -29,6 +30,10 @@ func VerifyZKProofFFI(
 	proofData []byte,
 	nbitsOverride *uint32,
 ) error {
+	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
+}
+
+func CheckRankPenalty(bits uint32, publicData []byte) error {
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
 }
 

--- a/node/zkpow/zkpow_test.go
+++ b/node/zkpow/zkpow_test.go
@@ -104,6 +104,11 @@ func TestMineAndVerifyProof(t *testing.T) {
 	err := VerifyCertificate(header, cert)
 	require.NoError(t, err, "VerifyProof should succeed for valid proof")
 	t.Logf("Verification completed in %v", time.Since(startVerify))
+
+	// The default mining configuration must also satisfy the rank-penalty rule,
+	// so a node mining with it stays valid once that fork activates.
+	require.NoError(t, CheckRankPenalty(header.Bits, cert.PublicData[:cert.PublicDataLen]),
+		"the mined certificate should satisfy the rank penalty rule")
 }
 
 // TestTamperedParams tests that tampering any header or certificate field causes rejection.

--- a/py-pearl-mining/Cargo.lock
+++ b/py-pearl-mining/Cargo.lock
@@ -952,6 +952,7 @@ dependencies = [
  "env_logger 0.10.2",
  "lazy_static",
  "pearl-blake3",
+ "primitive-types 0.12.2",
  "pyo3",
  "rayon",
  "tikv-jemallocator",

--- a/py-pearl-mining/Cargo.toml
+++ b/py-pearl-mining/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 pearl-blake3 = { path = "../pearl-blake3", features = ["serde", "pyo3"] }
 zk-pow = { path = "../zk-pow", features = ["pyo3"] }
 blake3 = "1.8"
+primitive-types = "0.12.1"
 rayon = "1.10"
 pyo3 = { version = "0.24", features = ["extension-module", "abi3-py312"] }
 lazy_static = "1.5"

--- a/py-pearl-mining/src/lib.rs
+++ b/py-pearl-mining/src/lib.rs
@@ -13,10 +13,12 @@ use std::sync::Mutex;
 
 use blake3::CHUNK_LEN;
 use pearl_blake3::{pad_to_chunk_boundary, MerkleProof, MerkleTree};
+use primitive_types::U256;
 use zk_pow::api::proof::{
     IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern,
     PublicProofParams, ZKProof,
 };
+use zk_pow::api::sanity_checks;
 use zk_pow::api::{prove, verify};
 use zk_pow::circuit::pearl_circuit::{PearlRecursion, RecursionCircuit};
 use zk_pow::ffi::mine::{mine as ffi_mine, mine_moe as ffi_mine_moe};
@@ -147,6 +149,32 @@ fn verify_plain_proof_v2(
         Ok(()) => Ok((true, "Mining solution verified successfully".into())),
         Err(e) => Ok((false, e.to_string())),
     }
+}
+
+#[pyfunction]
+fn penalized_target_bound<'py>(
+    py: Python<'py>,
+    target: &Bound<'_, PyAny>,
+    mining_config: &MiningConfiguration,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    // target (int) -> 32 little-endian bytes
+    let target_bytes = target.call_method1("to_bytes", (32usize, "little"))?;
+    let target_bytes: &[u8] = target_bytes.extract()?;
+    let bound = match sanity_checks::penalized_target_bound(
+        U256::from_little_endian(target_bytes),
+        mining_config,
+    ) {
+        Some(b) => b,
+        None => return Ok(None),
+    };
+    let mut out = [0u8; 32];
+    bound.to_little_endian(&mut out);
+    // 32 little-endian bytes -> int
+    let py_bytes = pyo3::types::PyBytes::new(py, &out);
+    let bound_int = py
+        .get_type::<pyo3::types::PyInt>()
+        .call_method1("from_bytes", (py_bytes, "little"))?;
+    Ok(Some(bound_int))
 }
 
 #[pyfunction]
@@ -397,6 +425,10 @@ fn pearl_mining(m: &Bound<'_, pyo3::types::PyModule>) -> PyResult<()> {
         PublicProofParams::MIN_MOE_WIRE_SIZE,
     )?;
     m.add("PUBLICDATA_MAX_SIZE", PublicProofParams::MAX_WIRE_SIZE)?;
+    m.add(
+        "PENALTY_BASE_RANK",
+        zk_pow::api::sanity_checks::PENALTY_BASE_RANK,
+    )?;
     m.add_class::<MerkleTree>()?;
     m.add_class::<MerkleProof>()?;
     m.add_class::<PeriodicPattern>()?;
@@ -410,6 +442,7 @@ fn pearl_mining(m: &Bound<'_, pyo3::types::PyModule>) -> PyResult<()> {
     m.add_class::<PyProof>()?;
     m.add_function(wrap_pyfunction!(mine, m)?)?;
     m.add_function(wrap_pyfunction!(mine_moe, m)?)?;
+    m.add_function(wrap_pyfunction!(penalized_target_bound, m)?)?;
     m.add_function(wrap_pyfunction!(py_pad_to_chunk_boundary, m)?)?;
     // V2 functions (current circuit; MoE and dense proofs)
     m.add_function(wrap_pyfunction!(generate_proof_v2, m)?)?;

--- a/spv/blockmanager.go
+++ b/spv/blockmanager.go
@@ -2843,10 +2843,7 @@ func (b *blockManager) checkHeaderSanity(blockHeader *wire.BlockHeader,
 		&b.cfg.ChainParams,
 	)
 
-	var flags blockchain.BehaviorFlags
-	if b.cfg.ChainParams.Net == wire.SimNet {
-		flags |= blockchain.BFNoPoWCheck
-	}
+	flags := blockchain.NetBehaviorFlags(&b.cfg.ChainParams)
 
 	err := blockchain.CheckBlockHeaderContext(
 		blockHeader, parentHeaderCtx, flags, chainCtx, true,
@@ -2855,8 +2852,8 @@ func (b *blockManager) checkHeaderSanity(blockHeader *wire.BlockHeader,
 		return err
 	}
 
-	if err := blockchain.CheckCertificateVersion(
-		cert, prevNodeHeight+1, &b.cfg.ChainParams,
+	if err := blockchain.CheckCertificateRules(
+		blockHeader, cert, prevNodeHeight+1, &b.cfg.ChainParams, flags,
 	); err != nil {
 		return err
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -19,8 +19,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	Major uint = 1
-	Minor uint = 2
-	Patch uint = 2
+	Minor uint = 3
+	Patch uint = 0
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/zk-pow/bindings/go/src/common.rs
+++ b/zk-pow/bindings/go/src/common.rs
@@ -1,11 +1,11 @@
 //! C-compatible structs and utilities for Go FFI.
 
-use anyhow::Result;
 use std::os::raw::c_char;
 use std::panic::AssertUnwindSafe;
 use std::slice;
 use std::sync::Mutex;
 
+use anyhow::Result;
 use zk_pow::api::proof::{IncompleteBlockHeader, MiningConfiguration, PublicProofParams};
 use zk_pow::api::prove;
 use zk_pow::circuit::pearl_circuit::{PearlRecursion, RecursionCircuit};
@@ -24,9 +24,13 @@ pub const ERROR_MSG_MAX_SIZE: usize = 128;
 /// Maximum size of a serialized ZK proof blob (excluding IncompleteBlockHeader and MiningConfiguration, including everything else).
 pub const MAX_ZK_PROOF_SIZE: usize = 60000;
 
+/// Smallest noise rank the rank-penalty rule accepts (exported to C header).
+pub const MIN_NOISE_RANK: u16 = 128;
+
 // Compile-time assertions to ensure constants stay in sync
 const _: () = assert!(MINING_CONFIG_RESERVED_SIZE == MiningConfiguration::RESERVED_SIZE);
 const _: () = assert!(MINING_CONFIG_SERIALIZED_SIZE == MiningConfiguration::SERIALIZED_SIZE);
+const _: () = assert!(MIN_NOISE_RANK as usize == zk_pow::api::sanity_checks::PENALTY_BASE_RANK);
 
 type CircuitCache = <PearlRecursion as RecursionCircuit>::CircuitCache;
 type V1CircuitCache = zk_pow::v1::circuit::circuit_utils::CircuitCache;

--- a/zk-pow/bindings/go/src/mine.rs
+++ b/zk-pow/bindings/go/src/mine.rs
@@ -2,16 +2,79 @@
 
 use std::os::raw::c_char;
 
-use zk_pow::api::proof::{IncompleteBlockHeader, MiningConfiguration};
+use zk_pow::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern};
 use zk_pow::api::prove;
 use zk_pow::ffi::mine::{mine as ffi_mine, mine_moe as ffi_mine_moe};
 use zk_pow::ffi::plain_proof::PlainProof;
 
-use crate::common::{catch_panic, copy_prove_result, set_error_msg, zk_prove, CZKProof};
+use crate::common::{catch_panic, copy_prove_result, set_error_msg, zk_prove, CZKProof, MIN_NOISE_RANK};
+
+// ============================================================================
+// Default mining configuration
+// ============================================================================
+
+/// Noise rank the default configuration mines at. Sitting on the rank-penalty
+/// floor keeps mined blocks valid once that rule activates, without paying the
+/// penalty a larger rank would.
+const DEFAULT_RANK: u16 = MIN_NOISE_RANK;
+
+/// Smallest common dimension the sanity checks allow for [`DEFAULT_RANK`] (`k >= 16 * r`).
+const DEFAULT_COMMON_DIM: u32 = 16 * DEFAULT_RANK as u32;
+
+/// Index patterns partitioning the jackpot tile: 4 rows of A by 8 columns of B.
+const DEFAULT_ROWS_PATTERN: [u32; 4] = [0, 8, 64, 72];
+const DEFAULT_COLS_PATTERN: [u32; 8] = [0, 1, 8, 9, 32, 33, 40, 41];
 
 // ============================================================================
 // Public FFI
 // ============================================================================
+
+/// Serializes the default mining configuration.
+///
+/// `e == 0` selects a standard job; otherwise it selects a GROUPED_GEMM job
+/// routing each token to `top_k` experts.
+///
+/// # Returns
+/// - 0: configuration written to `mining_config_out`
+/// - 2: System error
+///
+/// # Safety
+/// - `mining_config_out` must be a valid pointer to `MINING_CONFIG_SERIALIZED_SIZE` bytes
+/// - `error_msg_out` must be null or a valid pointer to a caller-allocated buffer of `ERROR_MSG_MAX_SIZE` bytes
+#[no_mangle]
+pub unsafe extern "C" fn default_mining_config(
+    e: u16,
+    top_k: u16,
+    mining_config_out: *mut [u8; crate::common::MINING_CONFIG_SERIALIZED_SIZE],
+    error_msg_out: *mut c_char,
+) -> i32 {
+    let result = catch_panic(|| {
+        if mining_config_out.is_null() {
+            set_error_msg(error_msg_out, "Null pointer");
+            return 2;
+        }
+
+        match build_default_config(e, top_k) {
+            Ok(config) => {
+                *mining_config_out = config.to_bytes();
+                set_error_msg(error_msg_out, "Default mining config written");
+                0
+            }
+            Err(err) => {
+                set_error_msg(error_msg_out, &format!("Invalid default mining config: {err}"));
+                2
+            }
+        }
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic_msg) => {
+            set_error_msg(error_msg_out, &format!("Internal panic: {panic_msg}"));
+            2
+        }
+    }
+}
 
 /// Perform mining and generate a standard (non-MoE) ZK proof in one step.
 ///
@@ -84,6 +147,17 @@ pub unsafe extern "C" fn mine_moe(
 // ============================================================================
 // Shared helpers
 // ============================================================================
+
+fn build_default_config(e: u16, top_k: u16) -> anyhow::Result<MiningConfiguration> {
+    Ok(MiningConfiguration {
+        common_dim: DEFAULT_COMMON_DIM,
+        rank: DEFAULT_RANK,
+        mma_type: MMAType::Int7xInt7ToInt32,
+        rows_pattern: PeriodicPattern::from_list(&DEFAULT_ROWS_PATTERN)?,
+        cols_pattern: PeriodicPattern::from_list(&DEFAULT_COLS_PATTERN)?,
+        moe: (e != 0).then_some(MoEConfig { e, top_k }),
+    })
+}
 
 /// Shared boilerplate for both `mine` and `mine_moe`.
 ///

--- a/zk-pow/bindings/go/src/verify.rs
+++ b/zk-pow/bindings/go/src/verify.rs
@@ -8,6 +8,7 @@ use std::slice;
 
 use crate::common::MAX_ZK_PROOF_SIZE;
 use zk_pow::api::proof::{IncompleteBlockHeader, PublicProofParams, ZKProof};
+use zk_pow::api::sanity_checks;
 use zk_pow::api::verify;
 
 use crate::common::{acquire_cache, catch_panic, set_error_msg, CZKProof};
@@ -141,6 +142,63 @@ pub unsafe extern "C" fn verify_zk_proof_v2_with_nbits(
     error_msg_out: *mut c_char,
 ) -> i32 {
     verify_zk_proof_inner(block_header, zk_proof, Some(nbits_override), error_msg_out)
+}
+
+/// Check wire `public_data` against the rank-penalty rule.
+///
+/// # Returns
+/// - 0: rule satisfied
+/// - 1: rule violated (the block must be rejected)
+/// - 2: System error (could not run the check)
+///
+/// # Safety
+/// - `public_data` must be a valid pointer to `public_data_len` bytes
+/// - `error_msg_out` must be null or a valid pointer to a caller-allocated buffer of `ERROR_MSG_MAX_SIZE` bytes
+#[no_mangle]
+pub unsafe extern "C" fn check_rank_penalty(
+    nbits: u32,
+    public_data: *const u8,
+    public_data_len: usize,
+    error_msg_out: *mut c_char,
+) -> i32 {
+    let result = catch_panic(|| {
+        if public_data.is_null() {
+            set_error_msg(error_msg_out, "Null pointer");
+            return 2;
+        }
+        if !PublicProofParams::is_valid_wire_size(public_data_len) {
+            set_error_msg(error_msg_out, &format!("invalid public_data_len {}", public_data_len));
+            return 1;
+        }
+
+        let public_data = slice::from_raw_parts(public_data, public_data_len);
+        let (mining_config, hash_jackpot) = match PublicProofParams::mining_config_and_jackpot_from_wire_bytes(public_data) {
+            Ok(fields) => fields,
+            Err(e) => {
+                set_error_msg(error_msg_out, &format!("{}", e));
+                return 1;
+            }
+        };
+
+        match sanity_checks::check_rank_penalty(&mining_config, &hash_jackpot, nbits) {
+            Ok(()) => {
+                set_error_msg(error_msg_out, "Rank penalty rule satisfied");
+                0
+            }
+            Err(e) => {
+                set_error_msg(error_msg_out, &format!("{}", e));
+                1
+            }
+        }
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic_msg) => {
+            set_error_msg(error_msg_out, &format!("Internal panic: {}", panic_msg));
+            2
+        }
+    }
 }
 
 /// Verify a V1 (version 1, master-format) ZK proof.

--- a/zk-pow/src/api/proof_utils.rs
+++ b/zk-pow/src/api/proof_utils.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail, ensure};
+use core::ops::Range;
 use plonky2::field::extension::quadratic::QuadraticExtension;
 use plonky2::field::types::{Field, Field64};
 use plonky2::hash::hash_types::HashOut;
@@ -1095,6 +1096,36 @@ mod tests {
         assert_eq!(moe.hash_routing, [0x11u8; 32]);
         assert_eq!(moe.outer_indices, vec![3u32, 7, 42]);
     }
+
+    #[test]
+    fn mining_config_and_jackpot_parse_from_moe_wire_bytes() {
+        // The rank-penalty FFI parses only the shared prefix (config + jackpot)
+        // and accepts any MoE-sized blob, since the MoE tail is irrelevant to
+        // the rule. Pin that the dense and MoE layouts agree on the prefix the
+        // rule reads (common_dim, rank, and the jackpot hash), even though the
+        // mining-config trailer (e, top_k) differs.
+        let mut dense = PublicProofParams::new_for_tests(64, 64, 256);
+        dense.hash_jackpot = [0xcdu8; 32];
+        let dense_bytes = dense.to_wire_bytes().unwrap();
+
+        let mut moe = dense.clone();
+        moe.mining_config.moe = Some(MoEConfig { e: 4, top_k: 4 });
+        moe.moe = Some(MoEParams {
+            routing_offsets: vec![64u32, 128, 192, 256],
+            expert_idx: 1,
+            hash_routing: [0x11u8; 32],
+            outer_indices: vec![3u32, 7, 42],
+        });
+        let moe_bytes = moe.to_wire_bytes().unwrap();
+        assert!(moe_bytes.len() > PublicProofParams::WIRE_SIZE);
+
+        let (dense_cfg, dense_jp) = PublicProofParams::mining_config_and_jackpot_from_wire_bytes(&dense_bytes).unwrap();
+        let (moe_cfg, moe_jp) = PublicProofParams::mining_config_and_jackpot_from_wire_bytes(&moe_bytes).unwrap();
+        assert_eq!(dense_cfg.common_dim, moe_cfg.common_dim);
+        assert_eq!(dense_cfg.rank, moe_cfg.rank);
+        assert_eq!(dense_jp, moe_jp);
+        assert_eq!(dense_jp, [0xcdu8; 32]);
+    }
 }
 
 impl PublicProofParams {
@@ -1123,6 +1154,47 @@ impl PublicProofParams {
         len == Self::WIRE_SIZE || (Self::MIN_MOE_WIRE_SIZE..=Self::MAX_WIRE_SIZE).contains(&len)
     }
 
+    /// Byte range of the serialized [`MiningConfiguration`] within wire `public_data`.
+    pub const MINING_CONFIG_RANGE: Range<usize> = 0..MiningConfiguration::SERIALIZED_SIZE;
+
+    /// Length of each `Hash256` field in the wire layout.
+    pub const HASH_LEN: usize = 32;
+
+    /// Byte range of `hash_a` within wire `public_data`.
+    pub const HASH_A_RANGE: Range<usize> =
+        MiningConfiguration::SERIALIZED_SIZE..MiningConfiguration::SERIALIZED_SIZE + Self::HASH_LEN;
+
+    /// Byte range of `hash_b` within wire `public_data`.
+    pub const HASH_B_RANGE: Range<usize> = {
+        let start = MiningConfiguration::SERIALIZED_SIZE + Self::HASH_LEN;
+        start..start + Self::HASH_LEN
+    };
+
+    /// Byte range of `hash_jackpot` within wire `public_data`.
+    ///
+    /// Follows the serialized [`MiningConfiguration`] and the two preceding hashes
+    /// (`hash_a`, `hash_b`), each [`Self::HASH_LEN`] bytes.
+    pub const HASH_JACKPOT_RANGE: Range<usize> = {
+        let start = MiningConfiguration::SERIALIZED_SIZE + 2 * Self::HASH_LEN;
+        start..start + Self::HASH_LEN
+    };
+
+    /// Parses just the mining configuration and jackpot hash from wire `public_data`.
+    ///
+    /// Both live in the core prefix that dense and MoE proofs share, so this needs
+    /// neither the MoE tail nor a block header — unlike [`Self::from_wire_bytes`],
+    /// which reconstructs the full parameters.
+    pub fn mining_config_and_jackpot_from_wire_bytes(public_data: &[u8]) -> Result<(MiningConfiguration, Hash256)> {
+        ensure!(
+            public_data.len() >= Self::WIRE_SIZE,
+            "public_data too short: need at least {} bytes",
+            Self::WIRE_SIZE
+        );
+        let mining_config = MiningConfiguration::from_bytes(&public_data[Self::MINING_CONFIG_RANGE])?;
+        let hash_jackpot: Hash256 = public_data[Self::HASH_JACKPOT_RANGE].try_into().unwrap();
+        Ok((mining_config, hash_jackpot))
+    }
+
     /// Deserialize from the wire `public_data` bytes produced by [`Self::to_wire_bytes`].
     ///
     /// `public_data` layout (non-MoE): [`Self::WIRE_SIZE`] bytes — core prefix only.
@@ -1138,10 +1210,10 @@ impl PublicProofParams {
             Self::WIRE_SIZE
         );
 
-        let mining_config = MiningConfiguration::from_bytes(&public_data[0..52])?;
-        let hash_a: [u8; 32] = public_data[52..84].try_into().unwrap();
-        let hash_b: [u8; 32] = public_data[84..116].try_into().unwrap();
-        let hash_jackpot: [u8; 32] = public_data[116..148].try_into().unwrap();
+        let mining_config = MiningConfiguration::from_bytes(&public_data[Self::MINING_CONFIG_RANGE])?;
+        let hash_a: [u8; 32] = public_data[Self::HASH_A_RANGE].try_into().unwrap();
+        let hash_b: [u8; 32] = public_data[Self::HASH_B_RANGE].try_into().unwrap();
+        let hash_jackpot: [u8; 32] = public_data[Self::HASH_JACKPOT_RANGE].try_into().unwrap();
         let m = u32::from_le_bytes(public_data[148..152].try_into().unwrap());
         let n = u32::from_le_bytes(public_data[152..156].try_into().unwrap());
         let t_rows = u32::from_le_bytes(public_data[156..160].try_into().unwrap());
@@ -1244,10 +1316,10 @@ impl PublicProofParams {
     /// Serialize to the wire `public_data` format (164 bytes non-MoE; longer when `moe` is set).
     pub fn to_wire_bytes(&self) -> Result<Vec<u8>> {
         let mut public_data = vec![0u8; Self::WIRE_SIZE];
-        public_data[0..52].copy_from_slice(&self.mining_config.to_bytes());
-        public_data[52..84].copy_from_slice(&self.hash_a);
-        public_data[84..116].copy_from_slice(&self.hash_b);
-        public_data[116..148].copy_from_slice(&self.hash_jackpot);
+        public_data[Self::MINING_CONFIG_RANGE].copy_from_slice(&self.mining_config.to_bytes());
+        public_data[Self::HASH_A_RANGE].copy_from_slice(&self.hash_a);
+        public_data[Self::HASH_B_RANGE].copy_from_slice(&self.hash_b);
+        public_data[Self::HASH_JACKPOT_RANGE].copy_from_slice(&self.hash_jackpot);
         public_data[148..152].copy_from_slice(&self.m.to_le_bytes());
         public_data[152..156].copy_from_slice(&self.n.to_le_bytes());
         public_data[156..160].copy_from_slice(&self.t_rows.to_le_bytes());

--- a/zk-pow/src/api/sanity_checks.rs
+++ b/zk-pow/src/api/sanity_checks.rs
@@ -1,6 +1,6 @@
 use crate::circuit::chip::blake3::program::DWORD_SIZE;
 use crate::{
-    api::proof::{MiningConfiguration, PublicProofParams},
+    api::proof::{Hash256, MiningConfiguration, PublicProofParams},
     api::proof_utils::nbits_to_difficulty,
     circuit::pearl_program::{TILE_D, TILE_H},
     ensure_eq,
@@ -8,6 +8,9 @@ use crate::{
 use anyhow::{Result, ensure};
 use log::info;
 use primitive_types::U256;
+
+/// Minimum accepted noise rank and normalization point for the rank penalty.
+pub const PENALTY_BASE_RANK: usize = 128;
 
 pub fn public_params_sanity_check(public_params: &PublicProofParams) -> Result<()> {
     let k = public_params.common_dim();
@@ -153,6 +156,68 @@ pub fn check_jackpot_against_nbits(public_params: &PublicProofParams, nbits_over
     Ok(())
 }
 
+/// Checks a mining configuration and jackpot hash against the rank-penalty rule.
+///
+/// Deciding *when* the rule applies is the caller's job: this crate has no notion of
+/// block height or fork activation. `nbits` is the difficulty target to measure the
+/// jackpot against — a block header's nbits for consensus, or a pool's share target.
+pub fn check_rank_penalty(config: &MiningConfiguration, hash_jackpot: &Hash256, nbits: u32) -> Result<()> {
+    let rank = config.rank as usize;
+    ensure!(rank >= PENALTY_BASE_RANK, "Rank must be >= {PENALTY_BASE_RANK} || r={rank}");
+    // Reject zero rather than passing it to scale_target.
+    let adjustment_factor = penalized_adjustment_factor(config);
+    ensure!(
+        adjustment_factor > 0,
+        "Degenerate mining configuration: h*w={} dot_product_length={}",
+        tile_size(config),
+        config.dot_product_length()
+    );
+    ensure!(
+        U256::from_little_endian(hash_jackpot) <= scale_target(nbits, adjustment_factor),
+        "Jackpot condition not satisfied: hash does not meet the rank-penalized difficulty target"
+    );
+    Ok(())
+}
+
+/// Number of hashed output elements per jackpot attempt.
+fn tile_size(config: &MiningConfiguration) -> usize {
+    config.rows_pattern.size() as usize * config.cols_pattern.size() as usize
+}
+
+/// How much easier the jackpot bound is made for a given configuration, in
+/// proportion to the work one attempt costs: the hashed tile size times the
+/// dot product length.
+fn difficulty_adjustment_factor(config: &MiningConfiguration) -> usize {
+    tile_size(config) * config.dot_product_length()
+}
+
+fn penalized_adjustment_factor(config: &MiningConfiguration) -> usize {
+    tile_size(config) * (config.dot_product_length() / config.rank as usize) * PENALTY_BASE_RANK
+}
+
+fn scale_target(nbits: u32, adjustment_factor: usize) -> U256 {
+    scale(nbits_to_difficulty(nbits), adjustment_factor)
+}
+
+/// Scales `base` by `adjustment_factor`, saturating at [`U256::MAX`] on overflow.
+///
+/// Caller must ensure `adjustment_factor > 0`: [`check_rank_penalty`] checks it
+/// outright, and [`public_params_sanity_check`] rules it out for a verified proof
+/// by requiring `k >= 16r`.
+fn scale(base: U256, adjustment_factor: usize) -> U256 {
+    debug_assert!(adjustment_factor > 0, "scale: zero adjustment factor");
+    if base > U256::MAX / adjustment_factor {
+        info!(
+            "Difficulty is too easy: hardness={} adjustment_factor={}",
+            U256::MAX / base,
+            adjustment_factor
+        );
+        U256::MAX
+    } else {
+        base * adjustment_factor
+    }
+}
+
 /// Computes difficulty bound for proof verification.
 ///
 /// # Arguments
@@ -162,19 +227,130 @@ pub fn check_jackpot_against_nbits(public_params: &PublicProofParams, nbits_over
 /// # Returns
 /// * Adjusted difficulty bound as U256
 pub fn extract_difficulty_bound(nbits: u32, config: &MiningConfiguration) -> U256 {
-    let target_difficulty = nbits_to_difficulty(nbits);
-    let h = config.rows_pattern.size() as usize;
-    let w = config.cols_pattern.size() as usize;
-    let tile_size = h * w;
-    let difficulty_adjustment_factor = tile_size * config.dot_product_length();
-    if target_difficulty > U256::MAX / difficulty_adjustment_factor {
-        info!(
-            "Difficulty is too easy: hardness={} h*w*k={}",
-            U256::MAX / target_difficulty,
-            difficulty_adjustment_factor
+    scale_target(nbits, difficulty_adjustment_factor(config))
+}
+
+/// [`extract_difficulty_bound`] with the rank penalty applied, or `None` when the
+/// configuration is degenerate or the bound does not fit in 256 bits.
+///
+/// Unlike the consensus path this does not saturate: a miner scaling a share
+/// target must be told the target is unusable rather than handed [`U256::MAX`],
+/// which every hash satisfies.
+pub fn penalized_target_bound(target: U256, config: &MiningConfiguration) -> Option<U256> {
+    let factor = penalized_adjustment_factor(config);
+    if factor == 0 || target > U256::MAX / factor {
+        return None;
+    }
+    Some(target * factor)
+}
+
+#[cfg(test)]
+mod rank_penalty_tests {
+    use super::*;
+    use crate::api::proof::{MMAType, PeriodicPattern};
+
+    const TEST_NBITS: u32 = 0x1d00ffff;
+
+    fn test_config(rank: usize, common_dim: u32) -> MiningConfiguration {
+        MiningConfiguration {
+            common_dim,
+            rank: rank as u16,
+            mma_type: MMAType::Int7xInt7ToInt32,
+            rows_pattern: PeriodicPattern::from_list(&[0, 8, 64, 72]).unwrap(),
+            cols_pattern: PeriodicPattern::from_list(&[0, 1, 8, 9, 32, 33, 40, 41]).unwrap(),
+            moe: None,
+        }
+    }
+
+    fn jackpot_of(value: U256) -> Hash256 {
+        let mut bytes = [0u8; 32];
+        value.to_little_endian(&mut bytes);
+        bytes
+    }
+
+    /// The penalized counterpart of [`extract_difficulty_bound`], for the nbits
+    /// these tests compare against.
+    fn penalized_bound(nbits: u32, config: &MiningConfiguration) -> U256 {
+        penalized_target_bound(nbits_to_difficulty(nbits), config).unwrap()
+    }
+
+    #[test]
+    fn penalty_is_neutral_at_base_rank() {
+        let config = test_config(PENALTY_BASE_RANK, 4096);
+        assert_eq!(
+            penalized_bound(TEST_NBITS, &config),
+            extract_difficulty_bound(TEST_NBITS, &config)
         );
-        U256::MAX
-    } else {
-        target_difficulty * difficulty_adjustment_factor
+    }
+
+    #[test]
+    fn penalty_divides_bound_in_proportion_to_rank() {
+        for multiple in [2usize, 4, 8] {
+            let config = test_config(PENALTY_BASE_RANK * multiple, 65536);
+            assert_eq!(
+                penalized_bound(TEST_NBITS, &config),
+                extract_difficulty_bound(TEST_NBITS, &config) / multiple,
+                "rank {} should be penalized {}x",
+                config.rank,
+                multiple
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_rank_below_base() {
+        let config = test_config(PENALTY_BASE_RANK / 2, 4096);
+        let err = check_rank_penalty(&config, &[0u8; 32], TEST_NBITS).unwrap_err();
+        assert!(err.to_string().contains("Rank must be"), "unexpected error: {err}");
+    }
+
+    /// The bound is inclusive, and the comparison uses the penalized bound: above
+    /// the base rank, an unpenalized comparison would accept `bound + 1`.
+    #[test]
+    fn accepts_jackpot_at_the_bound_and_rejects_above_it() {
+        for rank in [PENALTY_BASE_RANK, PENALTY_BASE_RANK * 2] {
+            let config = test_config(rank, 65536);
+            let bound = penalized_bound(TEST_NBITS, &config);
+            check_rank_penalty(&config, &jackpot_of(bound), TEST_NBITS).unwrap();
+            check_rank_penalty(&config, &jackpot_of(bound + 1), TEST_NBITS).unwrap_err();
+        }
+    }
+
+    #[test]
+    fn rejects_degenerate_config_without_panicking() {
+        let config = test_config(PENALTY_BASE_RANK, 64);
+        check_rank_penalty(&config, &[0u8; 32], TEST_NBITS).unwrap_err();
+    }
+
+    #[test]
+    fn penalized_target_bound_scales_the_target() {
+        // At the base rank the penalized factor equals the unpenalized one, so
+        // penalized_target_bound(target) == target * difficulty_adjustment_factor.
+        let config = test_config(PENALTY_BASE_RANK, 4096);
+        let target = U256::from(1u64) << 200;
+        let bound = penalized_target_bound(target, &config).unwrap();
+        assert_eq!(bound, target * difficulty_adjustment_factor(&config));
+
+        // Doubling the rank halves the bound when common_dim is held fixed (the
+        // penalty's purpose): dot/rank halves, and BASE*rank doubles, net 1/2.
+        let bigger = test_config(PENALTY_BASE_RANK * 2, 4096);
+        let smaller_bound = penalized_target_bound(target, &bigger).unwrap();
+        assert_eq!(smaller_bound, bound / 2);
+    }
+
+    /// Neither input a miner can be handed may come back as a usable bound: a
+    /// degenerate configuration has no bound, and a target easy enough to overflow
+    /// must not be clamped to U256::MAX, which every hash satisfies.
+    #[test]
+    fn penalized_target_bound_rejects_unusable_inputs() {
+        let degenerate = test_config(PENALTY_BASE_RANK, 64);
+        assert_eq!(penalized_adjustment_factor(&degenerate), 0);
+        assert_eq!(penalized_target_bound(U256::from(1u64) << 200, &degenerate), None);
+
+        let config = test_config(PENALTY_BASE_RANK, 4096);
+        let largest = U256::MAX / penalized_adjustment_factor(&config);
+        assert!(penalized_target_bound(largest, &config).is_some());
+        assert_eq!(penalized_target_bound(largest + 1, &config), None);
+        assert_eq!(penalized_target_bound(U256::MAX, &config), None);
     }
 }


### PR DESCRIPTION
## Summary

A proof's jackpot bound is scaled by the work one attempt costs, and the noise rank divides that work, so mining at a larger rank buys a proportionally easier bound for the same effort. From `RankPenaltyForkHeight` on, a certificate's noise rank must be at least 128 and its jackpot must meet a bound scaled by `128/rank`, which cancels the advantage. The rule only tightens validity, so pre-fork nodes accept every post-fork block.

## Type

feat

## Scope

node (blockchain, chaincfg, zkpow, mining, netsync, wire), spv, zk-pow, py-pearl-mining, miner

## Changes

- **The rule** (`zk-pow/src/api/sanity_checks.rs`): `PENALTY_BASE_RANK = 128`, `check_rank_penalty`, and `penalized_target_bound`. The consensus path still saturates at `U256::MAX`, where an absurdly easy nbits legitimately means every jackpot passes; `penalized_target_bound` returns `None` instead, because a miner scaling a share target must be told the target is unusable rather than handed one every hash satisfies.
- **Wire parsing** (`zk-pow/src/api/proof_utils.rs`): named byte ranges replace the open-coded offsets, plus `mining_config_and_jackpot_from_wire_bytes`, which reads only the prefix dense and MoE proofs share so the rule needs neither the MoE tail nor a block header.
- **FFI**: `check_rank_penalty` and `default_mining_config` entry points, and an exported `MIN_NOISE_RANK` asserted at compile time against `PENALTY_BASE_RANK`.
- **Certificate rules** (`node/blockchain/validate.go`): `CheckCertificateVersion` becomes `CheckCertificateRules`, enforcing the version cutover, the dense-only fork and the rank-penalty rule together, and taking the header and the behavior flags the new rule reads. Adds `ErrRankPenalty`, and a `blockchain.New` assertion that the fork cannot precede `MoEForkHeight` since only V2 certificates carry a noise rank.
- **`NetBehaviorFlags`** (`node/blockchain/process.go`): derives the `BFNoPoWCheck` that SimNet needs in one place, replacing the three copies of that special case in `checkBlockSanity`, `CheckHeaderSanity` and the SPV block manager. The rank-penalty rule reads a proof, so it is skipped wherever proof of work is not verified, which includes block templates.
- **`CertificateV2.PublicDataBytes()`**: the `PublicData`/`PublicDataLen` pairing now appears once. `verifyCertificateV2`'s inline guard against an out-of-range length is gone: `Deserialize`, `Mine` and `MineMoE` are the only producers and all three bound it, and `ProofCommitment` sliced the same fields unguarded regardless.
- **Node miner** (`node/zkpow/miner.go`): the serialized mining configuration now comes from Rust's `default_mining_config` rather than a hardcoded byte array, and sits at rank 128 — the floor, so mined blocks stay valid past activation without paying a penalty. `DefaultNoiseRank` and `DefaultMMAType` had no other readers and are dropped.
- **Miner gateway**: `MiningJob.adjust_target` goes through `penalized_target_bound` and raises on a sub-floor rank, a degenerate configuration, or an unrepresentable bound; `MinerSettings.noise_rank` rejects values below the floor at load time rather than mining blocks consensus will reject.
- **Activation heights** (`node/chaincfg/params.go`): mainnet 96251, testnet 36761, testnet2 80627, and regtest 1, which verifies proofs.
- **Version**: 1.2.2 -> 1.3.0.

## Test plan

- [x] New tests added
  - `node/zkpow/rank_penalty_test.go` (zkpow tag) pins the Rust rule to an independent Go implementation of the same formula, and covers the rank floor plus public data the rule cannot parse. Testing each rank at its own bound also covers the property the fork exists for: a jackpot that wins at the base rank is rejected at a larger one.
  - `node/blockchain/rank_penalty_fork_test.go` covers when the rule applies: the activation boundary, the `BFNoPoWCheck` skip, block templates, and the params ordering invariant.
  - `node/mining/mining_test.go` now builds a template on regtest, which verifies proofs, so the template path is exercised with the certificate forks active; the existing coverage was SimNet-only, where the rule is skipped for the network regardless.
  - Rust unit tests for neutrality at the base rank, the proportional penalty above it, the inclusive bound, degenerate configurations, and unrepresentable bounds; Python tests for `adjust_target`.
- [x] Ran locally: `go build ./...`, `go test` for `node/blockchain`, `node/chaincfg`, `node/mining`, `node/wire`, `node/netsync` and `spv`; `gofmt`, `goimports` and `go mod tidy` clean; `cargo fmt --check` on `zk-pow`, `zk-pow/bindings/go` and `py-pearl-mining`; `ruff check` and `ruff format --check` on the changed Python files. `TestCheckBlockSanity` and the `node/wire` certificate tests fail identically on master without `-tags zkpow`.
- [ ] Full `task test` and the zk-pow and py-pearl-mining suites left to CI.

## Rollout

The testnet heights were rescheduled in the second commit, projected from the tips at each chain's own recent spacing (both run slow against the 3m14s target):

- testnet 36761, 7 blocks from tip 36754 at ~493 s/block, so ~19:15 IDT today
- testnet2 80627, 30 blocks from tip 80597 at ~243 s/block, so ~20:20 IDT today
- mainnet 96251, unchanged, ~283 blocks from tip 95968, so ~08:45 IDT tomorrow

Testnet stays roughly an hour ahead of testnet2 so problems surface on the internal chain first. Nodes must be upgraded before their network's height: an activation height that passes before the rollout completes would have upgraded nodes reject the blocks mined after it, so any height at risk needs rescheduling first.
