### PR TITLE
fix(chaincfg): reschedule testnet2 dense-only fork above the MoE blocks

### DIFF
--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -631,12 +631,6 @@ var TestNet2Params = Params{
 	MoEForkHeight: 54869,
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
-	//
-	// Rescheduled from 75122 to clear 12 MoE blocks between 78309 and 80050
-	// that the chain accepted while this fleet was still on a pre-fork build,
-	// so 75122 made the canonical chain unsyncable from genesis. Blocks 80051
-	// to the tip are all dense, so activating here both validates the existing
-	// chain and keeps the rule in force at the tip.
 	DenseOnlyForkHeight: 80051,
 
 	RankPenaltyForkHeight: 80627,

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -631,7 +631,13 @@ var TestNet2Params = Params{
 	MoEForkHeight: 54869,
 
 	// Dense-only softfork: MoE proofs are rejected from this height on.
-	DenseOnlyForkHeight: 75122,
+	//
+	// Rescheduled from 75122 to clear 12 MoE blocks between 78309 and 80050
+	// that the chain accepted while this fleet was still on a pre-fork build,
+	// so 75122 made the canonical chain unsyncable from genesis. Blocks 80051
+	// to the tip are all dense, so activating here both validates the existing
+	// chain and keeps the rule in force at the tip.
+	DenseOnlyForkHeight: 80051,
 
 	RankPenaltyForkHeight: 80627,
 

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 3
-	Patch uint = 0
+	Patch uint = 1
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

testnet2's canonical chain is currently **unsyncable from genesis** by any build that carries the dense-only softfork. This moves `DenseOnlyForkHeight` from 75122 to 80051 so the existing chain validates again, and bumps 1.3.0 -> 1.3.1.

## What happened

The dense-only softfork ([#260](https://github.com/pearl-research-labs/pearl/pull/260)) set testnet2's activation to 75122, reached **2026-07-23 09:55:38Z**, and shipped in v1.2.1 the same day. Each network's height was chosen to land shortly after its fleet upgrade:

| Network | Fork height | Fork block time | Fleet upgraded to v1.2.1 |
|---|---|---|---|
| internal | 28262 | 2026-07-23 10:39:48Z | 09:46:46Z |
| mainnet | 91630 | 2026-07-23 10:57:23Z | 10:41:46Z |
| testnet2 | 75122 | 2026-07-23 09:55:38Z | **never** |

testnet2 was left on `pearld:testnet-77fef91e` (2026-06-11), a build in which `DenseOnlyForkHeight` does not exist:

```
$ git show 77fef91e:node/chaincfg/params.go | rg -c DenseOnlyForkHeight
DenseOnlyForkHeight NOT PRESENT in 77fef91e
```

So nothing on the network could enforce the rule. Blocks 75122-78308 were dense because that is what the miners happened to produce, not because a node would have rejected an MoE proof. On **2026-07-31 08:01:06Z** a miner started emitting MoE certificates and they were accepted. Twelve MoE blocks now sit in the chain:

`78309, 78340, 78341, 78800, 78802, 78922, 78932, 78998, 79034, 79737, 79842, 80050`

## Why the fleet looks healthy

`CheckCertificateRules` is only reachable from block-connection paths (`checkBlockSanity`, `netsync/manager.go`, `spv/blockmanager.go`). Nothing re-validates blocks already in the index. The testnet2 fleet is now on v1.3.0, holds those blocks from before the upgrade, and sits happily above them, so the chain looks fine from the tip.

Anything that validates history stops at 78308: a fresh IBD on a new or rebuilt node, a Blockbook resync or reindex, and SPV clients. This is latent until a node's data dir is wiped or a node is replaced.

## The change

Activate at **80051**, immediately after the last MoE block (80050). Blocks 80051 through the tip (80647 at time of writing) are all dense, so this:

- makes the existing chain validate from genesis, since the 12 MoE blocks fall below activation, and
- keeps the rule in force at the tip, so there is no unenforced window and no coordination deadline.

A retroactive height is safe here precisely because the intervening blocks were verified dense. Only testnet2 is touched; internal and mainnet enforced from activation and are unchanged.

## Test plan

- [x] `go build ./node/...`, `gofmt` clean
- [x] `go test ./node/chaincfg/...`
- [x] `go test ./node/blockchain/ -run 'MoE|DenseOnly|Certificate|RankPenalty'`

Existing fork tests use synthetic heights, so no test changes are needed. No assertion constrains `DenseOnlyForkHeight` ordering (`blockchain.New` only checks `RankPenaltyForkHeight >= MoEForkHeight`), and 80051 stays below `RankPenaltyForkHeight` 80627.

## Rollout

Nodes can adopt this whenever: old (75122) and new (80051) enforcement agree on every block from 80051 up, so mixed versions do not disagree at the tip. The fix matters for nodes that need to sync history.
