### PR TITLE
feat(consensus): salted noise-seed hardfork

### DIFF
--- a/docs/salted-seed-fork-upgrade-guide.md
+++ b/docs/salted-seed-fork-upgrade-guide.md
@@ -1,0 +1,107 @@
+# Salted-Seed Hard Fork Upgrade Guide for Miners and Mining Pools
+
+Pearl is doing a hard fork. At a fixed block height (the **fork height**), blocks switch
+from the V2 (MoE) ZK certificate to the new V3 (salted noise-seed) certificate.
+
+| Network | Fork height (`SaltedSeedForkHeight`) |
+| ------- | ------------------------------------ |
+| Testnet | TBD                                  |
+| Mainnet | TBD                                  |
+
+**The short version:**
+
+- V3 changes how the noise seeds are derived from the matrix commitments: each Merkle
+  root is first salted with a keyed BLAKE3 hash that also commits the matrix dimensions
+  (`m` for A, `n` for B). The ZK circuits, wire formats, and share formats are unchanged.
+- Because the derivation feeds mining itself, **everything must be upgraded before the
+  fork height: node, ZK proving code, and miners.** A miner running old software
+  produces invalid shares from the fork height on. This is different from the MoE fork,
+  where old miners kept working.
+- Upgraded software switches automatically at the fork height. There is nothing to
+  schedule on your side; the certificate version comes from `getblocktemplate` per block.
+
+---
+
+## Step 1: Upgrade your node to v1.4.0
+
+Safe to do at any time before the fork. The node stays fully compatible with V2 blocks
+and shares until the fork height.
+
+`getblocktemplate` reports `requiredcertversion: 3` at and after the fork height
+(`2` before it). As with the MoE fork: read the version from the template, do not
+hardcode the fork height.
+
+## Step 2: Upgrade your ZK proving code (pools)
+
+Deploy before the fork height, or every block you build after the fork is rejected.
+
+If you followed the MoE fork guide and use the certificate-version dispatchers, you
+only need the new `pearl-mining` package (v0.3.0) — the dispatchers accept version 3:
+
+- `check_cert_version_eligible`, `generate_proof_for_cert_version`,
+  `verify_proof_for_cert_version`, and `verify_plain_proof_for_cert_version` handle
+  `requiredcertversion` 1, 2, and 3. Old package versions raise
+  `ValueError: unknown certificate version: 3`.
+- Versioned entry points exist too: `generate_proof_v3`, `verify_proof_v3`,
+  `verify_plain_proof_v3` (same circuits and circuit cache as V2; only the seed
+  derivation differs).
+- A share is bound to one derivation. A share mined under V2 rules fails V3
+  verification and vice versa, so verify shares with the version of the template
+  they were mined against.
+
+If you call the C FFI directly: `mine`, `mine_moe`, `verify_plain_proof_ffi`, and
+`prove_plain_proof_ffi` now take a `cert_version` argument. Rebuild against the new
+header; do not run old binaries against the new library.
+
+If you use the Rust crate directly: pass `SeedDerivation` (from
+`zk_pow::api::proof`) to `zk_prove_plain_proof` / `verify_plain_proof`, or map it
+from the certificate version with `CertificateVersion::seed_derivation()`.
+Reference: `zk-pow/src/api/seed.rs`.
+
+Only if you serialize certificates yourself: the V3 wire layout is identical to V2
+(`Version(4) | HeaderHash(32) | PublicDataLen(4) | PublicData(N) | ProofDataLen(4) |
+ProofData`) with `3` in the version field, and the header's proof commitment is
+`double_sha256(cert_version_le32 + public_data)` with the prefix now `3`.
+
+## Step 3: Upgrade your miners
+
+Unlike the MoE fork, this is required: V3 share noise uses salted seeds, so
+mining software that derives seeds the old way produces invalid shares from
+the fork height on. Pools should expect
+`verify_plain_proof_for_cert_version(3, ...)` to reject them.
+
+If you run the reference miner stack (vllm-miner + gateway), upgrading is all you
+need. The mining job now carries `cert_version` (and it is a required field of
+`submitPlainProof`); the miner reads it per job and salts when the job requires V3.
+Deploy at any time before the fork — it switches automatically at the fork height.
+
+If you built custom mining software, implement the new derivation:
+
+1. Compute the keyed Merkle roots of A and B exactly as today (`hash_a`, `hash_b`).
+   The wire formats do not change; shares still carry the raw roots.
+2. When the job's `cert_version` is 3, bind each root to its matrix dimension
+   before the (unchanged) seed chain:
+
+   ```text
+   bound_a = blake3(hash_a || m_le32 || 0^28, key = blake3("pearl/cert-v3/noise-seed/A"))
+   bound_b = blake3(hash_b || n_le32 || 0^28, key = blake3("pearl/cert-v3/noise-seed/B"))
+   ```
+
+   Each message is exactly one 64-byte BLAKE3 block: the 32-byte root, the
+   dimension as a little-endian u32, and 28 zero bytes.
+3. Use the bound roots wherever the raw roots fed the seed chain:
+   `b_noise_seed = blake3(job_key || bound_b)`, then
+   `a_noise_seed = blake3(b_noise_seed || bound_a)`.
+4. MoE only: salt **before** the routing fold — `bound_a` (not `hash_a`) goes into
+   `hash_activations = blake3(bound_a || hash_routing)`. The dimensions are
+   `m` = token count and `n` = the **per-expert** intermediate dimension (B holds
+   all experts stacked, but `n` does not include the expert count).
+
+Reference implementations: `zk-pow/src/api/seed.rs` (Rust, with pinned test
+vectors), `miner/miner-base/src/miner_base/commitment_hash.py` (Python,
+`bind_root_a`/`bind_root_b`), and the CUDA kernel behind
+`commitment_hash_from_merkle_roots(..., salted_dims=(m, n))` in `pearl-gemm`.
+
+## Questions
+
+Contact the Pearl team on the usual channels if anything is unclear.

--- a/docs/salted-seed-fork-upgrade-guide.md
+++ b/docs/salted-seed-fork-upgrade-guide.md
@@ -3,10 +3,11 @@
 Pearl is doing a hard fork. At a fixed block height (the **fork height**), blocks switch
 from the V2 (MoE) ZK certificate to the new V3 (salted noise-seed) certificate.
 
-| Network | Fork height (`SaltedSeedForkHeight`) |
-| ------- | ------------------------------------ |
-| Testnet | TBD                                  |
-| Mainnet | TBD                                  |
+| Network  | Fork height (`SaltedSeedForkHeight`) |
+| -------- | ------------------------------------ |
+| Mainnet  | `98900`                              |
+| Testnet  | `38648`                              |
+| Testnet2 | `83109`                              |
 
 **The short version:**
 

--- a/miner/conftest.py
+++ b/miner/conftest.py
@@ -347,7 +347,11 @@ def _adjust_mining_job_target(
     if bound is None:
         raise ValueError("degenerate mining config in test scaffolding")
     target //= bound
-    return MiningJob(incomplete_header_bytes=incomplete_header_bytes, target=target)
+    return MiningJob(
+        incomplete_header_bytes=incomplete_header_bytes,
+        target=target,
+        cert_version=CertificateVersion.ZK_MOE,
+    )
 
 
 @pytest.fixture

--- a/miner/miner-base/src/miner_base/commitment_hash.py
+++ b/miner/miner-base/src/miner_base/commitment_hash.py
@@ -5,6 +5,27 @@ from pearl_mining import MiningConfiguration
 
 from .matrix_merkle_tree import MatrixMerkleTree
 
+# Domain-separation salts for the V3 (salted noise-seed) certificate derivation:
+SEED_SALT_A = blake3(b"pearl/cert-v3/noise-seed/A").digest()
+SEED_SALT_B = blake3(b"pearl/cert-v3/noise-seed/B").digest()
+
+# root(32) || dim u32 LE(4) || zero padding(28) = one 64-byte BLAKE3 block.
+_BIND_PAD = b"\x00" * 28
+
+
+def _bind_root(merkle_root: bytes, dim: int, salt: bytes) -> bytes:
+    return blake3(merkle_root + dim.to_bytes(4, "little") + _BIND_PAD, key=salt).digest()
+
+
+def bind_root_a(a_merkle_root: bytes, m: int) -> bytes:
+    """V3 salting of A's Merkle root; commits the row count ``m``."""
+    return _bind_root(a_merkle_root, m, SEED_SALT_A)
+
+
+def bind_root_b(b_merkle_root: bytes, n: int) -> bytes:
+    """V3 salting of B's Merkle root; commits the column count ``n``."""
+    return _bind_root(b_merkle_root, n, SEED_SALT_B)
+
 
 class CommitmentHasher:
     """
@@ -60,7 +81,14 @@ class CommitmentHasher:
         *,
         routing_root: bytes | None = None,
         offsets_root: bytes | None = None,
+        salted_dims: tuple[int, int] | None = None,
     ) -> CommitmentHash:
+        # V3 (salted) derivation: salt each root before the MoE routing fold.
+        if salted_dims is not None:
+            m, n = salted_dims
+            A_merkle_root = bind_root_a(A_merkle_root, m)
+            B_merkle_root = bind_root_b(B_merkle_root, n)
+
         moe_args = (routing_root, offsets_root)
         if any(arg is not None for arg in moe_args):
             if any(arg is None for arg in moe_args):

--- a/miner/miner-base/src/miner_base/gateway_client.py
+++ b/miner/miner-base/src/miner_base/gateway_client.py
@@ -2,6 +2,7 @@ from contextlib import AbstractContextManager
 from types import TracebackType
 
 from miner_utils import get_logger
+from pearl_gateway.blockchain_utils.zk_certificate import CertificateVersion
 from pearl_gateway.comm.dataclasses import MiningJob
 from pearl_gateway.comm.json_rpc_client import JSONRPCClient
 from pearl_gateway.config import MinerRpcConfig
@@ -67,4 +68,4 @@ class DummyMiningClient(MiningClient):
         self.client = DummyRPCClient()
 
     def get_mining_info(self) -> MiningJob:
-        return MiningJob(b"\xde\xad\xba\xbe" * 8, 1)
+        return MiningJob(b"\xde\xad\xba\xbe" * 8, 1, cert_version=CertificateVersion.ZK_MOE)

--- a/miner/miner-base/tests/test_commitment_hash.py
+++ b/miner/miner-base/tests/test_commitment_hash.py
@@ -2,7 +2,7 @@ import secrets
 
 import pytest
 import torch
-from miner_base.commitment_hash import CommitmentHasher
+from miner_base.commitment_hash import CommitmentHasher, bind_root_a, bind_root_b
 from pearl_gateway.comm.dataclasses import CommitmentHash
 from pearl_gateway.comm.mining_configuration import MiningConfiguration
 from pearl_mining import IncompleteBlockHeader
@@ -71,3 +71,117 @@ class TestCommitmentHasher:
             CommitmentHasher.commitment_hash(
                 tensor_3d, tensor_3d, incomplete_header_bytes, mining_config
             )
+
+
+@pytest.fixture
+def job_key() -> bytes:
+    """Return a fixed job key for reproducible hashes."""
+    return bytes([0x11] * 32)
+
+
+@pytest.fixture
+def root_a() -> bytes:
+    """Return a fixed A root for reproducible hashes."""
+    return bytes([0xAA] * 32)
+
+
+@pytest.fixture
+def root_b() -> bytes:
+    """Return a fixed B root for reproducible hashes."""
+    return bytes([0xBB] * 32)
+
+
+@pytest.fixture
+def matrix_dimensions() -> tuple[int, int]:
+    """Return fixed matrix dimensions for salted hashes."""
+    return 192, 320
+
+
+@pytest.fixture
+def moe_roots() -> dict[str, bytes]:
+    """Return fixed MoE roots for reproducible hashes."""
+    return {
+        "routing_root": bytes([0xCC] * 32),
+        "offsets_root": bytes([0xDD] * 32),
+    }
+
+
+class TestSaltedSeedDerivation:
+    """Verify vectors shared with the Rust seed tests."""
+
+    def test_legacy_pinned_vector(self, root_a, root_b, job_key):
+        """Test the legacy noise-seed chain."""
+        result = CommitmentHasher.commitment_hash_from_merkle_roots(
+            root_a,
+            root_b,
+            job_key,
+        )
+        assert (
+            result.noise_seed_B.hex()
+            == "add6f7ea5feebf89c8a77e2ebfa0d82442e7dbb0046dbd48971861d12fcb0177"
+        )
+        assert (
+            result.noise_seed_A.hex()
+            == "483b07b6f73105030b9482255f37723f3fed69ae916724ee8291848b8c28794b"
+        )
+
+    def test_salted_pinned_vector(self, root_a, root_b, job_key, matrix_dimensions):
+        """Test the salted noise-seed chain."""
+        result = CommitmentHasher.commitment_hash_from_merkle_roots(
+            root_a,
+            root_b,
+            job_key,
+            salted_dims=matrix_dimensions,
+        )
+        assert (
+            result.noise_seed_B.hex()
+            == "60ed9b73c5a9599b200b6cd563e7f0d5d9a67d2402d85fd4ef966c580080d0e5"
+        )
+        assert (
+            result.noise_seed_A.hex()
+            == "301784168005ec833ab0aa60006f7fe7faaa95307d8c1fc6819b2ffdd717eccf"
+        )
+
+    def test_salted_moe_pinned_vector(self, root_a, root_b, job_key, matrix_dimensions):
+        """Pinned vector shared with the Rust test (`seed.rs::commitment_hash_pinned_vector_salted_moe`)."""
+        result = CommitmentHasher.commitment_hash_from_merkle_roots(
+            root_a,
+            root_b,
+            job_key,
+            routing_root=bytes([0xCC] * 32),
+            offsets_root=CommitmentHasher.get_offsets_hash([3, 5, 9, 12], job_key),
+            salted_dims=matrix_dimensions,
+        )
+        assert (
+            result.noise_seed_B.hex()
+            == "60ed9b73c5a9599b200b6cd563e7f0d5d9a67d2402d85fd4ef966c580080d0e5"
+        )
+        assert (
+            result.noise_seed_A.hex()
+            == "268a2eb78b3b2d2fead262221b24c6346d0a6d201890a467751f623b7eacd5c2"
+        )
+
+    def test_salted_moe_fold_order(
+        self,
+        root_a,
+        root_b,
+        job_key,
+        matrix_dimensions,
+        moe_roots,
+    ):
+        """Test that MoE roots are salted before the routing fold."""
+        matrix_rows, matrix_columns = matrix_dimensions
+        prebound = CommitmentHasher.commitment_hash_from_merkle_roots(
+            bind_root_a(root_a, matrix_rows),
+            bind_root_b(root_b, matrix_columns),
+            job_key,
+            **moe_roots,
+        )
+        salted = CommitmentHasher.commitment_hash_from_merkle_roots(
+            root_a,
+            root_b,
+            job_key,
+            salted_dims=matrix_dimensions,
+            **moe_roots,
+        )
+        assert prebound == salted

--- a/miner/pearl-gateway/src/pearl_gateway/blockchain_utils/zk_certificate.py
+++ b/miner/pearl-gateway/src/pearl_gateway/blockchain_utils/zk_certificate.py
@@ -21,6 +21,11 @@ class CertificateVersion(IntEnum):
 
     ZK_DENSE = 1  # V1: dense (non-MoE) proofs only.
     ZK_MOE = 2  # V2: MoE and dense proofs.
+    ZK_V3 = 3  # V3: V2 layout with the salted noise-seed derivation.
+
+    @property
+    def uses_salted_seeds(self) -> bool:
+        return self >= CertificateVersion.ZK_V3
 
 
 _DENSE_DTYPE = np.dtype(
@@ -65,6 +70,7 @@ class ZKCertificate:
 
         ZK_DENSE (v1): Version(4) | HeaderHash(32) | PublicData(164) | ProofDataLen(4) | ProofData
         ZK_MOE   (v2): Version(4) | HeaderHash(32) | PublicDataLen(4) | PublicData(N) | ProofDataLen(4) | ProofData
+        ZK_V3 (v3): same layout as v2 (only the noise-seed derivation differs).
         """
         public_data = bytes(self.proof.public_data)
         proof = bytes(self.proof.proof_data)
@@ -103,7 +109,7 @@ class ZKCertificate:
             public_data = bytes(arr["public_data"])
             proof_data_len = int(arr["proof_data_len"])
             proof_data = data[_DENSE_DTYPE.itemsize : _DENSE_DTYPE.itemsize + proof_data_len]
-        elif cert_version == CertificateVersion.ZK_MOE:
+        elif cert_version in (CertificateVersion.ZK_MOE, CertificateVersion.ZK_V3):
             arr = np.frombuffer(data, dtype=_MOE_PREAMBLE_DTYPE, count=1)[0]
             header_hash = bytes(arr["header_hash"])
             pd_len = int(arr["public_data_len"])

--- a/miner/pearl-gateway/src/pearl_gateway/comm/dataclasses.py
+++ b/miner/pearl-gateway/src/pearl_gateway/comm/dataclasses.py
@@ -50,7 +50,7 @@ class BlockTemplate:
     raw_transactions: list[bytes]
     coinbase_tx: Transaction
     # Certificate version this block must carry under the crossover cutover.
-    required_cert_version: CertificateVersion = CertificateVersion.ZK_MOE
+    required_cert_version: CertificateVersion
 
     @classmethod
     def from_get_block_template(
@@ -179,8 +179,8 @@ class MiningJob:
 
     incomplete_header_bytes: bytes
     target: int
-    # Certificate version required for this block;
-    cert_version: CertificateVersion = CertificateVersion.ZK_MOE
+    # Certificate version required for this block.
+    cert_version: CertificateVersion
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON-RPC response."""

--- a/miner/pearl-gateway/src/pearl_gateway/miner_rpc/schemas.py
+++ b/miner/pearl-gateway/src/pearl_gateway/miner_rpc/schemas.py
@@ -34,10 +34,11 @@ SUBMIT_PLAIN_PROOF_SCHEMA = {
         "plain_proof": {"type": "string", "pattern": BASE64_PATTERN},
         "mining_job": {
             "type": "object",
-            "required": ["incomplete_header_bytes", "target"],
+            "required": ["incomplete_header_bytes", "target", "cert_version"],
             "properties": {
                 "incomplete_header_bytes": {"type": "string", "pattern": BASE64_PATTERN},
                 "target": {"type": "integer", "minimum": 0},
+                "cert_version": {"type": "integer", "minimum": 1},
             },
         },
     },

--- a/miner/pearl-gateway/src/pearl_gateway/rpc_types.py
+++ b/miner/pearl-gateway/src/pearl_gateway/rpc_types.py
@@ -43,9 +43,5 @@ class GetBlockTemplateResponse(BaseModel):
     coinbaseaux: CoinbaseAux
     coinbasevalue: int = Field(ge=0)
     default_witness_commitment: str | None = None
-    # Optional for backward compatibility
-    requiredcertversion: int = Field(
-        default=int(CertificateVersion.ZK_DENSE),
-        ge=int(CertificateVersion.ZK_DENSE),
-        le=int(CertificateVersion.ZK_MOE),
-    )
+    # Absent from nodes that predate the field; those only ever require V1.
+    requiredcertversion: CertificateVersion = CertificateVersion.ZK_DENSE

--- a/miner/pearl-gateway/tests/miner_rpc/test_performance.py
+++ b/miner/pearl-gateway/tests/miner_rpc/test_performance.py
@@ -18,6 +18,7 @@ import numpy as np
 import pytest
 from bitcoinutils.transactions import Transaction
 from pearl_gateway.blockchain_utils.pearl_header import PearlHeader
+from pearl_gateway.blockchain_utils.zk_certificate import CertificateVersion
 from pearl_gateway.comm.dataclasses import BlockTemplate
 from pearl_gateway.config import MinerRpcConfig
 from pearl_gateway.miner_rpc.server import MinerRpcServer
@@ -186,6 +187,7 @@ class RawJsonRpcClient:
             "mining_job": {
                 "incomplete_header_bytes": "AAAAIDhiU/6qm0m0dHuhR3D/4amWtlumgYWBWHROIlcW1ln7CH+YUAYaAOJx8e9+e/LT+8Crf85o3D8eDKcHVk0PLvP3ZF5p//8PHQAAAAAAAAAA",
                 "target": 431358735298270906413161702650018451440568065076682751302691926835200,
+                "cert_version": int(CertificateVersion.ZK_MOE),
             },
         }
 
@@ -316,6 +318,7 @@ async def mock_work_cache():
         coinbase_tx=Transaction.from_raw(
             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0502a1050101ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
         ),
+        required_cert_version=CertificateVersion.ZK_MOE,
     )
 
     await cache.update_template(template)

--- a/miner/pearl-gateway/tests/test_comm_dataclasses.py
+++ b/miner/pearl-gateway/tests/test_comm_dataclasses.py
@@ -89,9 +89,15 @@ class TestAdjustTarget:
             col_indices=self.COL_INDICES,
         )
 
+    def _mining_job(self, target: int) -> MiningJob:
+        return MiningJob(
+            incomplete_header_bytes=b"",
+            target=target,
+            cert_version=CertificateVersion.ZK_MOE,
+        )
+
     def _adjusted_target(self, rank: int) -> int:
-        job = MiningJob(incomplete_header_bytes=b"", target=self.BLOCK_TARGET)
-        return job.adjust_target(self._mining_config(rank))
+        return self._mining_job(self.BLOCK_TARGET).adjust_target(self._mining_config(rank))
 
     def test_base_rank_is_unpenalized(self):
         """A miner at the base rank searches the plain hash-tile-scaled target."""
@@ -122,17 +128,15 @@ class TestAdjustTarget:
             row_indices=self.ROW_INDICES,
             col_indices=self.COL_INDICES,
         )
-        job = MiningJob(incomplete_header_bytes=b"", target=self.BLOCK_TARGET)
         with pytest.raises(ValueError, match="degenerate"):
-            job.adjust_target(config)
+            self._mining_job(self.BLOCK_TARGET).adjust_target(config)
 
     def test_target_too_easy_is_rejected(self):
         """A target whose penalized bound exceeds 256 bits must raise. Clamping it
         to the maximum target would have the miner search a target every hash
         satisfies."""
-        job = MiningJob(incomplete_header_bytes=b"", target=2**240)
         with pytest.raises(ValueError, match="too easy"):
-            job.adjust_target(self._mining_config(PENALTY_BASE_RANK))
+            self._mining_job(2**240).adjust_target(self._mining_config(PENALTY_BASE_RANK))
 
 
 class TestBlockTemplateCertVersion:

--- a/miner/pearl-gateway/tests/test_comm_dataclasses.py
+++ b/miner/pearl-gateway/tests/test_comm_dataclasses.py
@@ -8,6 +8,7 @@ from pearl_gateway.comm.dataclasses import (
 )
 from pearl_gateway.comm.mining_configuration import PearlMiningConfigurationFactory
 from pearl_mining import PENALTY_BASE_RANK
+from pydantic import ValidationError
 
 
 class TestMiningJob:
@@ -147,7 +148,7 @@ class TestBlockTemplateCertVersion:
     ):
         from pearl_gateway.rpc_types import GetBlockTemplateResponse
 
-        for version in (CertificateVersion.ZK_DENSE, CertificateVersion.ZK_MOE):
+        for version in CertificateVersion:
             data = {**sample_block_template_data, "requiredcertversion": int(version)}
             template = BlockTemplate.from_get_block_template(
                 GetBlockTemplateResponse.model_validate(data),
@@ -171,3 +172,13 @@ class TestBlockTemplateCertVersion:
             mining_address=mining_address,
         )
         assert template.required_cert_version == CertificateVersion.ZK_DENSE
+
+    def test_unknown_required_cert_version_is_rejected(self, sample_block_template_data):
+        """A version this build has no derivation for must fail loudly rather than
+        be mined under the wrong one."""
+        from pearl_gateway.rpc_types import GetBlockTemplateResponse
+
+        unknown = max(CertificateVersion) + 1
+        data = {**sample_block_template_data, "requiredcertversion": unknown}
+        with pytest.raises(ValidationError):
+            GetBlockTemplateResponse.model_validate(data)

--- a/miner/pearl-gateway/tests/test_json_schema.py
+++ b/miner/pearl-gateway/tests/test_json_schema.py
@@ -90,6 +90,7 @@ def test_invalid_submit_plain_proof_params_wrong_type():
         "mining_job": {
             "incomplete_header_bytes": "dGVzdA==",
             "target": 1000,
+            "cert_version": 2,
         },
     }
 
@@ -104,6 +105,7 @@ def test_invalid_submit_plain_proof_params_invalid_base64():
         "mining_job": {
             "incomplete_header_bytes": "dGVzdA==",
             "target": 1000,
+            "cert_version": 2,
         },
     }
 
@@ -118,8 +120,23 @@ def test_invalid_submit_plain_proof_params_negative_target():
         "mining_job": {
             "incomplete_header_bytes": "dGVzdA==",
             "target": -1,  # Should be non-negative
+            "cert_version": 2,
         },
     }
 
     with pytest.raises(fastjsonschema.exceptions.JsonSchemaException):
+        validate_submit_plain_proof(params)
+
+
+def test_invalid_submit_plain_proof_params_missing_cert_version():
+    """A share must state the certificate version it was mined for."""
+    params = {
+        "plain_proof": "dGVzdA==",
+        "mining_job": {
+            "incomplete_header_bytes": "dGVzdA==",
+            "target": 1000,
+        },
+    }
+
+    with pytest.raises(fastjsonschema.exceptions.JsonSchemaException, match="cert_version"):
         validate_submit_plain_proof(params)

--- a/miner/pearl-gateway/tests/test_work_cache.py
+++ b/miner/pearl-gateway/tests/test_work_cache.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from bitcoinutils.transactions import Transaction
 from pearl_gateway.blockchain_utils.pearl_header import PearlHeader
+from pearl_gateway.blockchain_utils.zk_certificate import CertificateVersion
 from pearl_gateway.comm.dataclasses import BlockTemplate, MiningJob, MiningPausedError
 from pearl_gateway.work_cache import WorkCache
 from pearl_mining import IncompleteBlockHeader
@@ -38,6 +39,7 @@ def different_block_template():
             "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0502a1050101ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000"
         ),
         raw_transactions=[],
+        required_cert_version=CertificateVersion.ZK_MOE,
     )
 
 

--- a/miner/pearl-gemm/csrc/blake3/blake3.cuh
+++ b/miner/pearl-gemm/csrc/blake3/blake3.cuh
@@ -156,6 +156,11 @@ __device__ __constant__ constexpr CompressParams
         .counter = 0,
         .block_len = MSG_BLOCK_SIZE,
         .flags = KEYED_HASH | CHUNK_START | CHUNK_END | ROOT};
+// Unkeyed compression for a single 64-byte message block.
+__device__ __constant__ constexpr CompressParams COMPRESS_PARAMS_SINGLE_BLOCK =
+    {.counter = 0,
+     .block_len = MSG_BLOCK_SIZE,
+     .flags = CHUNK_START | CHUNK_END | ROOT};
 
 CUTLASS_DEVICE
 u32 add32(u32 x, u32 y) {

--- a/miner/pearl-gemm/csrc/gemm/pearl_gemm_api.cpp
+++ b/miner/pearl-gemm/csrc/gemm/pearl_gemm_api.cpp
@@ -1001,7 +1001,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Commitment hash from Merkle roots", py::arg("A_merkle_root"),
         py::arg("B_merkle_root"), py::arg("key"), py::arg("A_commitment_hash"),
         py::arg("B_commitment_hash"), py::arg("routing_root") = py::none(),
-        py::arg("offsets_hash") = py::none());
+        py::arg("offsets_hash") = py::none(),
+        py::arg("salted_dim_a") = py::none(),
+        py::arg("salted_dim_b") = py::none());
   m.def("get_host_signal_header_size", &get_host_signal_header_size,
         "Calculate host signal header buffer size");
   m.def("get_host_signal_sync_size", &get_host_signal_sync_size,
@@ -1216,7 +1218,9 @@ TORCH_LIBRARY(pearl_gemm, m) {
       "    Tensor(A_commitment_hash!) A_commitment_hash, "
       "    Tensor(B_commitment_hash!) B_commitment_hash, "
       "    Tensor? routing_root=None, "
-      "    Tensor? offsets_hash=None"
+      "    Tensor? offsets_hash=None, "
+      "    int? salted_dim_a=None, "
+      "    int? salted_dim_b=None"
       ") -> ()");
   m.def(
       "build_routing_data("

--- a/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
@@ -2,6 +2,18 @@
 
 namespace pearl {
 
+// V3 domain-separation salts, encoded as little-endian u32 words. These are
+// blake3("pearl/cert-v3/noise-seed/{A,B}"), hardcoded so the derivation doesn't
+// depend on runtime string hashing.
+__device__ __constant__ uint32_t
+    SEED_SALT_A_U32[blake3::CHAINING_VALUE_SIZE_U32] = {
+        0x6C404982, 0x1615EDA0, 0x92F61696, 0xF876F0FC,
+        0x2ADBDB92, 0x52B82370, 0x1977D4F0, 0x7B0190C3};
+__device__ __constant__ uint32_t
+    SEED_SALT_B_U32[blake3::CHAINING_VALUE_SIZE_U32] = {
+        0x32063011, 0xCA0163EC, 0x71AFE22B, 0x4F4D3F8B,
+        0x39C6E91A, 0x04CCE888, 0x1D304448, 0xA99AB871};
+
 class CommitmentHashFromMerkleRootsKernel {
  public:
   using Element = uint8_t;
@@ -23,6 +35,9 @@ class CommitmentHashFromMerkleRootsKernel {
     Element* const ptr_B_commitment_hash;
     Element const* const ptr_routing_root;
     Element const* const ptr_offsets_hash;
+    bool apply_salt;
+    uint32_t salted_dim_a;
+    uint32_t salted_dim_b;
   };
 
   // Kernel entry point API
@@ -34,6 +49,9 @@ class CommitmentHashFromMerkleRootsKernel {
     Element* const ptr_B_commitment_hash;
     Element const* const ptr_routing_root;
     Element const* const ptr_offsets_hash;
+    bool apply_salt;
+    uint32_t salted_dim_a;
+    uint32_t salted_dim_b;
   };
 
   static Params to_underlying_arguments(Arguments const& args) {
@@ -43,7 +61,10 @@ class CommitmentHashFromMerkleRootsKernel {
             args.ptr_A_commitment_hash,
             args.ptr_B_commitment_hash,
             args.ptr_routing_root,
-            args.ptr_offsets_hash};
+            args.ptr_offsets_hash,
+            args.apply_salt,
+            args.salted_dim_a,
+            args.salted_dim_b};
   }
 
   static dim3 get_grid_shape(Params const& params) { return dim3(1); }
@@ -52,104 +73,56 @@ class CommitmentHashFromMerkleRootsKernel {
 
   CUTLASS_DEVICE
   void operator()(Params const& params, char* smem_buf) {
-    // Every combine here is a single BLAKE3 block: each input is exactly
-    // blake3::MSG_BLOCK_SIZE (64) bytes (two 32-byte roots).
-    static constexpr blake3::CompressParams single_block_params = {
-        .counter = 0,
-        .block_len = blake3::MSG_BLOCK_SIZE,
-        .flags = blake3::CHUNK_START | blake3::CHUNK_END | blake3::ROOT,
-    };
-
-    // First calculate B commitment hash: BLAKE3(key || B_merkle_root)
-    Tensor rBlockB = make_tensor<uint32_t>(RmemBlockLayout{});
-    Tensor rChainingValueB = make_tensor<uint32_t>(RmemChainingValueLayout{});
-
-    uint32_t const* key_u32 = (uint32_t const*)params.ptr_key;
+    // V3 binds each raw Merkle root to its matrix dimension.
+    Tensor rARoot = make_tensor<uint32_t>(RmemChainingValueLayout{});
+    Tensor rBRoot = make_tensor<uint32_t>(RmemChainingValueLayout{});
+    uint32_t const* A_merkle_root_u32 =
+        (uint32_t const*)params.ptr_A_merkle_root;
     uint32_t const* B_merkle_root_u32 =
         (uint32_t const*)params.ptr_B_merkle_root;
 
-    CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-      rBlockB(i) = key_u32[i];
-      rBlockB(i + blake3::CHAINING_VALUE_SIZE_U32) = B_merkle_root_u32[i];
-    }
-    CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-      rChainingValueB(i) = blake3::IV[i];
-    }
-    blake3::compress_msg_block_u32(rBlockB, rChainingValueB,
-                                   single_block_params);
-
-    // Determine the effective A root words. In the MoE case the routing
-    // commitment is folded into A's seed:
-    //   hash_routing     = BLAKE3(routing_root || offsets_hash)
-    //   hash_activations = BLAKE3(A_merkle_root || hash_routing)
-    // and hash_activations replaces A_merkle_root below. When the optional
-    // routing inputs are absent (nullptr) A_merkle_root is used directly
-    // (dense case, unchanged).
-    Tensor rARoot = make_tensor<uint32_t>(RmemChainingValueLayout{});
-    uint32_t const* A_merkle_root_u32 =
-        (uint32_t const*)params.ptr_A_merkle_root;
-
-    if (params.ptr_routing_root != nullptr) {
-      uint32_t const* routing_root_u32 =
-          (uint32_t const*)params.ptr_routing_root;
-      uint32_t const* offsets_hash_u32 =
-          (uint32_t const*)params.ptr_offsets_hash;
-
-      // hash_routing = BLAKE3(routing_root || offsets_hash)
-      Tensor rBlockRouting = make_tensor<uint32_t>(RmemBlockLayout{});
-      Tensor rHashRouting = make_tensor<uint32_t>(RmemChainingValueLayout{});
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-        rBlockRouting(i) = routing_root_u32[i];
-        rBlockRouting(i + blake3::CHAINING_VALUE_SIZE_U32) =
-            offsets_hash_u32[i];
-      }
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-        rHashRouting(i) = blake3::IV[i];
-      }
-      blake3::compress_msg_block_u32(rBlockRouting, rHashRouting,
-                                     single_block_params);
-
-      // hash_activations = BLAKE3(A_merkle_root || hash_routing)
-      Tensor rBlockActivations = make_tensor<uint32_t>(RmemBlockLayout{});
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-        rBlockActivations(i) = A_merkle_root_u32[i];
-        rBlockActivations(i + blake3::CHAINING_VALUE_SIZE_U32) =
-            rHashRouting(i);
-      }
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-        rARoot(i) = blake3::IV[i];
-      }
-      blake3::compress_msg_block_u32(rBlockActivations, rARoot,
-                                     single_block_params);
+    if (params.apply_salt) {
+      bind_root(A_merkle_root_u32, params.salted_dim_a, SEED_SALT_A_U32,
+                rARoot);
+      bind_root(B_merkle_root_u32, params.salted_dim_b, SEED_SALT_B_U32,
+                rBRoot);
     } else {
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-        rARoot(i) = A_merkle_root_u32[i];
-      }
+      load_chaining_value(A_merkle_root_u32, rARoot);
+      load_chaining_value(B_merkle_root_u32, rBRoot);
     }
 
-    // Now calculate A commitment hash: BLAKE3(B_commitment_hash || A_root)
-    Tensor rBlockA = make_tensor<uint32_t>(RmemBlockLayout{});
+    // In the MoE case the routing commitment is folded into A's root:
+    //   hash_routing     = BLAKE3(routing_root || offsets_hash)
+    //   hash_activations = BLAKE3(A_root || hash_routing)
+    // When the optional routing inputs are absent (nullptr) A's root is used
+    // as is (dense case).
+    if (params.ptr_routing_root != nullptr) {
+      Tensor rRoutingRoot = make_tensor<uint32_t>(RmemChainingValueLayout{});
+      Tensor rOffsetsHash = make_tensor<uint32_t>(RmemChainingValueLayout{});
+      load_chaining_value((uint32_t const*)params.ptr_routing_root,
+                          rRoutingRoot);
+      load_chaining_value((uint32_t const*)params.ptr_offsets_hash,
+                          rOffsetsHash);
+
+      Tensor rHashRouting = make_tensor<uint32_t>(RmemChainingValueLayout{});
+      hash_pair(rRoutingRoot, rOffsetsHash, rHashRouting);
+
+      Tensor rHashActivations =
+          make_tensor<uint32_t>(RmemChainingValueLayout{});
+      hash_pair(rARoot, rHashRouting, rHashActivations);
+      copy(rHashActivations, rARoot);
+    }
+
+    // The seed chain: BLAKE3(key || B_root), then BLAKE3(that || A_root).
+    Tensor rKey = make_tensor<uint32_t>(RmemChainingValueLayout{});
+    load_chaining_value((uint32_t const*)params.ptr_key, rKey);
+
+    Tensor rChainingValueB = make_tensor<uint32_t>(RmemChainingValueLayout{});
+    hash_pair(rKey, rBRoot, rChainingValueB);
+
+    // A's seed is derived from B's commitment.
     Tensor rChainingValueA = make_tensor<uint32_t>(RmemChainingValueLayout{});
-
-    CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-      rBlockA(i) = rChainingValueB(i);  // Use B's result, not the key!
-      rBlockA(i + blake3::CHAINING_VALUE_SIZE_U32) = rARoot(i);
-    }
-    CUTLASS_PRAGMA_UNROLL
-    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
-      rChainingValueA(i) = blake3::IV[i];
-    }
-
-    blake3::compress_msg_block_u32(rBlockA, rChainingValueA,
-                                   single_block_params);
+    hash_pair(rChainingValueB, rARoot, rChainingValueA);
 
     // Copy the result back to global memory
     uint32_t* A_commitment_hash_u32 = (uint32_t*)params.ptr_A_commitment_hash;
@@ -160,6 +133,53 @@ class CommitmentHashFromMerkleRootsKernel {
       A_commitment_hash_u32[i] = rChainingValueA(i);
       B_commitment_hash_u32[i] = rChainingValueB(i);
     }
+  }
+
+ private:
+  template <class TensorOut>
+  CUTLASS_DEVICE static void load_chaining_value(uint32_t const* src,
+                                                 TensorOut& out) {
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+      out(i) = src[i];
+    }
+  }
+
+  // Unkeyed BLAKE3(left || right) over two 32-byte chaining values, which
+  // together are exactly one message block.
+  template <class TensorLeft, class TensorRight, class TensorOut>
+  CUTLASS_DEVICE static void hash_pair(TensorLeft const& left,
+                                       TensorRight const& right,
+                                       TensorOut& out) {
+    Tensor rBlock = make_tensor<uint32_t>(RmemBlockLayout{});
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+      rBlock(i) = left(i);
+      rBlock(i + blake3::CHAINING_VALUE_SIZE_U32) = right(i);
+      out(i) = blake3::IV[i];
+    }
+    blake3::compress_msg_block_u32(rBlock, out,
+                                   blake3::COMPRESS_PARAMS_SINGLE_BLOCK);
+  }
+
+  // V3 salting of one Merkle root: keyed BLAKE3 of a single block holding
+  // `root || dim as u32 LE || zero padding`, with `salt` as the BLAKE3 key.
+  template <class TensorOut>
+  CUTLASS_DEVICE static void bind_root(uint32_t const* root, uint32_t dim,
+                                       uint32_t const* salt, TensorOut& out) {
+    Tensor rBlock = make_tensor<uint32_t>(RmemBlockLayout{});
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < blake3::MSG_BLOCK_SIZE_U32; ++i) {
+      rBlock(i) = 0;
+    }
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < blake3::CHAINING_VALUE_SIZE_U32; ++i) {
+      rBlock(i) = root[i];
+      out(i) = salt[i];
+    }
+    rBlock(blake3::CHAINING_VALUE_SIZE_U32) = dim;
+    blake3::compress_msg_block_u32(rBlock, out,
+                                   blake3::COMPRESS_PARAMS_SINGLE_BLOCK_KEYED);
   }
 };  // class CommitmentHashFromMerkleRootsKernel
 }  // namespace pearl

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_api.hpp
@@ -6,6 +6,7 @@
 #include <torch/python.h>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 // Include only the host function declaration
 #include "blake3/blake3_constants.hpp"
@@ -23,6 +24,15 @@ constexpr size_t DEFAULT_LEAVES_PER_MT_BLOCK = 512;  // compute_blake_mt_kernel
 // merkle_tree_roots_kernel builds a TMA descriptor over `data`;
 // cuTensorMapEncodeTiled requires the global address to be 16-byte aligned.
 constexpr uintptr_t TMA_GLOBAL_ALIGNMENT_BYTES = 16;
+
+// V3 salting writes the matrix dimension into the hashed block as a u32.
+constexpr int64_t MAX_SALTED_DIM = std::numeric_limits<uint32_t>::max();
+
+uint32_t to_salted_dim(int64_t dim, const char* name) {
+  TORCH_CHECK(dim > 0 && dim <= MAX_SALTED_DIM, name, " must be in [1, ",
+              MAX_SALTED_DIM, "], got ", dim);
+  return static_cast<uint32_t>(dim);
+}
 
 size_t get_required_scratchpad_bytes(
     size_t matrix_bytes, size_t threads_per_block = DEFAULT_THREADS_PER_BLOCK) {
@@ -111,17 +121,15 @@ void run_tensor_hash(
               roots.data_ptr<uint8_t>(), *dprops, stream);
 }
 
-// Computes both A and B commitment hashes from their merkle roots
-// Should be the same as commitment_hash_from_merkle_roots from Commitment_hash.py
-//
-// routing_root and offsets_hash are optional. When both are provided the MoE
-// routing commitment is folded into A's seed (see the kernel); they must be
-// supplied together or not at all (the dense case passes neither).
+// Computes both commitment hashes from their Merkle roots.
+// Optional routing inputs and V3 dimensions must each be supplied as a pair.
 void run_commitment_hash_from_merkle_roots(
     at::Tensor& A_merkle_root, at::Tensor& B_merkle_root, at::Tensor& key,
     at::Tensor& A_commitment_hash, at::Tensor& B_commitment_hash,
     std::optional<at::Tensor> routing_root = std::nullopt,
-    std::optional<at::Tensor> offsets_hash = std::nullopt) {
+    std::optional<at::Tensor> offsets_hash = std::nullopt,
+    std::optional<int64_t> salted_dim_a = std::nullopt,
+    std::optional<int64_t> salted_dim_b = std::nullopt) {
   CHECK_DEVICE(A_merkle_root);
   CHECK_DEVICE(B_merkle_root);
   CHECK_DEVICE(key);
@@ -182,6 +190,17 @@ void run_commitment_hash_from_merkle_roots(
     offsets_hash_ptr = offsets_hash_tensor.data_ptr<uint8_t>();
   }
 
+  TORCH_CHECK(salted_dim_a.has_value() == salted_dim_b.has_value(),
+              "salted_dim_a and salted_dim_b must be provided together");
+
+  const bool apply_salt = salted_dim_a.has_value();
+  uint32_t salted_dim_a_u32 = 0;
+  uint32_t salted_dim_b_u32 = 0;
+  if (apply_salt) {
+    salted_dim_a_u32 = to_salted_dim(salted_dim_a.value(), "salted_dim_a");
+    salted_dim_b_u32 = to_salted_dim(salted_dim_b.value(), "salted_dim_b");
+  }
+
   auto stream = at::cuda::getCurrentCUDAStream();
   auto dprops = at::cuda::getCurrentDeviceProperties();
 
@@ -189,7 +208,7 @@ void run_commitment_hash_from_merkle_roots(
       A_merkle_root.data_ptr<uint8_t>(), B_merkle_root.data_ptr<uint8_t>(),
       key.data_ptr<uint8_t>(), A_commitment_hash.data_ptr<uint8_t>(),
       B_commitment_hash.data_ptr<uint8_t>(), routing_root_ptr, offsets_hash_ptr,
-      *dprops, stream);
+      apply_salt, salted_dim_a_u32, salted_dim_b_u32, *dprops, stream);
 }
 
 #undef CHECK_DEVICE

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_decl.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_decl.hpp
@@ -17,11 +17,11 @@ void tensor_hash(
     uint32_t leaves_per_mt_block,  // compute_blake_mt_kernel threads
     uint8_t* roots, cudaDeviceProp& deviceProp, cudaStream_t stream);
 
-// routing_root and offsets_hash are optional (nullptr in the dense case). When
-// both are provided the MoE routing commitment is folded into A's seed before
-// computing the A commitment hash.
+// routing_root and offsets_hash are nullptr for dense GEMMs.
+// apply_salt uses salted_dim_a and salted_dim_b for V3.
 void commitment_hash_from_merkle_roots(
     const uint8_t* A_merkle_root, const uint8_t* B_merkle_root,
     const uint8_t* key, uint8_t* A_commitment_hash, uint8_t* B_commitment_hash,
-    const uint8_t* routing_root, const uint8_t* offsets_hash,
-    cudaDeviceProp& deviceProp, cudaStream_t stream);
+    const uint8_t* routing_root, const uint8_t* offsets_hash, bool apply_salt,
+    uint32_t salted_dim_a, uint32_t salted_dim_b, cudaDeviceProp& deviceProp,
+    cudaStream_t stream);

--- a/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_host.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/tensor_hash_host.hpp
@@ -280,8 +280,9 @@ void tensor_hash(
 void commitment_hash_from_merkle_roots(
     const uint8_t* A_merkle_root, const uint8_t* B_merkle_root,
     const uint8_t* key, uint8_t* A_commitment_hash, uint8_t* B_commitment_hash,
-    const uint8_t* routing_root, const uint8_t* offsets_hash,
-    cudaDeviceProp& deviceProp, cudaStream_t stream) {
+    const uint8_t* routing_root, const uint8_t* offsets_hash, bool apply_salt,
+    uint32_t salted_dim_a, uint32_t salted_dim_b, cudaDeviceProp& deviceProp,
+    cudaStream_t stream) {
 
   using CommitmentHashFromMerkleRootsKernel =
       pearl::CommitmentHashFromMerkleRootsKernel;
@@ -293,7 +294,10 @@ void commitment_hash_from_merkle_roots(
       static_cast<uint8_t*>(A_commitment_hash),
       static_cast<uint8_t*>(B_commitment_hash),
       static_cast<const uint8_t*>(routing_root),
-      static_cast<const uint8_t*>(offsets_hash)};
+      static_cast<const uint8_t*>(offsets_hash),
+      apply_salt,
+      salted_dim_a,
+      salted_dim_b};
 
   typename CommitmentHashFromMerkleRootsKernel::Params kernel_params =
       CommitmentHashFromMerkleRootsKernel::to_underlying_arguments(args);

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -586,10 +586,10 @@ def commitment_hash_from_merkle_roots(
     B_commitment_hash,
     routing_root=None,
     offsets_hash=None,
+    salted_dims: tuple[int, int] | None = None,
 ):
-    """
-    Compute the commitment hash from merkle roots of a 2D tensor.
-    """
+    """Compute commitment hashes from 2D-tensor Merkle roots."""
+    salted_dim_a, salted_dim_b = salted_dims if salted_dims is not None else (None, None)
     return pearl_gemm_cuda.commitment_hash_from_merkle_roots(
         A_merkle_root,
         B_merkle_root,
@@ -598,6 +598,8 @@ def commitment_hash_from_merkle_roots(
         B_commitment_hash,
         routing_root,
         offsets_hash,
+        salted_dim_a,
+        salted_dim_b,
     )
 
 
@@ -610,6 +612,8 @@ def _abstract_commitment_hash_from_merkle_roots(
     B_commitment_hash,
     routing_root=None,
     offsets_hash=None,
+    salted_dim_a=None,
+    salted_dim_b=None,
 ):
     return None
 

--- a/miner/pearl-gemm/src/pearl_gemm/test_components.py
+++ b/miner/pearl-gemm/src/pearl_gemm/test_components.py
@@ -56,14 +56,15 @@ def commitment_hash_from_merkle_roots(
     commitment_hash_B: torch.Tensor,
     routing_root: torch.Tensor | None = None,
     offsets_hash: torch.Tensor | None = None,
+    salted_dims: tuple[int, int] | None = None,
 ):
     """
     Compute the commitment hash from merkle roots of a 2D tensor.
 
-    routing_root and offsets_hash are optional MoE inputs (provided together)
-    that fold the routing commitment into A's seed; omitting both is the dense
-    case.
+    routing_root and offsets_hash are optional paired MoE inputs; omitting both
+    selects the dense path.
     """
+    salted_dim_a, salted_dim_b = salted_dims if salted_dims is not None else (None, None)
     return torch.ops.pearl_gemm.commitment_hash_from_merkle_roots(
         A_merkle_root,
         B_merkle_root,
@@ -72,6 +73,8 @@ def commitment_hash_from_merkle_roots(
         commitment_hash_B,
         routing_root,
         offsets_hash,
+        salted_dim_a,
+        salted_dim_b,
     )  # type: ignore
 
 

--- a/miner/vllm-miner/src/vllm_miner/gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/gemm_operators.py
@@ -137,7 +137,7 @@ def pearl_gemm_noisy(
         tensor_hash_scratchpad,
     )
 
-    # Generate commitment hash for noise generation
+    # Generate commitment hashes for noise generation.
     commitment_hash_A_tensor = torch.empty(32, device="cuda", dtype=torch.uint8)
     commitment_hash_B_tensor = torch.empty(32, device="cuda", dtype=torch.uint8)
     commitment_hash_from_merkle_roots(
@@ -146,6 +146,7 @@ def pearl_gemm_noisy(
         key_tensor,
         commitment_hash_A_tensor,
         commitment_hash_B_tensor,
+        salted_dims=(m, n) if mining_job.cert_version.uses_salted_seeds else None,
     )
 
     # Generate noise factors from commitment hashes

--- a/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
+++ b/miner/vllm-miner/src/vllm_miner/moe_gemm_operators.py
@@ -150,6 +150,14 @@ def prepare_moe_noising(
     A_hash = _hash_2d(A_q.contiguous().view(torch.uint8), key_tensor, device)
     B_hash = _hash_2d(B_stacked.contiguous().view(torch.uint8), key_tensor, device)
 
+    # V3 (salted) mining: the kernel salts the raw roots before the routing
+    # fold. The proof's ``n`` is the per-expert intermediate dimension.
+    salted_dims = (
+        (num_tokens, num_stacked_weight_rows // num_experts)
+        if mining_job.cert_version.uses_salted_seeds
+        else None
+    )
+
     num_routed_slots = num_tokens * top_k
     routing_data = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
     slot_indices = torch.empty(num_routed_slots, dtype=torch.int32, device=device)
@@ -183,6 +191,7 @@ def prepare_moe_noising(
         commitment_hash_B,
         routing_root=routing_hash,
         offsets_hash=offsets_hash,
+        salted_dims=salted_dims,
     )
 
     (

--- a/miner/vllm-miner/tests/test_reference_vs_kernels.py
+++ b/miner/vllm-miner/tests/test_reference_vs_kernels.py
@@ -18,6 +18,10 @@ from miner_base.matrix_merkle_tree import MatrixMerkleTree
 from miner_base.noise_generation import NoiseGenerator
 from pearl_gemm.test_components import inner_hash as inner_hash_cuda
 
+# Arbitrary (m, n) for the V3 salted derivation; any positive pair exercises
+# the same path.
+SALTED_DIMS = (192, 320)
+
 
 def _to_cuda_u8(data: bytes) -> torch.Tensor:
     return torch.frombuffer(bytearray(data), dtype=torch.uint8).cuda()
@@ -111,7 +115,8 @@ class TestMatrixMerkleTreeVsTensorHash:
             f"Hash mismatch for shape {m, n}: MatrixMerkleTree root doesn't match tensor_hash result"
         )
 
-    def test_commitment_hash_reference_vs_cuda(self, test_noise_seed_A):
+    @pytest.mark.parametrize("salted_dims", [None, SALTED_DIMS])
+    def test_commitment_hash_reference_vs_cuda(self, test_noise_seed_A, salted_dims):
         """Test that Python reference commitment hash matches CUDA implementation."""
         # Generate random 32-byte merkle roots directly
         A_merkle_root = secrets.token_bytes(blake3.digest_size)
@@ -127,6 +132,7 @@ class TestMatrixMerkleTreeVsTensorHash:
             A_merkle_root,
             B_merkle_root,
             test_noise_seed_A,
+            salted_dims=salted_dims,
         )
 
         # Compute commitment hash using CUDA implementation
@@ -138,6 +144,7 @@ class TestMatrixMerkleTreeVsTensorHash:
             key_tensor,
             cuda_commitment_A_tensor,
             cuda_commitment_B_tensor,
+            salted_dims=salted_dims,
         )
         torch.cuda.synchronize()
 
@@ -153,7 +160,8 @@ class TestMatrixMerkleTreeVsTensorHash:
             "Commitment hash mismatch: Python reference doesn't match CUDA implementation"
         )
 
-    def test_commitment_hash_moe_reference_vs_cuda(self, test_noise_seed_A):
+    @pytest.mark.parametrize("salted_dims", [None, SALTED_DIMS])
+    def test_commitment_hash_moe_reference_vs_cuda(self, test_noise_seed_A, salted_dims):
         """MoE folding: kernel routing_root/offsets_hash path matches CommitmentHasher."""
         # Cumulative exclusive ends per expert; last == m * top_k.
         routing_offsets = [3, 5, 9, 12]
@@ -173,6 +181,7 @@ class TestMatrixMerkleTreeVsTensorHash:
             test_noise_seed_A,
             routing_root=routing_root,
             offsets_root=offsets_root,
+            salted_dims=salted_dims,
         )
 
         cuda_commitment_A_tensor = torch.empty(blake3.digest_size, device="cuda", dtype=torch.uint8)
@@ -185,6 +194,7 @@ class TestMatrixMerkleTreeVsTensorHash:
             cuda_commitment_B_tensor,
             routing_root=_to_cuda_u8(routing_root),
             offsets_hash=_to_cuda_u8(offsets_root),
+            salted_dims=salted_dims,
         )
         torch.cuda.synchronize()
 

--- a/node/blockchain/chain.go
+++ b/node/blockchain/chain.go
@@ -2225,6 +2225,15 @@ func New(config *Config) (*BlockChain, error) {
 		return nil, AssertError("blockchain.New RankPenaltyForkHeight must not " +
 			"precede MoEForkHeight")
 	}
+	if config.ChainParams.SaltedSeedForkHeight < 0 {
+		return nil, AssertError("blockchain.New SaltedSeedForkHeight must be >= 0")
+	}
+	// V3 supersedes V2, so the salted-seed cutover cannot precede the V2 cutover.
+	if config.ChainParams.SaltedSeedForkHeight != 0 &&
+		config.ChainParams.SaltedSeedForkHeight < config.ChainParams.MoEForkHeight {
+		return nil, AssertError("blockchain.New SaltedSeedForkHeight must not " +
+			"precede MoEForkHeight")
+	}
 
 	// Generate a checkpoint by height map from the provided checkpoints
 	// and assert the provided checkpoints are sorted by height as required.

--- a/node/blockchain/moe_fork_test.go
+++ b/node/blockchain/moe_fork_test.go
@@ -23,6 +23,8 @@ func moeSimNetParams() chaincfg.Params {
 	params := chaincfg.SimNetParams
 	params.ReduceMinDifficulty = false
 	params.MoEForkHeight = moeForkTestHeight
+	// Exercise the V1/V2 cutover in isolation; disable the later V3 fork.
+	params.SaltedSeedForkHeight = 0
 	return params
 }
 

--- a/node/blockchain/salted_seed_fork_test.go
+++ b/node/blockchain/salted_seed_fork_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/pearl-research-labs/pearl/node/btcutil"
+	"github.com/pearl-research-labs/pearl/node/chaincfg"
+	"github.com/pearl-research-labs/pearl/node/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for the salted noise-seed (V3) certificate version cutover on SimNet,
+// mirroring the MoE fork tests in moe_fork_test.go.
+
+const saltedForkTestHeight = int32(4)
+
+func saltedSimNetParams() chaincfg.Params {
+	params := chaincfg.SimNetParams
+	params.ReduceMinDifficulty = false
+	params.MoEForkHeight = 1
+	params.SaltedSeedForkHeight = saltedForkTestHeight
+	return params
+}
+
+func v3Cert(proofData []byte, publicDataLen uint32) *wire.CertificateV3 {
+	cert := &wire.CertificateV3{}
+	cert.ProofData = proofData
+	cert.PublicDataLen = publicDataLen
+	return cert
+}
+
+// TestSaltedSeedForkActivationAcceptsRequiredVersion builds a chain across the
+// activation boundary and asserts each block is accepted with the version
+// required at its height (V2 before the fork, V3 at and after it). Blocks are
+// produced by SolveBlock, so mining-side version selection is covered too.
+func TestSaltedSeedForkActivationAcceptsRequiredVersion(t *testing.T) {
+	params := saltedSimNetParams()
+	chain, teardown, err := chainSetup("salted_fork_accept", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	for h := int32(1); h <= saltedForkTestHeight+2; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoErrorf(t, err, "block at height %d should be accepted", h)
+
+		want := wire.CertificateVersionV2
+		if h >= saltedForkTestHeight {
+			want = wire.CertificateVersionV3
+		}
+		require.Equalf(t, want, block.MsgBlock().BlockCertificate().Version(),
+			"unexpected certificate version at height %d", h)
+
+		tip = block
+	}
+
+	require.Equal(t, saltedForkTestHeight+2, chain.BestSnapshot().Height)
+}
+
+// TestSaltedSeedForkRejectsWrongVersion asserts the strict cutover: a V3
+// certificate is rejected below the activation height, and a V2 certificate is
+// rejected at it.
+func TestSaltedSeedForkRejectsWrongVersion(t *testing.T) {
+	params := saltedSimNetParams()
+	chain, teardown, err := chainSetup("salted_fork_reject", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	// Extend until the next block is pre-fork (height saltedForkTestHeight-1).
+	for h := int32(1); h <= saltedForkTestHeight-2; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoError(t, err)
+		tip = block
+	}
+
+	bad := newBlockForcedCert(t, chain, tip, v3Cert([]byte{0x00}, 0))
+	_, _, err = chain.ProcessBlock(bad, BFNone)
+	requireRuleError(t, err, ErrDisallowedCertVersion)
+
+	// Advance to the activation height with a valid block, then force V2.
+	block, _, err := addBlock(chain, tip, nil)
+	require.NoError(t, err)
+	tip = block
+
+	bad = newBlockForcedCert(t, chain, tip,
+		&wire.CertificateV2{ProofData: []byte{0x00}})
+	_, _, err = chain.ProcessBlock(bad, BFNone)
+	requireRuleError(t, err, ErrDisallowedCertVersion)
+
+	// The tip must be unchanged by the rejected blocks.
+	require.Equal(t, saltedForkTestHeight-1, chain.BestSnapshot().Height)
+}
+
+// TestCheckCertificateRulesDenseOnlyAppliesToV3 asserts the dense-only rule
+// reads the V2 payload embedded in a V3 certificate.
+func TestCheckCertificateRulesDenseOnlyAppliesToV3(t *testing.T) {
+	params := &chaincfg.Params{
+		MoEForkHeight:        1,
+		SaltedSeedForkHeight: 2,
+		DenseOnlyForkHeight:  2,
+	}
+
+	dense := v3Cert(nil, wire.PublicDataSizeDenseV2)
+	moe := v3Cert(nil, wire.PublicDataSizeDenseV2+1)
+	placeholder := v3Cert(nil, 0)
+
+	require.NoError(t, checkCertVersion(dense, 2, params))
+	require.NoError(t, checkCertVersion(placeholder, 2, params))
+	requireRuleError(t, checkCertVersion(moe, 2, params),
+		ErrDisallowedCertVersion)
+}

--- a/node/blockchain/salted_seed_fork_test.go
+++ b/node/blockchain/salted_seed_fork_test.go
@@ -118,3 +118,36 @@ func TestCheckCertificateRulesDenseOnlyAppliesToV3(t *testing.T) {
 	requireRuleError(t, checkCertVersion(moe, 2, params),
 		ErrDisallowedCertVersion)
 }
+
+// TestSaltedSeedForkBlockTemplateVersion verifies CheckConnectBlockTemplate enforces
+// the required cert version on unmined templates (BFNoPoWCheck) at the fork height.
+func TestSaltedSeedForkBlockTemplateVersion(t *testing.T) {
+	params := saltedSimNetParams()
+	chain, teardown, err := chainSetup("salted_fork_template", &params)
+	require.NoError(t, err)
+	defer teardown()
+
+	tip := btcutil.NewBlock(chain.chainParams.GenesisBlock)
+	tip.SetHeight(0)
+
+	// Advance until the next block is at the activation height.
+	for h := int32(1); h < saltedForkTestHeight; h++ {
+		block, _, err := addBlock(chain, tip, nil)
+		require.NoError(t, err)
+		tip = block
+	}
+
+	// At the fork height, a template carrying a V3 certificate must connect.
+	v3Template := newBlockForcedCert(t, chain, tip,
+		&wire.CertificateV3{CertificateV2: wire.CertificateV2{Hash: *tip.Hash()}})
+	require.Equal(t, wire.CertificateVersionV3,
+		v3Template.MsgBlock().BlockCertificate().Version())
+	require.NoError(t, chain.CheckConnectBlockTemplate(v3Template),
+		"V3 template must be accepted at the fork height")
+
+	// The same template carrying a V2 certificate must be rejected.
+	v2Template := newBlockForcedCert(t, chain, tip,
+		&wire.CertificateV2{Hash: *tip.Hash()})
+	requireRuleError(t, chain.CheckConnectBlockTemplate(v2Template),
+		ErrDisallowedCertVersion)
+}

--- a/node/blockchain/solve.go
+++ b/node/blockchain/solve.go
@@ -12,24 +12,30 @@ import (
 	"github.com/pearl-research-labs/pearl/node/zkpow"
 )
 
-// SolveBlock mines a block certificate for the given header at the given height.
-// It produces a V2 certificate when the MoE fork is active; otherwise V1.
+// SolveBlock mines a block certificate for the given header at the given height,
+// producing the certificate version consensus requires at that height.
 //
 // On SimNet it returns a lightweight dummy certificate of the required version
 // (no actual mining). For real mining it modifies header.ProofCommitment to
 // match the mined certificate.
 func SolveBlock(header *wire.BlockHeader, params *chaincfg.Params, height int32) (wire.BlockCertificate, error) {
-	moeActive := params.IsMoEForkActive(height)
+	version := params.RequiredCertVersion(height)
 
 	if params.Net == wire.SimNet {
-		if moeActive {
+		switch version {
+		case wire.CertificateVersionV3:
+			cert := &wire.CertificateV3{}
+			cert.ProofData = []byte{0x00}
+			return cert, nil
+		case wire.CertificateVersionV2:
 			return &wire.CertificateV2{ProofData: []byte{0x00}}, nil
+		default:
+			return &wire.CertificateV1{ProofData: []byte{0x00}}, nil
 		}
-		return &wire.CertificateV1{ProofData: []byte{0x00}}, nil
 	}
 
-	if moeActive {
-		return zkpow.Mine(header)
+	if version == wire.CertificateVersionV1 {
+		return nil, fmt.Errorf("V1 mining not supported in this build; use a pre-fork binary")
 	}
-	return nil, fmt.Errorf("V1 mining not supported in this build; use a pre-fork binary")
+	return zkpow.Mine(header, version)
 }

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -543,18 +543,7 @@ func CheckCertificateRules(header *wire.BlockHeader, cert wire.BlockCertificate,
 		return ruleError(ErrDisallowedCertVersion, str)
 	}
 
-	// The remaining rules read V2-layout fields (V3 shares the layout via embedding).
-	var c *wire.CertificateV2
-	switch v := cert.(type) {
-	case *wire.CertificateV2:
-		c = v
-	case *wire.CertificateV3:
-		c = &v.CertificateV2
-	default:
-		return nil
-	}
-
-	if c.IsMoE() && params.IsDenseOnlyForkActive(height) {
+	if cert.IsMoE() && params.IsDenseOnlyForkActive(height) {
 		str := fmt.Sprintf("MoE certificate is not allowed at height %d "+
 			"(dense-only fork active from height %d)",
 			height, params.DenseOnlyForkHeight)
@@ -562,7 +551,7 @@ func CheckCertificateRules(header *wire.BlockHeader, cert wire.BlockCertificate,
 	}
 
 	if params.IsRankPenaltyForkActive(height) && flags&BFNoPoWCheck != BFNoPoWCheck {
-		if err := zkpow.CheckRankPenalty(header.Bits, c.PublicDataBytes()); err != nil {
+		if err := zkpow.CheckRankPenalty(header.Bits, cert.PublicDataBytes()); err != nil {
 			str := fmt.Sprintf("certificate fails the rank penalty rule at "+
 				"height %d (fork active from height %d): %v",
 				height, params.RankPenaltyForkHeight, err)

--- a/node/blockchain/validate.go
+++ b/node/blockchain/validate.go
@@ -513,7 +513,8 @@ func CheckBlockSanity(block *btcutil.Block, chainParams *chaincfg.Params, timeSo
 // must satisfy:
 //   - Before MoEForkHeight (or with the fork disabled): only V1 accepted
 //   - At and after MoEForkHeight (hardfork): only V2 accepted
-//   - At and after DenseOnlyForkHeight (softfork): V2 certificates must
+//   - At and after SaltedSeedForkHeight (hardfork): only V3 accepted
+//   - At and after DenseOnlyForkHeight (softfork): V2/V3 certificates must
 //     carry a dense (non-MoE) proof
 //   - At and after RankPenaltyForkHeight (softfork): the proof's noise rank
 //     must meet a minimum and its jackpot must meet a difficulty bound scaled
@@ -542,9 +543,14 @@ func CheckCertificateRules(header *wire.BlockHeader, cert wire.BlockCertificate,
 		return ruleError(ErrDisallowedCertVersion, str)
 	}
 
-	// The remaining rules read fields only a V2 certificate has.
-	c, ok := cert.(*wire.CertificateV2)
-	if !ok {
+	// The remaining rules read V2-layout fields (V3 shares the layout via embedding).
+	var c *wire.CertificateV2
+	switch v := cert.(type) {
+	case *wire.CertificateV2:
+		c = v
+	case *wire.CertificateV3:
+		c = &v.CertificateV2
+	default:
 		return nil
 	}
 

--- a/node/blockchain/validate_test.go
+++ b/node/blockchain/validate_test.go
@@ -164,8 +164,9 @@ func TestCheckBlockSanity(t *testing.T) {
 		Bits:       chainParams.PowLimitBits,
 	}
 
-	// Mine a valid certificate (only 1 block, so longer ZK proof time is acceptable)
-	cert, err := zkpow.Mine(&header)
+	// Mine a valid certificate (only 1 block, so longer ZK proof time is
+	// acceptable), of the version regtest requires at height 1.
+	cert, err := zkpow.Mine(&header, chainParams.RequiredCertVersion(1))
 	if err != nil {
 		t.Fatalf("Mine failed: %v", err)
 	}

--- a/node/btcjson/chainsvrresults.go
+++ b/node/btcjson/chainsvrresults.go
@@ -301,8 +301,8 @@ type GetBlockTemplateResult struct {
 	RejectReason string   `json:"reject-reason,omitempty"`
 
 	// RequiredCertVersion is the block certificate version that a block built
-	// from this template must carry under the MoE hardfork cutover (V1 before
-	// the activation height, V2 at and after it). It is the single source of
+	// from this template must carry at its height under the hardfork cutovers
+	// (see chaincfg.Params.RequiredCertVersion). It is the single source of
 	// truth for miners selecting which proof/certificate to produce.
 	RequiredCertVersion uint32 `json:"requiredcertversion"`
 }

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -273,6 +273,13 @@ type Params struct {
 	// noise rank (enforced in blockchain.New).
 	RankPenaltyForkHeight int32
 
+	// SaltedSeedForkHeight is the block height at which the salted noise-seed
+	// hardfork activates: at and after it blocks must carry a V3 certificate
+	// (wire.CertificateVersionV3). A value of 0 disables the fork.
+	//
+	// Must not activate before MoEForkHeight: V3 supersedes V2.
+	SaltedSeedForkHeight int32
+
 	// Mempool parameters
 	RelayNonStdTxs bool
 
@@ -310,11 +317,20 @@ func (p *Params) IsRankPenaltyForkActive(height int32) bool {
 	return p.RankPenaltyForkHeight != 0 && height >= p.RankPenaltyForkHeight
 }
 
+// IsSaltedSeedForkActive reports whether the salted noise-seed hardfork is active
+// at the given block height. The fork is disabled when SaltedSeedForkHeight is 0.
+func (p *Params) IsSaltedSeedForkActive(height int32) bool {
+	return p.SaltedSeedForkHeight != 0 && height >= p.SaltedSeedForkHeight
+}
+
 // RequiredCertVersion returns the block certificate version that a block at the
-// given height must use under the strict MoE hardfork cutover: the V2
-// certificate at and after the activation height, the V1 certificate before it
-// (and always, when the fork is disabled).
+// given height must use under the strict hardfork cutovers: V3 at and after the
+// salted noise-seed fork, V2 at and after the MoE fork, V1 before both (and
+// always, when the forks are disabled).
 func (p *Params) RequiredCertVersion(height int32) wire.CertificateVersion {
+	if p.IsSaltedSeedForkActive(height) {
+		return wire.CertificateVersionV3
+	}
 	if p.IsMoEForkActive(height) {
 		return wire.CertificateVersionV2
 	}
@@ -351,6 +367,8 @@ var MainNetParams = Params{
 	DenseOnlyForkHeight: 91630,
 
 	RankPenaltyForkHeight: 96251,
+
+	SaltedSeedForkHeight: 98830,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
@@ -432,6 +450,9 @@ var RegressionNetParams = Params{
 
 	// Active from genesis because regtest verifies proofs.
 	RankPenaltyForkHeight: 1,
+
+	// Salted noise-seed (V3) fork active from genesis.
+	SaltedSeedForkHeight: 1,
 
 	// Chain parameters
 	GenesisBlock:         &regTestGenesisBlock,
@@ -541,6 +562,8 @@ var TestNetParams = Params{
 
 	RankPenaltyForkHeight: 36761,
 
+	SaltedSeedForkHeight: 38648,
+
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
 
@@ -635,6 +658,8 @@ var TestNet2Params = Params{
 
 	RankPenaltyForkHeight: 80627,
 
+	SaltedSeedForkHeight: 83109,
+
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: nil,
 
@@ -714,6 +739,9 @@ var SimNetParams = Params{
 	// MoE hardfork active from genesis on local test networks so the gateway's
 	// V2 (MoE) certificates are accepted at every mined height.
 	MoEForkHeight: 1,
+
+	// Salted noise-seed (V3) fork active from genesis.
+	SaltedSeedForkHeight: 1,
 
 	// Chain parameters
 	GenesisBlock:         &simNetGenesisBlock,

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -368,7 +368,7 @@ var MainNetParams = Params{
 
 	RankPenaltyForkHeight: 96251,
 
-	SaltedSeedForkHeight: 98830,
+	SaltedSeedForkHeight: 98900,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{

--- a/node/chaincfg/params_test.go
+++ b/node/chaincfg/params_test.go
@@ -135,6 +135,41 @@ func TestMoEForkDisabled(t *testing.T) {
 	}
 }
 
+// TestSaltedSeedForkActivation verifies the strict cutover at the salted
+// noise-seed hardfork activation height: V2 before the fork (with the MoE fork
+// active), V3 at and after it.
+func TestSaltedSeedForkActivation(t *testing.T) {
+	const forkHeight = int32(200)
+	p := Params{MoEForkHeight: 100, SaltedSeedForkHeight: forkHeight}
+
+	tests := []struct {
+		name        string
+		height      int32
+		wantActive  bool
+		wantVersion wire.CertificateVersion
+	}{
+		{"just before fork", forkHeight - 1, false, wire.CertificateVersionV2},
+		{"at fork height", forkHeight, true, wire.CertificateVersionV3},
+		{"after fork height", forkHeight + 1, true, wire.CertificateVersionV3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantActive, p.IsSaltedSeedForkActive(tt.height))
+			require.Equal(t, tt.wantVersion, p.RequiredCertVersion(tt.height))
+		})
+	}
+}
+
+// TestSaltedSeedForkDisabled verifies that a zero SaltedSeedForkHeight disables
+// the fork at every height (the version follows the MoE fork schedule).
+func TestSaltedSeedForkDisabled(t *testing.T) {
+	p := Params{MoEForkHeight: 1, SaltedSeedForkHeight: 0}
+	for _, height := range []int32{1, 100, 1_000_000} {
+		require.False(t, p.IsSaltedSeedForkActive(height))
+		require.Equal(t, wire.CertificateVersionV2, p.RequiredCertVersion(height))
+	}
+}
+
 // TestRankPenaltyForkActivation verifies the activation boundary of the
 // rank-penalty softfork, including the disabled case.
 func TestRankPenaltyForkActivation(t *testing.T) {

--- a/node/mining/mining.go
+++ b/node/mining/mining.go
@@ -658,9 +658,7 @@ mempoolLoop:
 	var certificate wire.BlockCertificate
 	switch g.chainParams.RequiredCertVersion(nextBlockHeight) {
 	case wire.CertificateVersionV3:
-		cert := &wire.CertificateV3{}
-		cert.Hash = msgBlock.BlockHash()
-		certificate = cert
+		certificate = &wire.CertificateV3{CertificateV2: wire.CertificateV2{Hash: msgBlock.BlockHash()}}
 	case wire.CertificateVersionV2:
 		certificate = &wire.CertificateV2{Hash: msgBlock.BlockHash()}
 	default:

--- a/node/mining/mining.go
+++ b/node/mining/mining.go
@@ -654,12 +654,16 @@ mempoolLoop:
 		Bits:       reqDifficulty,
 	}}
 	// Use a certificate placeholder whose version matches what consensus
-	// requires at this height; after MoEForkHeight the template must carry
-	// a V2 certificate, otherwise CheckConnectBlockTemplate rejects it.
+	// requires at this height, otherwise CheckConnectBlockTemplate rejects it.
 	var certificate wire.BlockCertificate
-	if g.chainParams.IsMoEForkActive(nextBlockHeight) {
+	switch g.chainParams.RequiredCertVersion(nextBlockHeight) {
+	case wire.CertificateVersionV3:
+		cert := &wire.CertificateV3{}
+		cert.Hash = msgBlock.BlockHash()
+		certificate = cert
+	case wire.CertificateVersionV2:
 		certificate = &wire.CertificateV2{Hash: msgBlock.BlockHash()}
-	} else {
+	default:
 		certificate = &wire.CertificateV1{Hash: msgBlock.BlockHash()}
 	}
 	msgBlock.MsgHeader.MsgCertificate = wire.MsgCertificate{Certificate: certificate}

--- a/node/mining/mining_test.go
+++ b/node/mining/mining_test.go
@@ -140,6 +140,7 @@ func TestNewBlockTemplateForkRulesActive(t *testing.T) {
 		"the network under test must be one that verifies proofs")
 	require.True(t, params.IsMoEForkActive(1))
 	require.True(t, params.IsRankPenaltyForkActive(1))
+	require.True(t, params.IsSaltedSeedForkActive(1))
 
 	generator := newTestGenerator(t, &params)
 
@@ -147,6 +148,7 @@ func TestNewBlockTemplateForkRulesActive(t *testing.T) {
 	require.NoError(t, err,
 		"template generation must survive the rank-penalty fork activation")
 	require.Equal(t, int32(1), template.Height)
-	require.Equal(t, wire.CertificateVersionV2,
-		template.Block.BlockCertificate().Version())
+	require.Equal(t, wire.CertificateVersionV3,
+		template.Block.BlockCertificate().Version(),
+		"regtest requires V3 certificates from genesis")
 }

--- a/node/peer/peer.go
+++ b/node/peer/peer.go
@@ -38,7 +38,7 @@ const (
 
 	// MinAcceptableProtocolVersion is the lowest protocol version that a
 	// connected peer may support.
-	MinAcceptableProtocolVersion = wire.ProtocolVersion
+	MinAcceptableProtocolVersion = 1
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 50

--- a/node/rpcserver.go
+++ b/node/rpcserver.go
@@ -73,7 +73,7 @@ const (
 	gbtRegenerateSeconds = 60
 
 	// maxProtocolVersion is the max protocol version the server supports.
-	maxProtocolVersion = 1
+	maxProtocolVersion = wire.ProtocolVersion
 
 	// defaultMaxFeeRate is the default value to use(0.1 PRL/kvB) when the
 	// `MaxFee` field is not set when calling `testmempoolaccept`.

--- a/node/rpcserver_test.go
+++ b/node/rpcserver_test.go
@@ -46,6 +46,11 @@ func TestBlockTemplateResultRequiredCertVersion(t *testing.T) {
 			cert: &wire.CertificateV2{},
 			want: uint32(wire.CertificateVersionV2),
 		},
+		{
+			name: "v3 placeholder at/after the salted-seed fork",
+			cert: &wire.CertificateV3{},
+			want: uint32(wire.CertificateVersionV3),
+		},
 	}
 
 	for _, tc := range testCases {

--- a/node/rpcserverhelp.go
+++ b/node/rpcserverhelp.go
@@ -335,7 +335,7 @@ var helpDescsEnUS = map[string]string{
 	"getblocktemplateresult-capabilities":               "List of server capabilities including 'proposal' to indicate support for block proposals",
 	"getblocktemplateresult-reject-reason":              "Reason the proposal was invalid as-is (only applies to proposal responses)",
 	"getblocktemplateresult-default_witness_commitment": "The witness commitment itself. Will be populated if the block has witness data",
-	"getblocktemplateresult-requiredcertversion":        "Certificate version a block built on this template must carry under the MoE hardfork cutover (1 before the activation height, 2 at and after)",
+	"getblocktemplateresult-requiredcertversion":        "Certificate version a block built on this template must carry at its height under the hardfork cutovers (1 before the MoE fork, 2 at and after it, 3 at and after the salted-seed fork)",
 
 	// GetBlockTemplateCmd help.
 	"getblocktemplate--synopsis": "Returns a JSON object with information necessary to construct a block to mine or accepts a proposal to validate.\n" +

--- a/node/wire/certificate.go
+++ b/node/wire/certificate.go
@@ -31,6 +31,9 @@ Version-first design enables polymorphic decoding:
 	  PublicData: committed public fields (variable-length, up to PublicDataMaxSizeV2)
 	  ProofData: Plonky2 proof bytes
 
+	CertificateV3: identical layout to CertificateV2; the version selects the
+	  salted noise-seed derivation.
+
 KEY DESIGN: SYMMETRIC SERIALIZATION
 
 Certificate types implement perfectly mirrored Serialize/Deserialize methods:
@@ -40,8 +43,9 @@ Certificate types implement perfectly mirrored Serialize/Deserialize methods:
 
 # NETWORK RESTRICTIONS
 
-CertificateVersionV1 and CertificateVersionV2 are allowed. IsCertVersionAllowed(v)
-returns true for both. blockchain.checkBlockSanity also validates via IsCertVersionAllowed.
+CertificateVersionV1, CertificateVersionV2 and CertificateVersionV3 are allowed.
+IsCertVersionAllowed(v) returns true for all three. blockchain.checkBlockSanity
+also validates via IsCertVersionAllowed.
 
 # GENESIS BLOCKS
 
@@ -77,6 +81,7 @@ const (
 	CertificateVersionNull CertificateVersion = 0
 	CertificateVersionV1   CertificateVersion = 1
 	CertificateVersionV2   CertificateVersion = 2
+	CertificateVersionV3   CertificateVersion = 3
 )
 
 // BlockCertificate is the interface that all certificate types must implement.
@@ -103,7 +108,7 @@ type BlockCertificate interface {
 
 // IsCertVersionAllowed reports whether certificate version v is permitted.
 func IsCertVersionAllowed(v CertificateVersion) bool {
-	return v == CertificateVersionV1 || v == CertificateVersionV2
+	return v == CertificateVersionV1 || v == CertificateVersionV2 || v == CertificateVersionV3
 }
 
 // MsgCertificate wraps a BlockCertificate and handles polymorphic
@@ -150,6 +155,9 @@ func (m *MsgCertificate) PrlDecode(r io.Reader, pver uint32) error {
 
 	case CertificateVersionV2:
 		m.Certificate = &CertificateV2{}
+
+	case CertificateVersionV3:
+		m.Certificate = &CertificateV3{}
 
 	default:
 		return fmt.Errorf("unsupported certificate version: %d", version)

--- a/node/wire/certificate.go
+++ b/node/wire/certificate.go
@@ -96,6 +96,15 @@ type BlockCertificate interface {
 	// SHA256d(CertificateVersion_LE(4) || PublicData)
 	ProofCommitment() chainhash.Hash
 
+	// PublicDataBytes returns the meaningful public data bytes.
+	PublicDataBytes() []byte
+
+	// ProofBytes returns the raw ZK proof bytes.
+	ProofBytes() []byte
+
+	// IsMoE reports whether the certificate carries a MoE proof.
+	IsMoE() bool
+
 	// Serialize writes certificate fields (excludes version - handled by MsgCertificate).
 	Serialize(w io.Writer) error
 
@@ -108,7 +117,12 @@ type BlockCertificate interface {
 
 // IsCertVersionAllowed reports whether certificate version v is permitted.
 func IsCertVersionAllowed(v CertificateVersion) bool {
-	return v == CertificateVersionV1 || v == CertificateVersionV2 || v == CertificateVersionV3
+	switch v {
+	case CertificateVersionV1, CertificateVersionV2, CertificateVersionV3:
+		return true
+	default:
+		return false
+	}
 }
 
 // MsgCertificate wraps a BlockCertificate and handles polymorphic

--- a/node/wire/certificate_test.go
+++ b/node/wire/certificate_test.go
@@ -42,6 +42,16 @@ func testBlockHeader(nbits ...uint32) wire.BlockHeader {
 	}
 }
 
+// mineV2 mines a real V2 certificate and returns its concrete type.
+func mineV2(t *testing.T, header *wire.BlockHeader) *wire.CertificateV2 {
+	t.Helper()
+	cert, err := zkpow.Mine(header, wire.CertificateVersionV2)
+	require.NoError(t, err, "mining should succeed")
+	v2, ok := cert.(*wire.CertificateV2)
+	require.True(t, ok, "mined certificate should be CertificateV2")
+	return v2
+}
+
 // ============================================================================
 // CertificateV1 Tests
 // ============================================================================
@@ -49,11 +59,10 @@ func testBlockHeader(nbits ...uint32) wire.BlockHeader {
 func TestCertificateV2_SerializeDeserialize(t *testing.T) {
 	header := testBlockHeader()
 
-	cert, err := zkpow.Mine(&header)
-	require.NoError(t, err, "mining should succeed")
+	cert := mineV2(t, &header)
 
 	var buf bytes.Buffer
-	err = cert.Serialize(&buf)
+	err := cert.Serialize(&buf)
 	require.NoError(t, err, "serialization should succeed")
 
 	serialized := buf.Bytes()
@@ -73,18 +82,16 @@ func TestCertificateV2_SerializeDeserialize(t *testing.T) {
 func TestCertificateV2_Verify(t *testing.T) {
 	header := testBlockHeader()
 
-	cert, err := zkpow.Mine(&header)
-	require.NoError(t, err, "mining should succeed")
+	cert := mineV2(t, &header)
 
-	err = zkpow.VerifyCertificate(&header, cert)
+	err := zkpow.VerifyCertificate(&header, cert)
 	require.NoError(t, err, "valid CertificateV2 should verify")
 }
 
 func TestCertificateV1_VerifyErrors(t *testing.T) {
 	header := testBlockHeader()
 
-	origCert, err := zkpow.Mine(&header)
-	require.NoError(t, err, "mining should succeed")
+	origCert := mineV2(t, &header)
 
 	createCert := func() *wire.CertificateV2 {
 		proofDataCopy := make([]byte, len(origCert.ProofData))
@@ -151,15 +158,14 @@ func TestCertificateV1_BlockHash(t *testing.T) {
 func TestMsgCertificate_MoE_RoundTrip(t *testing.T) {
 	header := testBlockHeader()
 
-	cert, err := zkpow.Mine(&header)
-	require.NoError(t, err, "mining should succeed")
+	cert := mineV2(t, &header)
 
 	msg := &wire.MsgCertificate{Certificate: cert}
 	require.NotNil(t, msg)
 	require.Equal(t, wire.CertificateVersionV2, msg.Certificate.Version())
 
 	var buf bytes.Buffer
-	err = msg.PrlEncode(&buf, wire.ProtocolVersion)
+	err := msg.PrlEncode(&buf, wire.ProtocolVersion)
 	require.NoError(t, err, "encoding should succeed")
 
 	decoded := &wire.MsgCertificate{}
@@ -170,4 +176,51 @@ func TestMsgCertificate_MoE_RoundTrip(t *testing.T) {
 	decodedMoE, ok := decoded.Certificate.(*wire.CertificateV2)
 	require.True(t, ok, "decoded certificate should be CertificateV2")
 	require.Equal(t, cert.Hash, decodedMoE.Hash)
+}
+
+// ============================================================================
+// CertificateV3 Tests
+// ============================================================================
+
+// TestCertificateV3_MineVerifyRoundTrip mines a real V3 (salted noise-seed)
+// certificate and verifies it, its wire round-trip, and its domain separation
+// from V2.
+func TestCertificateV3_MineVerifyRoundTrip(t *testing.T) {
+	header := testBlockHeader()
+
+	cert, err := zkpow.Mine(&header, wire.CertificateVersionV3)
+	require.NoError(t, err, "V3 mining should succeed")
+	v3, ok := cert.(*wire.CertificateV3)
+	require.True(t, ok, "mined certificate should be CertificateV3")
+	require.Equal(t, wire.CertificateVersionV3, v3.Version())
+
+	require.NoError(t, zkpow.VerifyCertificate(&header, v3),
+		"valid CertificateV3 should verify")
+
+	// The commitment must hash version 3, not the embedded V2's version.
+	require.NotEqual(t, v3.CertificateV2.ProofCommitment(), v3.ProofCommitment(),
+		"V3 proof commitment must be domain-separated from V2")
+
+	// Wire round-trip through MsgCertificate.
+	msg := &wire.MsgCertificate{Certificate: v3}
+	var buf bytes.Buffer
+	require.NoError(t, msg.PrlEncode(&buf, wire.ProtocolVersion))
+	decoded := &wire.MsgCertificate{}
+	require.NoError(t, decoded.PrlDecode(bytes.NewReader(buf.Bytes()), wire.ProtocolVersion))
+	decodedV3, ok := decoded.Certificate.(*wire.CertificateV3)
+	require.True(t, ok, "decoded certificate should be CertificateV3")
+	require.Equal(t, v3.Hash, decodedV3.Hash)
+	require.Equal(t, v3.PublicDataLen, decodedV3.PublicDataLen)
+
+	// A V3 proof re-labeled as V2 must be rejected (salted vs legacy seeds).
+	asV2 := &wire.CertificateV2{
+		PublicDataLen: v3.PublicDataLen,
+		PublicData:    v3.PublicData,
+		ProofData:     v3.ProofData,
+	}
+	relabeledHeader := header
+	relabeledHeader.ProofCommitment = asV2.ProofCommitment()
+	asV2.Hash = relabeledHeader.BlockHash()
+	require.Error(t, zkpow.VerifyCertificate(&relabeledHeader, asV2),
+		"V3 proof must not verify under the legacy (V2) derivation")
 }

--- a/node/wire/certificate_v1.go
+++ b/node/wire/certificate_v1.go
@@ -35,6 +35,21 @@ func (c *CertificateV1) BlockHash() chainhash.Hash {
 	return c.Hash
 }
 
+// PublicDataBytes returns the public data bytes for V1 certificates.
+func (c *CertificateV1) PublicDataBytes() []byte {
+	return c.PublicData[:]
+}
+
+// ProofBytes returns the raw ZK proof bytes.
+func (c *CertificateV1) ProofBytes() []byte {
+	return c.ProofData
+}
+
+// IsMoE reports whether the certificate carries a MoE proof (always false for V1).
+func (c *CertificateV1) IsMoE() bool {
+	return false
+}
+
 // ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData(164)).
 func (c *CertificateV1) ProofCommitment() chainhash.Hash {
 	var buf [4 + PublicDataSizeV1]byte

--- a/node/wire/certificate_v2.go
+++ b/node/wire/certificate_v2.go
@@ -59,9 +59,14 @@ func (c *CertificateV2) PublicDataBytes() []byte {
 
 // ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData[:PublicDataLen]).
 func (c *CertificateV2) ProofCommitment() chainhash.Hash {
-	publicData := c.PublicDataBytes()
+	return proofCommitment(c.Version(), c.PublicDataBytes())
+}
+
+// proofCommitment computes SHA256d(CertificateVersion_LE(4) || publicData).
+// V3 overrides ProofCommitment to hash version 3 (domain separation from V2).
+func proofCommitment(version CertificateVersion, publicData []byte) chainhash.Hash {
 	buf := make([]byte, 4+len(publicData))
-	binary.LittleEndian.PutUint32(buf[:4], uint32(c.Version()))
+	binary.LittleEndian.PutUint32(buf[:4], uint32(version))
 	copy(buf[4:], publicData)
 	return chainhash.DoubleHashH(buf)
 }

--- a/node/wire/certificate_v2.go
+++ b/node/wire/certificate_v2.go
@@ -57,6 +57,11 @@ func (c *CertificateV2) PublicDataBytes() []byte {
 	return c.PublicData[:c.PublicDataLen]
 }
 
+// ProofBytes returns the raw ZK proof bytes.
+func (c *CertificateV2) ProofBytes() []byte {
+	return c.ProofData
+}
+
 // ProofCommitment computes SHA256d(CertificateVersion_LE(4) || PublicData[:PublicDataLen]).
 func (c *CertificateV2) ProofCommitment() chainhash.Hash {
 	return proofCommitment(c.Version(), c.PublicDataBytes())

--- a/node/wire/certificate_v3.go
+++ b/node/wire/certificate_v3.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2025-2026 The Pearl Research Labs developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
+)
+
+// CertificateV3 is a version-3 (V3) block certificate: wire layout identical
+// to CertificateV2, but the verifier uses the salted noise-seed derivation.
+type CertificateV3 struct {
+	CertificateV2
+}
+
+func (c *CertificateV3) Version() CertificateVersion {
+	return CertificateVersionV3
+}
+
+// ProofCommitment hashes version 3, not the embedded V2's version.
+func (c *CertificateV3) ProofCommitment() chainhash.Hash {
+	return proofCommitment(c.Version(), c.PublicDataBytes())
+}

--- a/node/wire/protocol.go
+++ b/node/wire/protocol.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// ProtocolVersion is the latest protocol version this package supports.
-	ProtocolVersion uint32 = 1
+	ProtocolVersion uint32 = 2
 )
 
 const (

--- a/node/zkpow/miner.go
+++ b/node/zkpow/miner.go
@@ -54,12 +54,12 @@ func defaultMiningConfig(e, topK uint32) ([miningConfigSize]byte, error) {
 	return config, nil
 }
 
-// Mine mines a standard (non-MoE) block using the default dimensions.
-// Returns a V2 certificate that handles both MoE and non-MoE proofs.
+// Mine mines a standard (non-MoE) block using the default dimensions, producing a
+// certificate of the given version (V2 legacy derivation, V3 salted derivation).
 // This function modifies header.ProofCommitment to match the mined certificate.
-func Mine(header *wire.BlockHeader) (*wire.CertificateV2, error) {
+func Mine(header *wire.BlockHeader, certVersion wire.CertificateVersion) (wire.BlockCertificate, error) {
 	cHeader := blockHeaderToC(header)
-	publicData, proofData, err := callMineFFI(cHeader, DefaultM, DefaultN, 0, 0)
+	publicData, proofData, err := callMineFFI(cHeader, DefaultM, DefaultN, 0, 0, certVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -67,23 +67,17 @@ func Mine(header *wire.BlockHeader) (*wire.CertificateV2, error) {
 		return nil, fmt.Errorf("unexpected public_data_len %d (max %d)",
 			len(publicData), wire.PublicDataMaxSizeV2)
 	}
-
-	cert := &wire.CertificateV2{
-		PublicDataLen: uint32(len(publicData)),
-		ProofData:     proofData,
-	}
-	copy(cert.PublicData[:], publicData)
-	header.ProofCommitment = cert.ProofCommitment()
-	cert.Hash = header.BlockHash()
-	return cert, nil
+	return newCertificate(header, certVersion, publicData, proofData)
 }
 
 // MineMoE mines an MoE block with e experts and topK experts per token.
 // Intended for testing MoE verification; not used in production.
 // This function modifies header.ProofCommitment to match the mined certificate.
-func MineMoE(header *wire.BlockHeader, m, n, e, topK uint32) (*wire.CertificateV2, error) {
+func MineMoE(header *wire.BlockHeader, m, n, e, topK uint32,
+	certVersion wire.CertificateVersion) (wire.BlockCertificate, error) {
+
 	cHeader := blockHeaderToC(header)
-	publicData, proofData, err := callMineFFI(cHeader, m, n, e, topK)
+	publicData, proofData, err := callMineFFI(cHeader, m, n, e, topK, certVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -91,19 +85,39 @@ func MineMoE(header *wire.BlockHeader, m, n, e, topK uint32) (*wire.CertificateV
 	if len(publicData) > wire.PublicDataMaxSizeV2 {
 		return nil, fmt.Errorf("unexpected public_data_len %d for MoE proof (max %d)", len(publicData), wire.PublicDataMaxSizeV2)
 	}
-	cert := &wire.CertificateV2{
-		PublicDataLen: uint32(len(publicData)),
-		ProofData:     proofData,
+	return newCertificate(header, certVersion, publicData, proofData)
+}
+
+// newCertificate wraps a mined proof in a certificate of the given version and
+// seals it: stamps header.ProofCommitment, then stores the block hash.
+func newCertificate(header *wire.BlockHeader, certVersion wire.CertificateVersion,
+	publicData, proofData []byte) (wire.BlockCertificate, error) {
+
+	var cert wire.BlockCertificate
+	var payload *wire.CertificateV2
+	switch certVersion {
+	case wire.CertificateVersionV2:
+		c := &wire.CertificateV2{}
+		cert, payload = c, c
+	case wire.CertificateVersionV3:
+		c := &wire.CertificateV3{}
+		cert, payload = c, &c.CertificateV2
+	default:
+		return nil, fmt.Errorf("mining does not support certificate version %d", certVersion)
 	}
-	copy(cert.PublicData[:len(publicData)], publicData)
+	payload.PublicDataLen = uint32(len(publicData))
+	copy(payload.PublicData[:], publicData)
+	payload.ProofData = proofData
+
 	header.ProofCommitment = cert.ProofCommitment()
-	cert.Hash = header.BlockHash()
+	payload.Hash = header.BlockHash()
 	return cert, nil
 }
 
 // callMineFFI invokes the Rust mine function and returns the public data and proof data as Go slices.
 // No C types or raw pointers escape this function.
-func callMineFFI(cHeader C.IncompleteBlockHeader, m, n, e, topK uint32) (publicData, proofData []byte, err error) {
+func callMineFFI(cHeader C.IncompleteBlockHeader, m, n, e, topK uint32,
+	certVersion wire.CertificateVersion) (publicData, proofData []byte, err error) {
 	miningConfig, err := defaultMiningConfig(e, topK)
 	if err != nil {
 		return nil, nil, err
@@ -124,12 +138,12 @@ func callMineFFI(cHeader C.IncompleteBlockHeader, m, n, e, topK uint32) (publicD
 	var result C.int32_t
 	if e == 0 {
 		result = C.mine(
-			C.uint32_t(m), C.uint32_t(n),
+			C.uint32_t(m), C.uint32_t(n), C.uint32_t(certVersion),
 			&cHeader, cMiningConfig, &cZKProof, &errorBuf[0],
 		)
 	} else {
 		result = C.mine_moe(
-			C.uint32_t(m), C.uint32_t(n),
+			C.uint32_t(m), C.uint32_t(n), C.uint32_t(certVersion),
 			&cHeader, cMiningConfig, &cZKProof, &errorBuf[0],
 		)
 	}

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -21,7 +21,6 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/wire"
 )
 

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -40,14 +40,10 @@ const MinNoiseRank = C.MIN_NOISE_RANK
 // V2 certificates (CertificateV2) handle both MoE and non-MoE new proofs.
 // V1 certificates (CertificateV1) are verified using the V1 proof format.
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
-	switch cert.Version() {
-	case wire.CertificateVersionV1:
-		c, ok := cert.(*wire.CertificateV1)
-		if !ok {
-			return fmt.Errorf("invalid V1 certificate type: %T", cert)
-		}
+	switch c := cert.(type) {
+	case *wire.CertificateV1:
 		return verifyCertificateV1(header, c)
-	case wire.CertificateVersionV2, wire.CertificateVersionV3:
+	case *wire.CertificateV2, *wire.CertificateV3:
 		return VerifyZKProofFFI(header, cert, nil)
 	default:
 		return fmt.Errorf("unknown certificate type: %T", cert)

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -41,10 +41,12 @@ const MinNoiseRank = C.MIN_NOISE_RANK
 // V1 certificates (CertificateV1) are verified using the V1 proof format.
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
 	switch c := cert.(type) {
+	case *wire.CertificateV3:
+		return verifyCertificateV3(header, c)
+	case *wire.CertificateV2:
+		return verifyCertificateV2(header, c)
 	case *wire.CertificateV1:
 		return verifyCertificateV1(header, c)
-	case *wire.CertificateV2, *wire.CertificateV3:
-		return VerifyZKProofFFI(header, cert, nil)
 	default:
 		return fmt.Errorf("unknown certificate type: %T", cert)
 	}
@@ -100,6 +102,14 @@ func verifyCertificateV1(header *wire.BlockHeader, c *wire.CertificateV1) error 
 // ================================================================================
 // V2/V3 CERTIFICATE VERIFICATION
 // ================================================================================
+
+func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error {
+	return VerifyZKProofFFI(header, c, nil)
+}
+
+func verifyCertificateV3(header *wire.BlockHeader, c *wire.CertificateV3) error {
+	return VerifyZKProofFFI(header, c, nil)
+}
 
 // VerifyZKProofFFI verifies a V2/V3-layout ZK proof via the Rust FFI.
 func VerifyZKProofFFI(

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -36,10 +36,13 @@ const MinNoiseRank = C.MIN_NOISE_RANK
 
 // VerifyCertificate performs sanity checks followed by cryptographic proof verification.
 // It returns an error if the certificate is invalid or does not match the header.
+// V3 certificates (CertificateV3) share the V2 layout but use the salted noise-seed derivation.
 // V2 certificates (CertificateV2) handle both MoE and non-MoE new proofs.
 // V1 certificates (CertificateV1) are verified using the V1 proof format.
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
 	switch c := cert.(type) {
+	case *wire.CertificateV3:
+		return verifyCertificateV3(header, c)
 	case *wire.CertificateV2:
 		return verifyCertificateV2(header, c)
 	case *wire.CertificateV1:
@@ -97,16 +100,29 @@ func verifyCertificateV1(header *wire.BlockHeader, c *wire.CertificateV1) error 
 }
 
 // ================================================================================
-// V2 CERTIFICATE VERIFICATION
+// V2/V3 CERTIFICATE VERIFICATION
 // ================================================================================
 
 func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error {
-	return VerifyZKProofFFI(header, c.Hash, c.ProofCommitment(), c.PublicDataBytes(),
-		c.ProofData, nil)
+	return verifyV2Layout(header, c, c)
 }
 
+func verifyCertificateV3(header *wire.BlockHeader, c *wire.CertificateV3) error {
+	return verifyV2Layout(header, c, &c.CertificateV2)
+}
+
+// verifyV2Layout verifies a certificate with the V2 wire layout (V2, or V3 via
+// its embedded V2 payload). cert supplies the version and proof commitment.
+func verifyV2Layout(header *wire.BlockHeader, cert wire.BlockCertificate, payload *wire.CertificateV2) error {
+	return VerifyZKProofFFI(header, cert.Version(), payload.Hash, cert.ProofCommitment(),
+		payload.PublicDataBytes(), payload.ProofData, nil)
+}
+
+// VerifyZKProofFFI verifies a V2-layout ZK proof via the Rust FFI. certVersion
+// selects the noise-seed derivation (V2 legacy, V3 salted).
 func VerifyZKProofFFI(
 	header *wire.BlockHeader,
+	certVersion wire.CertificateVersion,
 	certHash chainhash.Hash,
 	proofCommitment chainhash.Hash,
 	publicData []byte,
@@ -149,10 +165,21 @@ func VerifyZKProofFFI(
 	// Call Rust FFI
 	var errorBuf [C.ERROR_MSG_MAX_SIZE]C.char
 	var result C.int32_t
-	if nbitsOverride != nil {
-		result = C.verify_zk_proof_v2_with_nbits(&cBlockHeader, &cZKProof, C.uint32_t(*nbitsOverride), &errorBuf[0])
-	} else {
-		result = C.verify_zk_proof_v2(&cBlockHeader, &cZKProof, &errorBuf[0])
+	switch certVersion {
+	case wire.CertificateVersionV2:
+		if nbitsOverride != nil {
+			result = C.verify_zk_proof_v2_with_nbits(&cBlockHeader, &cZKProof, C.uint32_t(*nbitsOverride), &errorBuf[0])
+		} else {
+			result = C.verify_zk_proof_v2(&cBlockHeader, &cZKProof, &errorBuf[0])
+		}
+	case wire.CertificateVersionV3:
+		if nbitsOverride != nil {
+			result = C.verify_zk_proof_v3_with_nbits(&cBlockHeader, &cZKProof, C.uint32_t(*nbitsOverride), &errorBuf[0])
+		} else {
+			result = C.verify_zk_proof_v3(&cBlockHeader, &cZKProof, &errorBuf[0])
+		}
+	default:
+		return fmt.Errorf("unsupported certificate version %d for FFI verification", certVersion)
 	}
 	msg := C.GoString(&errorBuf[0])
 

--- a/node/zkpow/verify.go
+++ b/node/zkpow/verify.go
@@ -40,13 +40,15 @@ const MinNoiseRank = C.MIN_NOISE_RANK
 // V2 certificates (CertificateV2) handle both MoE and non-MoE new proofs.
 // V1 certificates (CertificateV1) are verified using the V1 proof format.
 func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) error {
-	switch c := cert.(type) {
-	case *wire.CertificateV3:
-		return verifyCertificateV3(header, c)
-	case *wire.CertificateV2:
-		return verifyCertificateV2(header, c)
-	case *wire.CertificateV1:
+	switch cert.Version() {
+	case wire.CertificateVersionV1:
+		c, ok := cert.(*wire.CertificateV1)
+		if !ok {
+			return fmt.Errorf("invalid V1 certificate type: %T", cert)
+		}
 		return verifyCertificateV1(header, c)
+	case wire.CertificateVersionV2, wire.CertificateVersionV3:
+		return VerifyZKProofFFI(header, cert, nil)
 	default:
 		return fmt.Errorf("unknown certificate type: %T", cert)
 	}
@@ -103,46 +105,31 @@ func verifyCertificateV1(header *wire.BlockHeader, c *wire.CertificateV1) error 
 // V2/V3 CERTIFICATE VERIFICATION
 // ================================================================================
 
-func verifyCertificateV2(header *wire.BlockHeader, c *wire.CertificateV2) error {
-	return verifyV2Layout(header, c, c)
-}
-
-func verifyCertificateV3(header *wire.BlockHeader, c *wire.CertificateV3) error {
-	return verifyV2Layout(header, c, &c.CertificateV2)
-}
-
-// verifyV2Layout verifies a certificate with the V2 wire layout (V2, or V3 via
-// its embedded V2 payload). cert supplies the version and proof commitment.
-func verifyV2Layout(header *wire.BlockHeader, cert wire.BlockCertificate, payload *wire.CertificateV2) error {
-	return VerifyZKProofFFI(header, cert.Version(), payload.Hash, cert.ProofCommitment(),
-		payload.PublicDataBytes(), payload.ProofData, nil)
-}
-
-// VerifyZKProofFFI verifies a V2-layout ZK proof via the Rust FFI. certVersion
-// selects the noise-seed derivation (V2 legacy, V3 salted).
+// VerifyZKProofFFI verifies a V2/V3-layout ZK proof via the Rust FFI.
 func VerifyZKProofFFI(
 	header *wire.BlockHeader,
-	certVersion wire.CertificateVersion,
-	certHash chainhash.Hash,
-	proofCommitment chainhash.Hash,
-	publicData []byte,
-	proofData []byte,
+	cert wire.BlockCertificate,
 	nbitsOverride *uint32,
 ) error {
+	certHash := cert.BlockHash()
 	blockHash := header.BlockHash()
 	if !certHash.IsEqual(&blockHash) {
 		return fmt.Errorf("block hash mismatch: certificate has %s, header has %s",
 			certHash, blockHash)
 	}
 
+	proofCommitment := cert.ProofCommitment()
 	if header.ProofCommitment != proofCommitment {
 		return fmt.Errorf("proof commitment mismatch: header has %s, certificate has %s",
 			header.ProofCommitment, proofCommitment)
 	}
 
+	publicData := cert.PublicDataBytes()
 	if len(publicData) == 0 { // avoid publicData[0] index below
 		return fmt.Errorf("empty public data")
 	}
+
+	proofData := cert.ProofBytes()
 	if len(proofData) == 0 { // avoid proofData[0] index below
 		return fmt.Errorf("empty proof data")
 	}
@@ -165,7 +152,7 @@ func VerifyZKProofFFI(
 	// Call Rust FFI
 	var errorBuf [C.ERROR_MSG_MAX_SIZE]C.char
 	var result C.int32_t
-	switch certVersion {
+	switch cert.Version() {
 	case wire.CertificateVersionV2:
 		if nbitsOverride != nil {
 			result = C.verify_zk_proof_v2_with_nbits(&cBlockHeader, &cZKProof, C.uint32_t(*nbitsOverride), &errorBuf[0])
@@ -179,7 +166,7 @@ func VerifyZKProofFFI(
 			result = C.verify_zk_proof_v3(&cBlockHeader, &cZKProof, &errorBuf[0])
 		}
 	default:
-		return fmt.Errorf("unsupported certificate version %d for FFI verification", certVersion)
+		return fmt.Errorf("unsupported certificate version %d for FFI verification", cert.Version())
 	}
 	msg := C.GoString(&errorBuf[0])
 

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -24,6 +24,7 @@ func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) err
 
 func VerifyZKProofFFI(
 	header *wire.BlockHeader,
+	certVersion wire.CertificateVersion,
 	certHash chainhash.Hash,
 	proofCommitment chainhash.Hash,
 	publicData []byte,
@@ -37,10 +38,11 @@ func CheckRankPenalty(bits uint32, publicData []byte) error {
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")
 }
 
-func Mine(header *wire.BlockHeader) (*wire.CertificateV2, error) {
+func Mine(header *wire.BlockHeader, certVersion wire.CertificateVersion) (wire.BlockCertificate, error) {
 	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable mining")
 }
 
-func MineMoE(header *wire.BlockHeader, m, n, e, topK uint32) (*wire.CertificateV2, error) {
+func MineMoE(header *wire.BlockHeader, m, n, e, topK uint32,
+	certVersion wire.CertificateVersion) (wire.BlockCertificate, error) {
 	return nil, fmt.Errorf("zkpow: build with -tags zkpow to enable MoE mining")
 }

--- a/node/zkpow/zkpow_stub.go
+++ b/node/zkpow/zkpow_stub.go
@@ -5,7 +5,6 @@ package zkpow
 import (
 	"fmt"
 
-	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/wire"
 )
 
@@ -24,11 +23,7 @@ func VerifyCertificate(header *wire.BlockHeader, cert wire.BlockCertificate) err
 
 func VerifyZKProofFFI(
 	header *wire.BlockHeader,
-	certVersion wire.CertificateVersion,
-	certHash chainhash.Hash,
-	proofCommitment chainhash.Hash,
-	publicData []byte,
-	proofData []byte,
+	cert wire.BlockCertificate,
 	nbitsOverride *uint32,
 ) error {
 	return fmt.Errorf("zkpow: build with -tags zkpow to enable proof verification")

--- a/node/zkpow/zkpow_test.go
+++ b/node/zkpow/zkpow_test.go
@@ -43,15 +43,23 @@ func testBlockHeader(nbits ...uint32) *wire.BlockHeader {
 	}
 }
 
+// requireV2 asserts cert is a CertificateV2 and returns it.
+func requireV2(t *testing.T, cert wire.BlockCertificate) *wire.CertificateV2 {
+	t.Helper()
+	v2, ok := cert.(*wire.CertificateV2)
+	require.True(t, ok, "mined certificate should be CertificateV2")
+	return v2
+}
+
 // mineCertificate mines a block and returns the header and certificate.
 func mineCertificate(t *testing.T) (*wire.BlockHeader, *wire.CertificateV2) {
 	t.Helper()
 	header := testBlockHeader()
 
-	cert, err := Mine(header)
+	cert, err := Mine(header, wire.CertificateVersionV2)
 	require.NoError(t, err, "mining should succeed")
 
-	return header, cert
+	return header, requireV2(t, cert)
 }
 
 // copyBlockHeader creates a copy of BlockHeader for tampering tests
@@ -219,10 +227,11 @@ func mineMoECertificate(t *testing.T) (*wire.BlockHeader, *wire.CertificateV2) {
 	t.Helper()
 	header := testBlockHeader()
 
-	cert, err := MineMoE(header, DefaultMoEM, DefaultMoEN, DefaultMoEE, DefaultMoETopK)
+	cert, err := MineMoE(header, DefaultMoEM, DefaultMoEN, DefaultMoEE, DefaultMoETopK,
+		wire.CertificateVersionV2)
 	require.NoError(t, err, "MoE mining should succeed")
 
-	return header, cert
+	return header, requireV2(t, cert)
 }
 
 // TestMoEMineAndVerifyProof tests the full MoE mining and verification flow.
@@ -317,7 +326,7 @@ func BenchmarkMine(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				cert, err := Mine(header)
+				cert, err := Mine(header, wire.CertificateVersionV2)
 				if err != nil {
 					b.Fatalf("mining failed: %v", err)
 				}
@@ -336,7 +345,7 @@ func BenchmarkMine(b *testing.B) {
 func BenchmarkVerifyProof(b *testing.B) {
 	header := testBlockHeader()
 
-	cert, err := Mine(header)
+	cert, err := Mine(header, wire.CertificateVersionV2)
 	if err != nil {
 		b.Fatalf("mining failed during setup: %v", err)
 	}

--- a/py-pearl-mining/Cargo.lock
+++ b/py-pearl-mining/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "py-pearl-mining"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "blake3",
  "env_logger 0.10.2",

--- a/py-pearl-mining/Cargo.toml
+++ b/py-pearl-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-pearl-mining"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Unified Python bindings for Pearl mining (blake3 merkle trees + ZK proof)"
 

--- a/py-pearl-mining/pyproject.toml
+++ b/py-pearl-mining/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 
 [project]
 name = "py-pearl-mining"
-version = "0.2.0"
+version = "0.3.0"
 requires-python = ">=3.12"
 description = "Unified Python bindings for Pearl mining"
 authors = [

--- a/py-pearl-mining/src/lib.rs
+++ b/py-pearl-mining/src/lib.rs
@@ -16,7 +16,7 @@ use pearl_blake3::{pad_to_chunk_boundary, MerkleProof, MerkleTree};
 use primitive_types::U256;
 use zk_pow::api::proof::{
     IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern,
-    PublicProofParams, ZKProof,
+    PublicProofParams, SeedDerivation, ZKProof,
 };
 use zk_pow::api::sanity_checks;
 use zk_pow::api::{prove, verify};
@@ -80,14 +80,20 @@ fn acquire_cache() -> PyResult<std::sync::MutexGuard<'static, CircuitCache>> {
         .map_err(|_| py_err("Cache poisoned by prior panic", "restart required"))
 }
 
-#[pyfunction]
-fn generate_proof_v2(
+fn generate_proof_impl(
     block_header: IncompleteBlockHeader,
     plain_proof: PlainProof,
+    seed_derivation: SeedDerivation,
 ) -> PyResult<PyProof> {
     let mut cache = acquire_cache()?;
-    let result = prove::zk_prove_plain_proof(block_header, &plain_proof, &mut cache, true)
-        .map_err(|e| py_err("Prove failed", e))?;
+    let result = prove::zk_prove_plain_proof(
+        block_header,
+        &plain_proof,
+        &mut cache,
+        true,
+        seed_derivation,
+    )
+    .map_err(|e| py_err("Prove failed", e))?;
 
     Ok(PyProof {
         public_data: result.public_data,
@@ -96,9 +102,26 @@ fn generate_proof_v2(
 }
 
 #[pyfunction]
-fn verify_proof_v2(
+fn generate_proof_v2(
+    block_header: IncompleteBlockHeader,
+    plain_proof: PlainProof,
+) -> PyResult<PyProof> {
+    generate_proof_impl(block_header, plain_proof, SeedDerivation::Legacy)
+}
+
+/// V3 proving: same circuits as V2, salted noise-seed derivation.
+#[pyfunction]
+fn generate_proof_v3(
+    block_header: IncompleteBlockHeader,
+    plain_proof: PlainProof,
+) -> PyResult<PyProof> {
+    generate_proof_impl(block_header, plain_proof, SeedDerivation::Salted)
+}
+
+fn verify_proof_impl(
     block_header: IncompleteBlockHeader,
     proof: &PyProof,
+    seed_derivation: SeedDerivation,
 ) -> PyResult<(bool, String)> {
     if !PublicProofParams::is_valid_wire_size(proof.public_data.len()) {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -109,15 +132,36 @@ fn verify_proof_v2(
         )));
     }
 
-    let (params, zk_proof) =
-        ZKProof::deserialize(block_header, &proof.public_data, &proof.proof_data)
-            .map_err(|e| py_err("Deserialize failed", e))?;
+    let (params, zk_proof) = ZKProof::deserialize(
+        block_header,
+        seed_derivation,
+        &proof.public_data,
+        &proof.proof_data,
+    )
+    .map_err(|e| py_err("Deserialize failed", e))?;
 
     let mut cache = acquire_cache()?;
     match verify::verify_block(&params, &zk_proof, &mut cache) {
         Ok(_) => Ok((true, "Verified".into())),
         Err(e) => Ok((false, format!("Rejected: {}", e))),
     }
+}
+
+#[pyfunction]
+fn verify_proof_v2(
+    block_header: IncompleteBlockHeader,
+    proof: &PyProof,
+) -> PyResult<(bool, String)> {
+    verify_proof_impl(block_header, proof, SeedDerivation::Legacy)
+}
+
+/// V3 (salted noise-seed) verification: same circuits and cache as V2.
+#[pyfunction]
+fn verify_proof_v3(
+    block_header: IncompleteBlockHeader,
+    proof: &PyProof,
+) -> PyResult<(bool, String)> {
+    verify_proof_impl(block_header, proof, SeedDerivation::Salted)
 }
 
 #[pyfunction]
@@ -138,6 +182,18 @@ fn warmup_prove_v2(mining_config: MiningConfiguration) -> PyResult<()> {
     prove::warmup_prove(mining_config, &mut cache).map_err(|e| py_err("Warmup prove failed", e))
 }
 
+fn verify_plain_proof_impl(
+    block_header: IncompleteBlockHeader,
+    plain_proof: PlainProof,
+    nbits_override: Option<u32>,
+    seed_derivation: SeedDerivation,
+) -> PyResult<(bool, String)> {
+    match verify::verify_plain_proof(&block_header, &plain_proof, nbits_override, seed_derivation) {
+        Ok(()) => Ok((true, "Mining solution verified successfully".into())),
+        Err(e) => Ok((false, e.to_string())),
+    }
+}
+
 #[pyfunction]
 #[pyo3(signature = (block_header, plain_proof, nbits_override=None))]
 fn verify_plain_proof_v2(
@@ -145,10 +201,28 @@ fn verify_plain_proof_v2(
     plain_proof: PlainProof,
     nbits_override: Option<u32>,
 ) -> PyResult<(bool, String)> {
-    match verify::verify_plain_proof(&block_header, &plain_proof, nbits_override) {
-        Ok(()) => Ok((true, "Mining solution verified successfully".into())),
-        Err(e) => Ok((false, e.to_string())),
-    }
+    verify_plain_proof_impl(
+        block_header,
+        plain_proof,
+        nbits_override,
+        SeedDerivation::Legacy,
+    )
+}
+
+/// V3 (salted noise-seed) plain-proof verification.
+#[pyfunction]
+#[pyo3(signature = (block_header, plain_proof, nbits_override=None))]
+fn verify_plain_proof_v3(
+    block_header: IncompleteBlockHeader,
+    plain_proof: PlainProof,
+    nbits_override: Option<u32>,
+) -> PyResult<(bool, String)> {
+    verify_plain_proof_impl(
+        block_header,
+        plain_proof,
+        nbits_override,
+        SeedDerivation::Salted,
+    )
 }
 
 #[pyfunction]
@@ -177,8 +251,16 @@ fn penalized_target_bound<'py>(
     Ok(Some(bound_int))
 }
 
+/// Map a certificate version to its noise-seed derivation (errors on unknown versions).
+fn seed_derivation_for(cert_version: u32) -> PyResult<SeedDerivation> {
+    Ok(CertificateVersion::try_from(cert_version)
+        .map_err(value_err)?
+        .seed_derivation())
+}
+
 #[pyfunction]
-#[pyo3(signature = (m, n, k, block_header, mining_config, signal_range=None, wrong_jackpot_hash=false))]
+#[pyo3(signature = (m, n, k, block_header, mining_config, signal_range=None, wrong_jackpot_hash=false, *, cert_version))]
+#[allow(clippy::too_many_arguments)]
 fn mine(
     m: usize,
     n: usize,
@@ -187,6 +269,7 @@ fn mine(
     mining_config: MiningConfiguration,
     signal_range: Option<(i8, i8)>,
     wrong_jackpot_hash: bool,
+    cert_version: u32,
 ) -> PyResult<PlainProof> {
     ffi_mine(
         m,
@@ -196,12 +279,14 @@ fn mine(
         mining_config,
         signal_range,
         wrong_jackpot_hash,
+        seed_derivation_for(cert_version)?,
     )
     .map_err(|e| py_err("Mining failed", e))
 }
 
 #[pyfunction]
-#[pyo3(signature = (m, n, k, block_header, mining_config, signal_range=None, wrong_jackpot_hash=false))]
+#[pyo3(signature = (m, n, k, block_header, mining_config, signal_range=None, wrong_jackpot_hash=false, *, cert_version))]
+#[allow(clippy::too_many_arguments)]
 fn mine_moe(
     m: usize,
     n: usize,
@@ -210,6 +295,7 @@ fn mine_moe(
     mining_config: MiningConfiguration,
     signal_range: Option<(i8, i8)>,
     wrong_jackpot_hash: bool,
+    cert_version: u32,
 ) -> PyResult<PlainProof> {
     // Both `e` and `top_k` are committed in `mining_config` (via its `moe` field), so
     // the caller selects GROUPED_GEMM by passing a config with `moe` set.
@@ -221,6 +307,7 @@ fn mine_moe(
         mining_config,
         signal_range,
         wrong_jackpot_hash,
+        seed_derivation_for(cert_version)?,
     )
     .map_err(|e| py_err("MoE mining failed", e))
 }
@@ -363,6 +450,7 @@ fn generate_proof_for_cert_version(
     match core_check_cert_version_eligible(cert_version, &plain_proof).map_err(value_err)? {
         CertificateVersion::ZkDense => generate_proof_v1(block_header, plain_proof),
         CertificateVersion::ZkMoe => generate_proof_v2(block_header, plain_proof),
+        CertificateVersion::ZkV3 => generate_proof_v3(block_header, plain_proof),
     }
 }
 
@@ -376,6 +464,7 @@ fn verify_proof_for_cert_version(
     match CertificateVersion::try_from(cert_version).map_err(value_err)? {
         CertificateVersion::ZkDense => verify_proof_v1(block_header, proof),
         CertificateVersion::ZkMoe => verify_proof_v2(block_header, proof),
+        CertificateVersion::ZkV3 => verify_proof_v3(block_header, proof),
     }
 }
 
@@ -393,6 +482,9 @@ fn verify_plain_proof_for_cert_version(
         }
         CertificateVersion::ZkMoe => {
             verify_plain_proof_v2(block_header, plain_proof, nbits_override)
+        }
+        CertificateVersion::ZkV3 => {
+            verify_plain_proof_v3(block_header, plain_proof, nbits_override)
         }
     }
 }
@@ -450,6 +542,10 @@ fn pearl_mining(m: &Bound<'_, pyo3::types::PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(verify_plain_proof_v2, m)?)?;
     m.add_function(wrap_pyfunction!(clear_circuit_cache_v2, m)?)?;
     m.add_function(wrap_pyfunction!(warmup_prove_v2, m)?)?;
+    // V3 functions (same circuits as V2; salted noise-seed derivation)
+    m.add_function(wrap_pyfunction!(generate_proof_v3, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_proof_v3, m)?)?;
+    m.add_function(wrap_pyfunction!(verify_plain_proof_v3, m)?)?;
     // V1 functions (legacy circuit; dense proofs only)
     m.add(
         "V1_PUBLICDATA_SIZE",
@@ -463,6 +559,7 @@ fn pearl_mining(m: &Bound<'_, pyo3::types::PyModule>) -> PyResult<()> {
     // Certificate-version dispatchers (recommended entry points)
     m.add("CERT_VERSION_ZK_DENSE", CertificateVersion::ZkDense as u32)?;
     m.add("CERT_VERSION_ZK_MOE", CertificateVersion::ZkMoe as u32)?;
+    m.add("CERT_VERSION_ZK_V3", CertificateVersion::ZkV3 as u32)?;
     m.add_function(wrap_pyfunction!(py_check_cert_version_eligible, m)?)?;
     m.add_function(wrap_pyfunction!(generate_proof_for_cert_version, m)?)?;
     m.add_function(wrap_pyfunction!(verify_proof_for_cert_version, m)?)?;

--- a/py-pearl-mining/tests/test_python_api.py
+++ b/py-pearl-mining/tests/test_python_api.py
@@ -54,6 +54,7 @@ def generate_plain_proof(
     rank: int = DEFAULT_RANK,
     signal_range: tuple[int, int] | None = None,
     wrong_jackpot_hash: bool = False,
+    cert_version: int = pearl_mining.CERT_VERSION_ZK_V3,
 ) -> pearl_mining.PlainProof:
     """Generate a PlainProof using mine()."""
     mining_config = create_default_mining_config(k, rank=rank)
@@ -65,6 +66,7 @@ def generate_plain_proof(
         mining_config,
         signal_range=signal_range,
         wrong_jackpot_hash=wrong_jackpot_hash,
+        cert_version=cert_version,
     )
 
 
@@ -78,8 +80,9 @@ def generate_moe_plain_proof(
     rank: int = DEFAULT_RANK,
     signal_range: tuple[int, int] | None = None,
     wrong_jackpot_hash: bool = False,
+    cert_version: int = pearl_mining.CERT_VERSION_ZK_V3,
 ) -> pearl_mining.PlainProof:
-    """Generate a PlainProof using mine_moe()."""
+    """Generate an MoE PlainProof with the current V3 derivation."""
     mining_config = create_default_mining_config(k, rank=rank, e=e, top_k=top_k)
     return pearl_mining.mine_moe(
         m,
@@ -89,6 +92,7 @@ def generate_moe_plain_proof(
         mining_config,
         signal_range=signal_range,
         wrong_jackpot_hash=wrong_jackpot_hash,
+        cert_version=cert_version,
     )
 
 
@@ -98,9 +102,9 @@ def prove_and_verify(
     *,
     expect_valid: bool = True,
 ) -> tuple[pearl_mining.ZKProof, bool, str]:
-    """Generate a ZK proof and verify it. Asserts the expected outcome."""
-    proof = pearl_mining.generate_proof_v2(block_header, plain_proof)
-    is_valid, message = pearl_mining.verify_proof_v2(block_header, proof)
+    """Generate a V3 ZK proof and verify it. Asserts the expected outcome."""
+    proof = pearl_mining.generate_proof_v3(block_header, plain_proof)
+    is_valid, message = pearl_mining.verify_proof_v3(block_header, proof)
     if expect_valid:
         assert is_valid, f"Verification unexpectedly failed: {message}"
     else:
@@ -114,9 +118,9 @@ def moe_prove_and_verify(
     *,
     expect_valid: bool = True,
 ) -> tuple[pearl_mining.ZKProof, bool, str]:
-    """Generate a ZK proof from an MoE mining solution and verify it."""
-    proof = pearl_mining.generate_proof_v2(block_header, moe_proof)
-    is_valid, message = pearl_mining.verify_proof_v2(block_header, proof)
+    """Generate a V3 ZK proof from an MoE mining solution and verify it."""
+    proof = pearl_mining.generate_proof_v3(block_header, moe_proof)
+    is_valid, message = pearl_mining.verify_proof_v3(block_header, proof)
     if expect_valid:
         assert is_valid, f"MoE verification unexpectedly failed: {message}"
     else:
@@ -159,14 +163,14 @@ class TestDifferentDimensions:
 
 
 class TestVerifyPlainProof:
-    """Tests for verify_plain_proof_v2(), which checks the mining solution without ZK proving."""
+    """Test V3 plain-proof verification without ZK proving."""
 
     def test_valid_plain_proof(self):
         m, n, k = 256, 128, DEFAULT_K
         block_header = create_test_block_header()
         plain_proof = generate_plain_proof(m, n, k, block_header)
 
-        is_valid, message = pearl_mining.verify_plain_proof_v2(block_header, plain_proof)
+        is_valid, message = pearl_mining.verify_plain_proof_v3(block_header, plain_proof)
         assert is_valid, f"verify_plain_proof failed on valid proof: {message}"
 
     def test_wrong_range_plain_proof(self):
@@ -181,7 +185,7 @@ class TestVerifyPlainProof:
             signal_range=OUT_OF_RANGE_SIGNAL_RANGE,
         )
 
-        is_valid, message = pearl_mining.verify_plain_proof_v2(block_header, plain_proof)
+        is_valid, message = pearl_mining.verify_plain_proof_v3(block_header, plain_proof)
         assert not is_valid, "verify_plain_proof accepted out-of-range matrices -- soundness issue!"
 
 
@@ -248,7 +252,7 @@ class TestMoEMineProveVerify:
             block_header,
         )
 
-        is_valid, msg = pearl_mining.verify_plain_proof_v2(block_header, moe_proof)
+        is_valid, msg = pearl_mining.verify_plain_proof_v3(block_header, moe_proof)
         assert is_valid, f"MoE plain proof verification failed: {msg}"
 
         moe_prove_and_verify(block_header, moe_proof)
@@ -258,14 +262,14 @@ class TestMoEMineProveVerify:
         block_header = create_test_block_header()
         moe_proof = generate_moe_plain_proof(m, n, k, e, top_k, block_header, rank=rank)
 
-        is_valid, msg = pearl_mining.verify_plain_proof_v2(block_header, moe_proof)
+        is_valid, msg = pearl_mining.verify_plain_proof_v3(block_header, moe_proof)
         assert is_valid, f"MoE plain proof verification failed: {msg}"
 
         moe_prove_and_verify(block_header, moe_proof)
 
 
 class TestMoEVerifyPlainProof:
-    """Tests for verify_plain_proof_v2() in the MoE context, which checks the MoE mining solution without ZK proving."""
+    """Test V3 plain-proof verification for MoE solutions."""
 
     def test_valid_moe_plain_proof(self):
         block_header = create_test_block_header()
@@ -278,7 +282,7 @@ class TestMoEVerifyPlainProof:
             block_header,
         )
 
-        is_valid, msg = pearl_mining.verify_plain_proof_v2(block_header, moe_proof)
+        is_valid, msg = pearl_mining.verify_plain_proof_v3(block_header, moe_proof)
         assert is_valid, f"verify_plain_proof failed on valid proof: {msg}"
 
     def test_wrong_range_moe_plain_proof(self):
@@ -294,7 +298,7 @@ class TestMoEVerifyPlainProof:
             signal_range=OUT_OF_RANGE_SIGNAL_RANGE,
         )
 
-        is_valid, msg = pearl_mining.verify_plain_proof_v2(block_header, moe_proof)
+        is_valid, msg = pearl_mining.verify_plain_proof_v3(block_header, moe_proof)
         assert not is_valid, "verify_plain_proof accepted out-of-range matrices -- soundness issue!"
 
 
@@ -349,8 +353,8 @@ class TestMoESerialization:
         encoded = moe_proof.to_base64()
         restored = pearl_mining.PlainProof.from_base64(encoded)
 
-        is_valid_original, _ = pearl_mining.verify_plain_proof_v2(block_header, moe_proof)
-        is_valid_restored, _ = pearl_mining.verify_plain_proof_v2(block_header, restored)
+        is_valid_original, _ = pearl_mining.verify_plain_proof_v3(block_header, moe_proof)
+        is_valid_restored, _ = pearl_mining.verify_plain_proof_v3(block_header, restored)
         assert is_valid_original and is_valid_restored, "Round-trip serialization broke the proof"
 
 
@@ -364,6 +368,13 @@ BINCODE_OPTION_NONE_TAG = 0x00
 HARD_NBITS = 0x10FFFFFF
 
 VALID_CERT_VERSIONS = [
+    pearl_mining.CERT_VERSION_ZK_DENSE,
+    pearl_mining.CERT_VERSION_ZK_MOE,
+    pearl_mining.CERT_VERSION_ZK_V3,
+]
+
+# Versions using the legacy (unsalted) noise-seed derivation.
+LEGACY_CERT_VERSIONS = [
     pearl_mining.CERT_VERSION_ZK_DENSE,
     pearl_mining.CERT_VERSION_ZK_MOE,
 ]
@@ -415,7 +426,10 @@ class TestLegacyV1Deserialization:
     def test_accepts_legacy_v1_blob(self):
         m, n, k = 256, 128, DEFAULT_K
         block_header = create_test_block_header()
-        plain_proof = generate_plain_proof(m, n, k, block_header)
+        # Old V1 miners used the legacy derivation.
+        plain_proof = generate_plain_proof(
+            m, n, k, block_header, cert_version=pearl_mining.CERT_VERSION_ZK_DENSE
+        )
 
         raw = base64.b64decode(plain_proof.to_base64())
         assert raw[-1] == BINCODE_OPTION_NONE_TAG
@@ -454,7 +468,7 @@ class TestCertVersionEligibility:
 
     def test_unknown_versions_rejected(self):
         dense = make_dummy_plain_proof(moe=False)
-        for version in (0, 3):
+        for version in (0, 4):
             with pytest.raises(ValueError, match="unknown certificate version"):
                 pearl_mining.check_cert_version_eligible(version, dense)
 
@@ -462,11 +476,15 @@ class TestCertVersionEligibility:
 class TestCertVersionDispatchers:
     """The *_for_cert_version entry points pick the circuit from the block's version."""
 
-    @pytest.mark.parametrize("cert_version", VALID_CERT_VERSIONS)
+    @pytest.mark.parametrize("cert_version", LEGACY_CERT_VERSIONS)
     def test_dense_proof_round_trip_under_both_versions(self, cert_version):
         m, n, k = 256, 128, DEFAULT_K
         block_header = create_test_block_header()
-        plain_proof = generate_plain_proof(m, n, k, block_header)
+        # Both legacy versions share a derivation, so the same dense proof must
+        # verify under either dispatcher.
+        plain_proof = generate_plain_proof(
+            m, n, k, block_header, cert_version=pearl_mining.CERT_VERSION_ZK_DENSE
+        )
 
         is_valid, msg = pearl_mining.verify_plain_proof_for_cert_version(
             cert_version, block_header, plain_proof
@@ -490,13 +508,53 @@ class TestCertVersionDispatchers:
             )
 
 
+class TestSaltedCertVersion:
+    """V3 (salted noise-seed) mining, verification, and cross-derivation rejection."""
+
+    def test_salted_round_trip(self):
+        m, n, k = 256, 128, DEFAULT_K
+        block_header = create_test_block_header()
+        plain_proof = generate_plain_proof(m, n, k, block_header)
+
+        is_valid, msg = pearl_mining.verify_plain_proof_for_cert_version(
+            pearl_mining.CERT_VERSION_ZK_V3, block_header, plain_proof
+        )
+        assert is_valid, f"salted plain proof verification failed: {msg}"
+
+        proof = pearl_mining.generate_proof_for_cert_version(
+            pearl_mining.CERT_VERSION_ZK_V3, block_header, plain_proof
+        )
+        is_valid, msg = pearl_mining.verify_proof_for_cert_version(
+            pearl_mining.CERT_VERSION_ZK_V3, block_header, proof
+        )
+        assert is_valid, f"salted ZK verification failed: {msg}"
+
+    def test_cross_derivation_rejected(self):
+        """A proof mined under one derivation must fail under the other."""
+        m, n, k = 256, 128, DEFAULT_K
+        block_header = create_test_block_header()
+
+        legacy_proof = generate_plain_proof(
+            m, n, k, block_header, cert_version=pearl_mining.CERT_VERSION_ZK_MOE
+        )
+        is_valid, _ = pearl_mining.verify_plain_proof_v3(block_header, legacy_proof)
+        assert not is_valid, "legacy-derived proof accepted under the salted derivation"
+
+        salted_proof = generate_plain_proof(m, n, k, block_header)
+        is_valid, _ = pearl_mining.verify_plain_proof_v2(block_header, salted_proof)
+        assert not is_valid, "salted-derived proof accepted under the legacy derivation"
+
+
 class TestV1NbitsOverride:
-    """verify_plain_proof_v1() supports pool share-difficulty overrides like v2."""
+    """verify_plain_proof_v1() supports pool share-difficulty overrides."""
 
     def test_share_difficulty_override(self):
         m, n, k = 256, 128, DEFAULT_K
         block_header = create_test_block_header()
-        plain_proof = generate_plain_proof(m, n, k, block_header)
+        # V1 verification uses the legacy derivation.
+        plain_proof = generate_plain_proof(
+            m, n, k, block_header, cert_version=pearl_mining.CERT_VERSION_ZK_DENSE
+        )
 
         is_valid, msg = pearl_mining.verify_plain_proof_v1(
             block_header, plain_proof, nbits_override=DEFAULT_NBITS

--- a/uv.lock
+++ b/uv.lock
@@ -2368,7 +2368,9 @@ version = "0.0.1"
 source = { editable = "miner/pearl-gemm" }
 dependencies = [
     { name = "blake3" },
+    { name = "cuda-python" },
     { name = "numpy" },
+    { name = "nvidia-cutlass-dsl" },
     { name = "packaging" },
     { name = "pearl-gemm-build-utils" },
     { name = "pydantic" },
@@ -2397,7 +2399,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "blake3", specifier = ">=1.0.7" },
+    { name = "cuda-python", specifier = ">=13.0,<13.1" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "nvidia-cutlass-dsl", specifier = ">=4.4" },
     { name = "packaging", specifier = ">=21.0" },
     { name = "pearl-gemm-build-utils", editable = "miner/pearl-gemm-build-utils" },
     { name = "pydantic", specifier = ">=2.12.0,<3.0.0" },
@@ -2575,7 +2579,7 @@ wheels = [
 
 [[package]]
 name = "py-pearl-mining"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "py-pearl-mining" }
 
 [package.dev-dependencies]

--- a/version/version.go
+++ b/version/version.go
@@ -19,8 +19,8 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	Major uint = 1
-	Minor uint = 3
-	Patch uint = 1
+	Minor uint = 4
+	Patch uint = 0
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/zk-pow/bindings/go/Cargo.lock
+++ b/zk-pow/bindings/go/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dab3fe76c1571ecd5cfe878b61bce3fedf4adbde5d8a8653b2a7956ffd14628"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation-sys"

--- a/zk-pow/bindings/go/src/common.rs
+++ b/zk-pow/bindings/go/src/common.rs
@@ -6,7 +6,7 @@ use std::slice;
 use std::sync::Mutex;
 
 use anyhow::Result;
-use zk_pow::api::proof::{IncompleteBlockHeader, MiningConfiguration, PublicProofParams};
+use zk_pow::api::proof::{IncompleteBlockHeader, MiningConfiguration, PublicProofParams, SeedDerivation};
 use zk_pow::api::prove;
 use zk_pow::circuit::pearl_circuit::{PearlRecursion, RecursionCircuit};
 use zk_pow::ffi::plain_proof::PlainProof;
@@ -124,9 +124,10 @@ pub(crate) unsafe fn zk_prove(
     error_msg_out: *mut c_char,
     header: IncompleteBlockHeader,
     proof: &PlainProof,
+    seed_derivation: SeedDerivation,
 ) -> Option<prove::ProveResult> {
     let mut cache = acquire_cache();
-    match catch_panic(|| prove::zk_prove_plain_proof(header, proof, &mut cache, false)) {
+    match catch_panic(|| prove::zk_prove_plain_proof(header, proof, &mut cache, false, seed_derivation)) {
         Ok(Ok(r)) => Some(r),
         Ok(Err(e)) => {
             set_error_msg(error_msg_out, &format!("Prove failed: {}", e));

--- a/zk-pow/bindings/go/src/mine.rs
+++ b/zk-pow/bindings/go/src/mine.rs
@@ -2,10 +2,10 @@
 
 use std::os::raw::c_char;
 
-use zk_pow::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern};
+use zk_pow::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern, SeedDerivation};
 use zk_pow::api::prove;
 use zk_pow::ffi::mine::{mine as ffi_mine, mine_moe as ffi_mine_moe};
-use zk_pow::ffi::plain_proof::PlainProof;
+use zk_pow::ffi::plain_proof::{CertificateVersion, PlainProof};
 
 use crate::common::{catch_panic, copy_prove_result, set_error_msg, zk_prove, CZKProof, MIN_NOISE_RANK};
 
@@ -78,6 +78,8 @@ pub unsafe extern "C" fn default_mining_config(
 
 /// Perform mining and generate a standard (non-MoE) ZK proof in one step.
 ///
+/// `cert_version` (from the node's `RequiredCertVersion`) selects the noise-seed derivation.
+///
 /// # Returns
 /// - 0: Mining and proof generation successful
 /// - 1: Invalid input
@@ -91,22 +93,31 @@ pub unsafe extern "C" fn default_mining_config(
 pub unsafe extern "C" fn mine(
     m: u32,
     n: u32,
+    cert_version: u32,
     block_header: *const IncompleteBlockHeader,
     mining_config: *const [u8; crate::common::MINING_CONFIG_SERIALIZED_SIZE],
     zk_proof_out: *mut CZKProof,
     error_msg_out: *mut c_char,
 ) -> i32 {
-    mine_inner(block_header, mining_config, zk_proof_out, error_msg_out, |header, config| {
-        ffi_mine(
-            m as usize,
-            n as usize,
-            config.common_dim as usize,
-            header,
-            config,
-            None,
-            false,
-        )
-    })
+    mine_inner(
+        cert_version,
+        block_header,
+        mining_config,
+        zk_proof_out,
+        error_msg_out,
+        |header, config, seed_derivation| {
+            ffi_mine(
+                m as usize,
+                n as usize,
+                config.common_dim as usize,
+                header,
+                config,
+                None,
+                false,
+                seed_derivation,
+            )
+        },
+    )
 }
 
 /// Perform MoE mining and generate a ZK proof in one step.
@@ -122,26 +133,36 @@ pub unsafe extern "C" fn mine(
 /// - `error_msg_out` must be null or a valid pointer to a caller-allocated buffer of `ERROR_MSG_MAX_SIZE` bytes
 ///
 /// `e` and `top_k` are read from the serialized `mining_config` trailer (committed in the job_key).
+/// `cert_version` selects the noise-seed derivation (see `mine`).
 #[no_mangle]
 pub unsafe extern "C" fn mine_moe(
     m: u32,
     n: u32,
+    cert_version: u32,
     block_header: *const IncompleteBlockHeader,
     mining_config: *const [u8; crate::common::MINING_CONFIG_SERIALIZED_SIZE],
     zk_proof_out: *mut CZKProof,
     error_msg_out: *mut c_char,
 ) -> i32 {
-    mine_inner(block_header, mining_config, zk_proof_out, error_msg_out, |header, config| {
-        ffi_mine_moe(
-            m as usize,
-            n as usize,
-            config.common_dim as usize,
-            header,
-            config,
-            None,
-            false,
-        )
-    })
+    mine_inner(
+        cert_version,
+        block_header,
+        mining_config,
+        zk_proof_out,
+        error_msg_out,
+        |header, config, seed_derivation| {
+            ffi_mine_moe(
+                m as usize,
+                n as usize,
+                config.common_dim as usize,
+                header,
+                config,
+                None,
+                false,
+                seed_derivation,
+            )
+        },
+    )
 }
 
 // ============================================================================
@@ -164,16 +185,25 @@ fn build_default_config(e: u16, top_k: u16) -> anyhow::Result<MiningConfiguratio
 /// Parses the mining config, validates pointers, calls the provided mining
 /// closure, then copies the result into `zk_proof_out`.
 unsafe fn mine_inner(
+    cert_version: u32,
     block_header: *const IncompleteBlockHeader,
     mining_config: *const [u8; crate::common::MINING_CONFIG_SERIALIZED_SIZE],
     zk_proof_out: *mut CZKProof,
     error_msg_out: *mut c_char,
-    do_mine: impl FnOnce(IncompleteBlockHeader, MiningConfiguration) -> anyhow::Result<PlainProof>,
+    do_mine: impl FnOnce(IncompleteBlockHeader, MiningConfiguration, SeedDerivation) -> anyhow::Result<PlainProof>,
 ) -> i32 {
     if block_header.is_null() || mining_config.is_null() || zk_proof_out.is_null() {
         set_error_msg(error_msg_out, "Null pointer");
         return 2;
     }
+
+    let seed_derivation = match CertificateVersion::try_from(cert_version) {
+        Ok(v) => v.seed_derivation(),
+        Err(e) => {
+            set_error_msg(error_msg_out, &format!("Invalid cert version: {}", e));
+            return 2;
+        }
+    };
 
     let config = match MiningConfiguration::from_bytes(&*mining_config) {
         Ok(c) => c,
@@ -190,7 +220,9 @@ unsafe fn mine_inner(
         return 2;
     }
 
-    let result = match mine_and_prove(error_msg_out, header, || do_mine(header, config)) {
+    let result = match mine_and_prove(error_msg_out, header, seed_derivation, || {
+        do_mine(header, config, seed_derivation)
+    }) {
         Some(r) => r,
         None => return 2,
     };
@@ -208,6 +240,7 @@ unsafe fn mine_inner(
 unsafe fn mine_and_prove(
     error_msg_out: *mut c_char,
     header: IncompleteBlockHeader,
+    seed_derivation: SeedDerivation,
     mine_fn: impl FnOnce() -> anyhow::Result<PlainProof>,
 ) -> Option<prove::ProveResult> {
     let proof = match catch_panic(mine_fn) {
@@ -222,5 +255,5 @@ unsafe fn mine_and_prove(
         }
     };
 
-    zk_prove(error_msg_out, header, &proof)
+    zk_prove(error_msg_out, header, &proof, seed_derivation)
 }

--- a/zk-pow/bindings/go/src/plain.rs
+++ b/zk-pow/bindings/go/src/plain.rs
@@ -9,7 +9,7 @@ use std::slice;
 
 use zk_pow::api::proof::IncompleteBlockHeader;
 use zk_pow::api::verify;
-use zk_pow::ffi::plain_proof::PlainProof;
+use zk_pow::ffi::plain_proof::{check_cert_version_eligible, PlainProof};
 
 use crate::common::{catch_panic, copy_prove_result, set_error_msg, zk_prove, CZKProof};
 
@@ -17,6 +17,7 @@ use crate::common::{catch_panic, copy_prove_result, set_error_msg, zk_prove, CZK
 /// checked against `nbits_override` (the pool share target; 0 = use the header's own nbits, i.e. a
 /// full-block check). The header's nbits is NOT modified — the proof commitment is derived from the
 /// header including its nbits, so it must stay what the miner mined. blake3-only (no plonky2).
+/// `cert_version` selects the noise-seed derivation and gates eligibility (MoE requires >= 2).
 /// Returns 0 = accepted, 1 = rejected, 2 = bad input / panic; the reason is written to `error_msg_out`.
 ///
 /// # Warning
@@ -28,6 +29,7 @@ pub unsafe extern "C" fn verify_plain_proof_ffi(
     block_header: *const IncompleteBlockHeader,
     pp_bytes: *const u8,
     pp_len: usize,
+    cert_version: u32,
     nbits_override: u32,
     error_msg_out: *mut c_char,
 ) -> i32 {
@@ -43,8 +45,12 @@ pub unsafe extern "C" fn verify_plain_proof_ffi(
             Ok(p) => p,
             Err(e) => return (1, format!("deserialize: {e}")),
         };
+        let version = match check_cert_version_eligible(cert_version, &pp) {
+            Ok(v) => v,
+            Err(e) => return (1, format!("rejected: {e}")),
+        };
         let nover = if nbits_override == 0 { None } else { Some(nbits_override) };
-        match verify::verify_plain_proof(&header, &pp, nover) {
+        match verify::verify_plain_proof(&header, &pp, nover, version.seed_derivation()) {
             Ok(()) => (0, "accepted".to_string()),
             Err(e) => (1, format!("rejected: {e}")),
         }
@@ -63,7 +69,8 @@ pub unsafe extern "C" fn verify_plain_proof_ffi(
 }
 
 /// Generate a plonky2 ZK certificate from a (bincode) PlainProof — the master's block-finalization
-/// step (EXPENSIVE; needs the circuit cache). Fills `zk_proof_out`: `public_data_len` + `public_data`
+/// step (EXPENSIVE; needs the circuit cache). `cert_version` is as in `verify_plain_proof_ffi`.
+/// Fills `zk_proof_out`: `public_data_len` + `public_data`
 /// (variable-length; the caller copies `public_data[..public_data_len]` into the block certificate),
 /// and `proof_blob`/`proof_blob_len` (the caller-allocated blob must hold `MAX_ZK_PROOF_SIZE` bytes).
 /// Returns 0 = success, 2 = bad input / prove failure / panic.
@@ -77,6 +84,7 @@ pub unsafe extern "C" fn prove_plain_proof_ffi(
     block_header: *const IncompleteBlockHeader,
     pp_bytes: *const u8,
     pp_len: usize,
+    cert_version: u32,
     zk_proof_out: *mut CZKProof,
     error_msg_out: *mut c_char,
 ) -> i32 {
@@ -105,7 +113,15 @@ pub unsafe extern "C" fn prove_plain_proof_ffi(
         }
     };
 
-    let result = match zk_prove(error_msg_out, header, &pp) {
+    let version = match check_cert_version_eligible(cert_version, &pp) {
+        Ok(v) => v,
+        Err(e) => {
+            set_error_msg(error_msg_out, &format!("cert version: {e}"));
+            return 2;
+        }
+    };
+
+    let result = match zk_prove(error_msg_out, header, &pp, version.seed_derivation()) {
         Some(r) => r,
         None => return 2,
     };
@@ -125,7 +141,7 @@ mod tests {
 
     use bincode::Options;
     use rand_chacha::rand_core::SeedableRng;
-    use zk_pow::api::proof::{MMAType, MiningConfiguration, MoEConfig, PeriodicPattern};
+    use zk_pow::api::proof::{MMAType, MiningConfiguration, MoEConfig, PeriodicPattern, SeedDerivation};
     use zk_pow::ffi::mine::try_mine_one_moe;
 
     use crate::common::{ERROR_MSG_MAX_SIZE, MAX_ZK_PROOF_SIZE, PUBLICDATA_MAX_SIZE};
@@ -159,7 +175,8 @@ mod tests {
         let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0xC0FFEE);
         let mut pp = None;
         for _ in 0..1000 {
-            if let Some(found) = try_mine_one_moe(&mut rng, m, n, k, header, config, None, false).unwrap() {
+            if let Some(found) = try_mine_one_moe(&mut rng, m, n, k, header, config, None, false, SeedDerivation::Legacy).unwrap()
+            {
                 pp = Some(found);
                 break;
             }
@@ -189,14 +206,14 @@ mod tests {
         let (header, pp_bytes) = mine_plain_proof_bytes();
         let mut err = [0 as c_char; ERROR_MSG_MAX_SIZE];
 
-        // 1. cheap blake3 share verify
-        let code = unsafe { verify_plain_proof_ffi(&header, pp_bytes.as_ptr(), pp_bytes.len(), 0, err.as_mut_ptr()) };
+        // 1. cheap blake3 share verify (V2 = legacy derivation)
+        let code = unsafe { verify_plain_proof_ffi(&header, pp_bytes.as_ptr(), pp_bytes.len(), 2, 0, err.as_mut_ptr()) };
         assert_eq!(code, 0, "verify_plain_proof_ffi rejected a valid proof: {}", err_str(&err));
 
         // 2. plonky2 prove into a caller-allocated CZKProof
         let mut blob = vec![0u8; MAX_ZK_PROOF_SIZE];
         let mut zk = new_czkproof(&mut blob);
-        let code = unsafe { prove_plain_proof_ffi(&header, pp_bytes.as_ptr(), pp_bytes.len(), &mut zk, err.as_mut_ptr()) };
+        let code = unsafe { prove_plain_proof_ffi(&header, pp_bytes.as_ptr(), pp_bytes.len(), 2, &mut zk, err.as_mut_ptr()) };
         assert_eq!(code, 0, "prove_plain_proof_ffi failed: {}", err_str(&err));
         assert!(zk.proof_blob_len > 0, "empty proof blob");
         assert!(zk.public_data_len >= 24, "V2 public_data too short: {}", zk.public_data_len);
@@ -220,7 +237,7 @@ mod tests {
         let mut zk = new_czkproof(&mut blob);
         let mut err = [0 as c_char; ERROR_MSG_MAX_SIZE];
 
-        let code = unsafe { prove_plain_proof_ffi(&header, garbage.as_ptr(), garbage.len(), &mut zk, err.as_mut_ptr()) };
+        let code = unsafe { prove_plain_proof_ffi(&header, garbage.as_ptr(), garbage.len(), 2, &mut zk, err.as_mut_ptr()) };
         assert_eq!(code, 2, "expected bad-input code 2, got {}: {}", code, err_str(&err));
     }
 }

--- a/zk-pow/bindings/go/src/verify.rs
+++ b/zk-pow/bindings/go/src/verify.rs
@@ -7,7 +7,7 @@ use std::os::raw::c_char;
 use std::slice;
 
 use crate::common::MAX_ZK_PROOF_SIZE;
-use zk_pow::api::proof::{IncompleteBlockHeader, PublicProofParams, ZKProof};
+use zk_pow::api::proof::{IncompleteBlockHeader, PublicProofParams, SeedDerivation, ZKProof};
 use zk_pow::api::sanity_checks;
 use zk_pow::api::verify;
 
@@ -27,6 +27,7 @@ unsafe fn verify_zk_proof_inner(
     block_header: *const IncompleteBlockHeader,
     zk_proof: *const CZKProof,
     nbits_override: Option<u32>,
+    seed_derivation: SeedDerivation,
     error_msg_out: *mut c_char,
 ) -> i32 {
     // Wrap in catch_unwind to prevent panics from crossing FFI boundary
@@ -58,7 +59,7 @@ unsafe fn verify_zk_proof_inner(
 
         let plonky2_proof = slice::from_raw_parts(zk_proof_ref.proof_blob, zk_proof_ref.proof_blob_len);
         let public_data = &zk_proof_ref.public_data[..zk_proof_ref.public_data_len];
-        let (params, zk_proof) = match ZKProof::deserialize(*block_header, public_data, plonky2_proof) {
+        let (params, zk_proof) = match ZKProof::deserialize(*block_header, seed_derivation, public_data, plonky2_proof) {
             Ok(r) => r,
             Err(e) => {
                 set_error_msg(error_msg_out, &format!("{}", e));
@@ -117,7 +118,7 @@ pub unsafe extern "C" fn verify_zk_proof_v2(
     zk_proof: *const CZKProof,
     error_msg_out: *mut c_char,
 ) -> i32 {
-    verify_zk_proof_inner(block_header, zk_proof, None, error_msg_out)
+    verify_zk_proof_inner(block_header, zk_proof, None, SeedDerivation::Legacy, error_msg_out)
 }
 
 /// Verify a ZK proof against public parameters, overriding the difficulty with the given nbits.
@@ -141,7 +142,40 @@ pub unsafe extern "C" fn verify_zk_proof_v2_with_nbits(
     nbits_override: u32,
     error_msg_out: *mut c_char,
 ) -> i32 {
-    verify_zk_proof_inner(block_header, zk_proof, Some(nbits_override), error_msg_out)
+    verify_zk_proof_inner(
+        block_header,
+        zk_proof,
+        Some(nbits_override),
+        SeedDerivation::Legacy,
+        error_msg_out,
+    )
+}
+
+/// `verify_zk_proof_v2` with the salted (V3) noise-seed derivation.
+#[no_mangle]
+pub unsafe extern "C" fn verify_zk_proof_v3(
+    block_header: *const IncompleteBlockHeader,
+    zk_proof: *const CZKProof,
+    error_msg_out: *mut c_char,
+) -> i32 {
+    verify_zk_proof_inner(block_header, zk_proof, None, SeedDerivation::Salted, error_msg_out)
+}
+
+/// `verify_zk_proof_v3` with the difficulty from `nbits_override`.
+#[no_mangle]
+pub unsafe extern "C" fn verify_zk_proof_v3_with_nbits(
+    block_header: *const IncompleteBlockHeader,
+    zk_proof: *const CZKProof,
+    nbits_override: u32,
+    error_msg_out: *mut c_char,
+) -> i32 {
+    verify_zk_proof_inner(
+        block_header,
+        zk_proof,
+        Some(nbits_override),
+        SeedDerivation::Salted,
+        error_msg_out,
+    )
 }
 
 /// Check wire `public_data` against the rank-penalty rule.

--- a/zk-pow/src/api/mod.rs
+++ b/zk-pow/src/api/mod.rs
@@ -2,4 +2,5 @@ pub mod proof;
 pub mod proof_utils;
 pub mod prove;
 pub mod sanity_checks;
+pub mod seed;
 pub mod verify;

--- a/zk-pow/src/api/proof.rs
+++ b/zk-pow/src/api/proof.rs
@@ -71,6 +71,8 @@ pub struct MiningConfiguration {
     pub moe: Option<MoEConfig>,
 }
 
+pub use crate::api::seed::SeedDerivation;
+
 /// Plaintext public parameters associated with a proof and are required for verification.
 ///
 /// On the wire (`to_wire_bytes` / `from_wire_bytes`) serialized in little-endian:
@@ -82,6 +84,8 @@ pub struct MiningConfiguration {
 #[derive(Debug, Clone)]
 pub struct PublicProofParams {
     pub block_header: IncompleteBlockHeader,
+    /// Noise-seed derivation context (from the certificate version); not on the wire.
+    pub seed_derivation: SeedDerivation,
     pub mining_config: MiningConfiguration,
     // job_key = blake3(block_header || mining_config)
     pub hash_a: Hash256, // blake3(A, key=job_key)

--- a/zk-pow/src/api/proof_utils.rs
+++ b/zk-pow/src/api/proof_utils.rs
@@ -9,7 +9,7 @@ use primitive_types::U256;
 
 use crate::api::proof::{
     Hash256, IncompleteBlockHeader, MINING_CONFIG_RESERVED_SIZE, MMAType, MiningConfiguration, MoEConfig, MoEParams,
-    PeriodicPattern, PrivateProofParams, PublicProofParams, ZKProof,
+    PeriodicPattern, PrivateProofParams, PublicProofParams, SeedDerivation, ZKProof,
 };
 use crate::api::sanity_checks::public_params_sanity_check;
 use crate::circuit::chip::blake3::program::{AuxiliaryCvLocation, AuxiliaryMsgLocation, BlakeProgram};
@@ -356,12 +356,16 @@ impl PublicProofParams {
     ///
     /// In the MoE setting `hash_a` is replaced by `hash_activations = blake3(hash_a || hash_router)`,
     /// so the routing affects A's noise seed without an extra chained hash.
+    ///
+    /// Under [`SeedDerivation::Salted`] the raw roots are salted first (MoE:
+    /// A is salted *before* the routing fold); the chain itself is unchanged.
     pub fn commitment_hash(&self, job_key: Hash256) -> (Hash256, Hash256) {
+        let (hash_a, hash_b) = self.seed_derivation.bind_roots(&self.hash_a, &self.hash_b, self.m, self.n);
         let hash_activations = match &self.moe {
-            Some(moe) => compute_hash_activations(&self.hash_a, &moe.hash_routing, &moe.routing_offsets, &job_key),
-            None => self.hash_a,
+            Some(moe) => compute_hash_activations(&hash_a, &moe.hash_routing, &moe.routing_offsets, &job_key),
+            None => hash_a,
         };
-        let b_noise_seed = blake3_digest(&[&job_key[..], &self.hash_b[..]].concat(), None);
+        let b_noise_seed = blake3_digest(&[&job_key[..], &hash_b[..]].concat(), None);
         let a_noise_seed = blake3_digest(&[&b_noise_seed[..], &hash_activations[..]].concat(), None);
 
         (b_noise_seed, a_noise_seed)
@@ -709,6 +713,7 @@ impl PublicProofParams {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         block_header: IncompleteBlockHeader,
+        seed_derivation: SeedDerivation,
         mining_config: MiningConfiguration,
         hash_a: Hash256,
         hash_b: Hash256,
@@ -720,6 +725,7 @@ impl PublicProofParams {
     ) -> Self {
         Self {
             block_header,
+            seed_derivation,
             mining_config,
             hash_a,
             hash_b,
@@ -736,6 +742,7 @@ impl PublicProofParams {
     #[allow(clippy::too_many_arguments)]
     pub fn new_dummy(
         block_header: IncompleteBlockHeader,
+        seed_derivation: SeedDerivation,
         mining_configuration: MiningConfiguration,
         m: u32,
         n: u32,
@@ -744,6 +751,7 @@ impl PublicProofParams {
     ) -> Self {
         Self::new(
             block_header,
+            seed_derivation,
             mining_configuration,
             [1; 32], // dummy hash_a
             [2; 32], // dummy hash_b
@@ -759,6 +767,7 @@ impl PublicProofParams {
     pub fn new_for_tests(m: u32, n: u32, k: u32) -> Self {
         Self::new_dummy(
             IncompleteBlockHeader::new_for_test(0x207FFFFF),
+            SeedDerivation::Legacy,
             MiningConfiguration {
                 common_dim: k,
                 rank: 128,
@@ -792,6 +801,7 @@ mod tests {
                 timestamp: 0,
                 nbits: 0,
             },
+            SeedDerivation::Legacy,
             MiningConfiguration {
                 common_dim: 4096 - 64,
                 rank: 128,
@@ -1058,7 +1068,7 @@ mod tests {
         assert_eq!(bytes.len(), PublicProofParams::WIRE_SIZE);
 
         let proof_blob = [0u8; ZKProof::PROOFDATA_PREAMBLE];
-        let (parsed, _) = ZKProof::deserialize(params.block_header, &bytes, &proof_blob).unwrap();
+        let (parsed, _) = ZKProof::deserialize(params.block_header, SeedDerivation::Legacy, &bytes, &proof_blob).unwrap();
         assert!(parsed.moe.is_none());
         assert_eq!(parsed.hash_a, params.hash_a);
         assert_eq!(parsed.hash_b, params.hash_b);
@@ -1087,7 +1097,7 @@ mod tests {
         assert!(bytes.len() > PublicProofParams::WIRE_SIZE);
 
         let proof_blob = [0u8; ZKProof::PROOFDATA_PREAMBLE];
-        let (parsed, _) = ZKProof::deserialize(params.block_header, &bytes, &proof_blob).unwrap();
+        let (parsed, _) = ZKProof::deserialize(params.block_header, SeedDerivation::Legacy, &bytes, &proof_blob).unwrap();
         let moe_config = parsed.mining_config.moe.as_ref().unwrap();
         assert_eq!(moe_config.e, 4);
         assert_eq!(moe_config.top_k, 4);
@@ -1203,7 +1213,11 @@ impl PublicProofParams {
     /// `hash_routing(32)` | `outer_count(u8)` | `outer_indices(u32 LE each)`.
     /// `e` and `top_k` come from `mining_config.moe` (committed in the job_key).
     /// Each routing offset is a `u32` bounded by `m * top_k < 2^32`, serialized as 4 LE bytes.
-    pub fn from_wire_bytes(block_header: IncompleteBlockHeader, public_data: &[u8]) -> Result<Self> {
+    pub fn from_wire_bytes(
+        block_header: IncompleteBlockHeader,
+        seed_derivation: SeedDerivation,
+        public_data: &[u8],
+    ) -> Result<Self> {
         ensure!(
             public_data.len() >= Self::WIRE_SIZE,
             "public_data too short: need at least {} bytes",
@@ -1298,6 +1312,7 @@ impl PublicProofParams {
 
         let result = Self {
             block_header,
+            seed_derivation,
             mining_config,
             hash_a,
             hash_b,
@@ -1458,10 +1473,11 @@ impl ZKProof {
     /// `proof_data` layout: `pow_bits(3) | rate_bits(3) | zeta(16) | plonky2_proof`
     pub fn deserialize(
         block_header: IncompleteBlockHeader,
+        seed_derivation: SeedDerivation,
         public_data: &[u8],
         proof_data: &[u8],
     ) -> Result<(PublicProofParams, Self)> {
-        let params = PublicProofParams::from_wire_bytes(block_header, public_data)?;
+        let params = PublicProofParams::from_wire_bytes(block_header, seed_derivation, public_data)?;
         let zk_proof = Self::from_bytes(proof_data)?;
         Ok((params, zk_proof))
     }

--- a/zk-pow/src/api/prove.rs
+++ b/zk-pow/src/api/prove.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use plonky2_field::goldilocks_field::GoldilocksField;
 
-use crate::api::proof::{IncompleteBlockHeader, MiningConfiguration, PublicProofParams};
+use crate::api::proof::{IncompleteBlockHeader, MiningConfiguration, PublicProofParams, SeedDerivation};
 use crate::api::proof::{PrivateProofParams, ZKProof};
 use crate::api::proof_utils::u32_field_array_to_hash;
 use crate::circuit::circuit_utils::CircuitCache;
@@ -22,9 +22,10 @@ pub fn zk_prove_plain_proof(
     proof: &PlainProof,
     cache: &mut CircuitCache,
     sanity_check: bool,
+    seed_derivation: SeedDerivation,
 ) -> Result<ProveResult> {
     // Convert PlainProof to proof parameters
-    let (private, public) = proof.parse_proof(block_header)?;
+    let (private, public) = proof.parse_proof(block_header, seed_derivation)?;
     if sanity_check {
         public.sanity_check_private_params(&private)?;
     }
@@ -102,7 +103,8 @@ pub fn warmup_prove(mining_configuration: MiningConfiguration, cache: &mut Circu
 
     let m = mining_configuration.rows_pattern.max() + 1;
     let n = mining_configuration.cols_pattern.max() + 1;
-    let mut public_params = PublicProofParams::new_dummy(block_header, mining_configuration, m, n, 0, 0);
+    // Seed values don't affect circuit shape, so warming up under Legacy covers both derivations.
+    let mut public_params = PublicProofParams::new_dummy(block_header, SeedDerivation::Legacy, mining_configuration, m, n, 0, 0);
     let private_params = public_params.fill_dummy_merkle_proof(private_params)?;
 
     let _ = prove_block(&mut public_params, private_params, cache)?;

--- a/zk-pow/src/api/seed.rs
+++ b/zk-pow/src/api/seed.rs
@@ -1,0 +1,137 @@
+//! Salted (certificate V3) Merkle-root pre-hashing and the seed-derivation
+//! selector. The seed chain lives in `PublicProofParams::commitment_hash`.
+
+use crate::api::proof::Hash256;
+use pearl_blake3::blake3_digest;
+
+/// How the noise seeds are derived from the Merkle roots. Selected by the
+/// certificate version; never serialized (the wire always carries raw roots).
+/// No `Default`: a silent default would verify under the wrong rules.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedDerivation {
+    /// Pre-V3 chain: `b_noise_seed = blake3(job_key || hash_b)`, etc.
+    Legacy,
+    /// V3 chain: roots are salted via [`bind_root_a`]/[`bind_root_b`] before
+    /// the (unchanged) seed chain.
+    Salted,
+}
+
+impl SeedDerivation {
+    pub fn bind_roots(self, hash_a: &Hash256, hash_b: &Hash256, m: u32, n: u32) -> (Hash256, Hash256) {
+        match self {
+            Self::Legacy => (*hash_a, *hash_b),
+            Self::Salted => (bind_root_a(hash_a, m), bind_root_b(hash_b, n)),
+        }
+    }
+}
+
+/// Domain-separation salt for A's root: `blake3("pearl/cert-v3/noise-seed/A")`.
+/// Hardcoded so consensus doesn't depend on runtime string hashing (re-derived in a test).
+pub const SEED_SALT_A: Hash256 = [
+    0x82, 0x49, 0x40, 0x6c, 0xa0, 0xed, 0x15, 0x16, 0x96, 0x16, 0xf6, 0x92, 0xfc, 0xf0, 0x76, 0xf8, 0x92, 0xdb, 0xdb, 0x2a, 0x70,
+    0x23, 0xb8, 0x52, 0xf0, 0xd4, 0x77, 0x19, 0xc3, 0x90, 0x01, 0x7b,
+];
+
+/// Domain-separation salt for B's root: `blake3("pearl/cert-v3/noise-seed/B")`.
+pub const SEED_SALT_B: Hash256 = [
+    0x11, 0x30, 0x06, 0x32, 0xec, 0x63, 0x01, 0xca, 0x2b, 0xe2, 0xaf, 0x71, 0x8b, 0x3f, 0x4d, 0x4f, 0x1a, 0xe9, 0xc6, 0x39, 0x88,
+    0xe8, 0xcc, 0x04, 0x48, 0x44, 0x30, 0x1d, 0x71, 0xb8, 0x9a, 0xa9,
+];
+
+/// `root || dim(u32 LE) || 28 zero bytes` — a single 64-byte BLAKE3 block.
+fn bind_message(root: &Hash256, dim: u32) -> [u8; 64] {
+    let mut msg = [0u8; 64];
+    msg[..32].copy_from_slice(root);
+    msg[32..36].copy_from_slice(&dim.to_le_bytes());
+    msg
+}
+
+/// V3 salting of A's Merkle root: `blake3(hash_a || pad32(m), key=SEED_SALT_A)`.
+/// Commits the row count `m`.
+pub fn bind_root_a(hash_a: &Hash256, m: u32) -> Hash256 {
+    blake3_digest(&bind_message(hash_a, m), Some(SEED_SALT_A))
+}
+
+/// V3 salting of B's Merkle root: `blake3(hash_b || pad32(n), key=SEED_SALT_B)`.
+/// Commits the column count `n` (the per-expert `n_e` in MoE; `e` rides on the job_key).
+pub fn bind_root_b(hash_b: &Hash256, n: u32) -> Hash256 {
+    blake3_digest(&bind_message(hash_b, n), Some(SEED_SALT_B))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::proof::{MoEParams, PublicProofParams};
+
+    #[test]
+    fn seed_salts_match_context_strings() {
+        assert_eq!(SEED_SALT_A, blake3_digest(b"pearl/cert-v3/noise-seed/A", None));
+        assert_eq!(SEED_SALT_B, blake3_digest(b"pearl/cert-v3/noise-seed/B", None));
+    }
+
+    /// Pinned vectors (independently computed with Python `blake3`).
+    #[test]
+    fn commitment_hash_pinned_vectors() {
+        let job_key = [0x11u8; 32];
+        let cases = [
+            (
+                SeedDerivation::Legacy,
+                [
+                    0xad, 0xd6, 0xf7, 0xea, 0x5f, 0xee, 0xbf, 0x89, 0xc8, 0xa7, 0x7e, 0x2e, 0xbf, 0xa0, 0xd8, 0x24, 0x42, 0xe7,
+                    0xdb, 0xb0, 0x04, 0x6d, 0xbd, 0x48, 0x97, 0x18, 0x61, 0xd1, 0x2f, 0xcb, 0x01, 0x77,
+                ],
+                [
+                    0x48, 0x3b, 0x07, 0xb6, 0xf7, 0x31, 0x05, 0x03, 0x0b, 0x94, 0x82, 0x25, 0x5f, 0x37, 0x72, 0x3f, 0x3f, 0xed,
+                    0x69, 0xae, 0x91, 0x67, 0x24, 0xee, 0x82, 0x91, 0x84, 0x8b, 0x8c, 0x28, 0x79, 0x4b,
+                ],
+            ),
+            (
+                SeedDerivation::Salted,
+                [
+                    0x60, 0xed, 0x9b, 0x73, 0xc5, 0xa9, 0x59, 0x9b, 0x20, 0x0b, 0x6c, 0xd5, 0x63, 0xe7, 0xf0, 0xd5, 0xd9, 0xa6,
+                    0x7d, 0x24, 0x02, 0xd8, 0x5f, 0xd4, 0xef, 0x96, 0x6c, 0x58, 0x00, 0x80, 0xd0, 0xe5,
+                ],
+                [
+                    0x30, 0x17, 0x84, 0x16, 0x80, 0x05, 0xec, 0x83, 0x3a, 0xb0, 0xaa, 0x60, 0x00, 0x6f, 0x7f, 0xe7, 0xfa, 0xaa,
+                    0x95, 0x30, 0x7d, 0x8c, 0x1f, 0xc6, 0x81, 0x9b, 0x2f, 0xfd, 0xd7, 0x17, 0xec, 0xcf,
+                ],
+            ),
+        ];
+        for (derivation, expected_b, expected_a) in cases {
+            let mut p = PublicProofParams::new_for_tests(192, 320, 256);
+            p.seed_derivation = derivation;
+            p.hash_a = [0xAA; 32];
+            p.hash_b = [0xBB; 32];
+            let (b, a) = p.commitment_hash(job_key);
+            assert_eq!(b, expected_b, "{derivation:?} b_noise_seed changed — consensus break");
+            assert_eq!(a, expected_a, "{derivation:?} a_noise_seed changed — consensus break");
+        }
+    }
+
+    #[test]
+    fn commitment_hash_pinned_vector_salted_moe() {
+        let mut p = PublicProofParams::new_for_tests(192, 320, 256);
+        p.seed_derivation = SeedDerivation::Salted;
+        p.hash_a = [0xAA; 32];
+        p.hash_b = [0xBB; 32];
+        p.moe = Some(MoEParams {
+            expert_idx: 0,
+            routing_offsets: vec![3, 5, 9, 12],
+            hash_routing: [0xCC; 32],
+            outer_indices: vec![],
+        });
+
+        let (b, a) = p.commitment_hash([0x11u8; 32]);
+        // B's seed does not involve the routing fold, so it matches the dense salted vector.
+        let expected_b = [
+            0x60, 0xed, 0x9b, 0x73, 0xc5, 0xa9, 0x59, 0x9b, 0x20, 0x0b, 0x6c, 0xd5, 0x63, 0xe7, 0xf0, 0xd5, 0xd9, 0xa6, 0x7d,
+            0x24, 0x02, 0xd8, 0x5f, 0xd4, 0xef, 0x96, 0x6c, 0x58, 0x00, 0x80, 0xd0, 0xe5,
+        ];
+        let expected_a = [
+            0x26, 0x8a, 0x2e, 0xb7, 0x8b, 0x3b, 0x2d, 0x2f, 0xea, 0xd2, 0x62, 0x22, 0x1b, 0x24, 0xc6, 0x34, 0x6d, 0x0a, 0x6d,
+            0x20, 0x18, 0x90, 0xa4, 0x67, 0x75, 0x1f, 0x62, 0x3b, 0x7e, 0xac, 0xd5, 0xc2,
+        ];
+        assert_eq!(b, expected_b, "salted MoE b_noise_seed changed — consensus break");
+        assert_eq!(a, expected_a, "salted MoE a_noise_seed changed — consensus break");
+    }
+}

--- a/zk-pow/src/api/verify.rs
+++ b/zk-pow/src/api/verify.rs
@@ -4,7 +4,7 @@ use plonky2_field::goldilocks_field::GoldilocksField;
 
 use crate::{
     api::{
-        proof::{IncompleteBlockHeader, PublicProofParams, ZKProof},
+        proof::{IncompleteBlockHeader, PublicProofParams, SeedDerivation, ZKProof},
         proof_utils::{CompiledPublicParams, compute_jackpot_hash, hash_to_u32_field_array},
         sanity_checks::check_jackpot_against_nbits,
     },
@@ -102,9 +102,10 @@ pub fn verify_plain_proof(
     block_header: &IncompleteBlockHeader,
     plain_proof: &PlainProof,
     nbits_override: Option<u32>,
+    seed_derivation: SeedDerivation,
 ) -> Result<()> {
     // Parse the plain proof to get private and public params
-    let (private_params, mut public_params) = plain_proof.parse_proof(*block_header)?;
+    let (private_params, mut public_params) = plain_proof.parse_proof(*block_header, seed_derivation)?;
 
     // Perform public params sanity check
     public_params.sanity_check()?;

--- a/zk-pow/src/bin/prove_verify.rs
+++ b/zk-pow/src/bin/prove_verify.rs
@@ -9,7 +9,7 @@ use log::info;
 use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use std::time::Instant;
-use zk_pow::api::proof::MoEConfig;
+use zk_pow::api::proof::{MoEConfig, SeedDerivation};
 use zk_pow::api::{
     proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, PeriodicPattern, PrivateProofParams, PublicProofParams},
     prove, verify,
@@ -83,6 +83,7 @@ fn setup(
 
     let mut public_params = PublicProofParams::new_dummy(
         block_header,
+        SeedDerivation::Legacy,
         mining_configuration,
         6144, // m: rows of A
         4096, // n: columns of B
@@ -226,7 +227,8 @@ fn test_ffi_mine_prove_verify_with_rank(rank: u16, is_moe: bool) {
 
     // Step 1: Mine using FFI (same path as Python)
     let start = Instant::now();
-    let pow_proof: PlainProof = mine_moe(m, n, k, block_header, mining_config, None, false).expect("Mining failed");
+    let pow_proof: PlainProof =
+        mine_moe(m, n, k, block_header, mining_config, None, false, SeedDerivation::Legacy).expect("Mining failed");
 
     info!("Mining took {:?}", start.elapsed());
 
@@ -246,7 +248,9 @@ fn test_ffi_mine_prove_verify_with_rank(rank: u16, is_moe: bool) {
 
     // Step 2: Parse plain proof to get private/public params
     let start = Instant::now();
-    let (private_params, mut public_params) = pow_proof.parse_proof(block_header).expect("Failed to parse plain proof");
+    let (private_params, mut public_params) = pow_proof
+        .parse_proof(block_header, SeedDerivation::Legacy)
+        .expect("Failed to parse plain proof");
     info!("Parsing took {:?}", start.elapsed());
 
     // Step 3: Prove

--- a/zk-pow/src/circuit/compat_test.rs
+++ b/zk-pow/src/circuit/compat_test.rs
@@ -6,7 +6,7 @@ mod test {
     use std::io::Write;
     use std::path::Path;
 
-    use crate::api::proof::{PublicProofParams, ZKProof};
+    use crate::api::proof::{PublicProofParams, SeedDerivation, ZKProof};
     use crate::api::{prove, verify};
     use crate::circuit::pearl_circuit::{PearlRecursion, RecursionCircuit};
     use crate::circuit::pearl_stark::PearlStark;
@@ -147,7 +147,9 @@ mod test {
     fn starky_hash(block_header: IncompleteBlockHeader, plain_proof: &PlainProof) -> String {
         use starky::stark::Stark;
 
-        let (private_params, public_params) = plain_proof.parse_proof(block_header).expect("Failed to parse plain proof");
+        let (private_params, public_params) = plain_proof
+            .parse_proof(block_header, SeedDerivation::Legacy)
+            .expect("Failed to parse plain proof");
 
         let mut hasher = blake3::Hasher::new();
 
@@ -243,9 +245,19 @@ mod test {
 
     fn generate_plain_proof(p: &Params) -> PlainProof {
         let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0xdeadbeef);
-        try_mine_one(&mut rng, p.m, p.n, p.k, p.block_header, p.mining_config, None, false)
-            .unwrap()
-            .unwrap()
+        try_mine_one(
+            &mut rng,
+            p.m,
+            p.n,
+            p.k,
+            p.block_header,
+            p.mining_config,
+            None,
+            false,
+            SeedDerivation::Legacy,
+        )
+        .unwrap()
+        .unwrap()
     }
 
     fn starky_fingerprint() -> String {
@@ -260,7 +272,8 @@ mod test {
 
         let p = params();
         let plain_proof = generate_plain_proof(&p);
-        let result = prove::zk_prove_plain_proof(p.block_header, &plain_proof, &mut cache, false).expect("Proving failed");
+        let result = prove::zk_prove_plain_proof(p.block_header, &plain_proof, &mut cache, false, SeedDerivation::Legacy)
+            .expect("Proving failed");
 
         let mut f = std::fs::File::create(proof_path).unwrap();
         f.write_all(&result.public_data).unwrap();
@@ -283,7 +296,8 @@ mod test {
         let public_data = &buffer[..PublicProofParams::WIRE_SIZE];
         let proof_data = &buffer[PublicProofParams::WIRE_SIZE..];
 
-        let (public_params, proof) = ZKProof::deserialize(params.block_header, public_data, proof_data).unwrap();
+        let (public_params, proof) =
+            ZKProof::deserialize(params.block_header, SeedDerivation::Legacy, public_data, proof_data).unwrap();
 
         let mut cache = <PearlRecursion as RecursionCircuit>::CircuitCache::default();
         verify::verify_block(&public_params, &proof, &mut cache).expect("Proof must verify");
@@ -332,14 +346,15 @@ mod test {
         let (header, config, m, n, k) = moe_params();
         let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0xcafe_babe);
         let plain_proof = loop {
-            let proof = try_mine_one_moe(&mut rng, m, n, k, header, config, None, false).unwrap();
+            let proof = try_mine_one_moe(&mut rng, m, n, k, header, config, None, false, SeedDerivation::Legacy).unwrap();
             if let Some(p) = proof {
                 break p;
             }
         };
 
         let mut cache = <PearlRecursion as RecursionCircuit>::CircuitCache::default();
-        let result = prove::zk_prove_plain_proof(header, &plain_proof, &mut cache, false).expect("MoE proving failed");
+        let result = prove::zk_prove_plain_proof(header, &plain_proof, &mut cache, false, SeedDerivation::Legacy)
+            .expect("MoE proving failed");
 
         let mut f = std::fs::File::create(proof_path).unwrap();
         f.write_all(&(result.public_data.len() as u32).to_le_bytes()).unwrap();
@@ -364,7 +379,7 @@ mod test {
         let public_data = &buffer[4..4 + public_data_len];
         let proof_data = &buffer[4 + public_data_len..];
 
-        let (public_params, proof) = ZKProof::deserialize(header, public_data, proof_data).unwrap();
+        let (public_params, proof) = ZKProof::deserialize(header, SeedDerivation::Legacy, public_data, proof_data).unwrap();
         assert!(public_params.moe.is_some(), "MoE fixture must have moe params");
 
         let mut cache = <PearlRecursion as RecursionCircuit>::CircuitCache::default();

--- a/zk-pow/src/circuit/pearl_noise.rs
+++ b/zk-pow/src/circuit/pearl_noise.rs
@@ -176,7 +176,7 @@ pub fn compute_noise(params: &CompiledPublicParams) -> MMSlice {
 mod tests {
     use crate::api::proof::PublicProofParams;
     #[cfg(debug_assertions)]
-    use crate::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, PeriodicPattern};
+    use crate::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, PeriodicPattern, SeedDerivation};
 
     use super::*;
 
@@ -268,7 +268,7 @@ mod tests {
             moe: None,
         };
 
-        let params = PublicProofParams::new_dummy(block_header, mining_configuration, 1024, 768, 0, 0);
+        let params = PublicProofParams::new_dummy(block_header, SeedDerivation::Legacy, mining_configuration, 1024, 768, 0, 0);
 
         compute_noise(&CompiledPublicParams::from(&params)); // Should panic in debug mode
     }
@@ -288,7 +288,7 @@ mod tests {
             moe: None,
         };
 
-        let params = PublicProofParams::new_dummy(block_header, mining_configuration, 1024, 768, 0, 0);
+        let params = PublicProofParams::new_dummy(block_header, SeedDerivation::Legacy, mining_configuration, 1024, 768, 0, 0);
 
         compute_noise(&CompiledPublicParams::from(&params)); // Should panic in debug mode
     }

--- a/zk-pow/src/ffi/mine.rs
+++ b/zk-pow/src/ffi/mine.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use primitive_types::U256;
 use rand::Rng;
 
-use crate::api::proof::{IncompleteBlockHeader, MiningConfiguration, PeriodicPattern};
+use crate::api::proof::{IncompleteBlockHeader, MiningConfiguration, PeriodicPattern, SeedDerivation};
 use crate::api::proof_utils::{compute_hash_activations, compute_jackpot_hash};
 use crate::api::sanity_checks::extract_difficulty_bound;
 use crate::circuit::pearl_noise::compute_noise_for_indices;
@@ -25,6 +25,7 @@ pub fn try_mine_one<R: Rng>(
     config: MiningConfiguration,
     signal_range: Option<(i8, i8)>,
     wrong_jackpot_hash: bool,
+    seed_derivation: SeedDerivation,
 ) -> Result<Option<PlainProof>> {
     let rank = config.rank as usize;
     let (signal_min, signal_max) = signal_range.unwrap_or((SIGNAL_MIN, SIGNAL_MAX));
@@ -45,7 +46,15 @@ pub fn try_mine_one<R: Rng>(
 
     let a_row_major = pearl_blake3::pad_to_chunk_boundary(&flatten_matrix(&a_matrix));
     let b_col_major = pearl_blake3::pad_to_chunk_boundary(&flatten_matrix(&b_transposed));
-    let (b_noise_seed, a_noise_seed) = compute_commitment_hash(&job_key, &a_row_major, &b_col_major);
+    let (b_noise_seed, a_noise_seed, _) = compute_commitment_hash_with_offsets(
+        &job_key,
+        &a_row_major,
+        &b_col_major,
+        None,
+        seed_derivation,
+        m as u32,
+        n as u32,
+    );
 
     // Compute noise using shared implementation from pearl_noise
     let a_all_rows: Vec<usize> = (0..m).collect();
@@ -128,10 +137,21 @@ pub fn try_mine_one_moe<R: Rng>(
     config: MiningConfiguration,
     signal_range: Option<(i8, i8)>,
     wrong_jackpot_hash: bool,
+    seed_derivation: SeedDerivation,
 ) -> Result<Option<PlainProof>> {
     // If we are in the non-moe case, mine via the original function.
     if config.moe.is_none() {
-        return try_mine_one(rng, m, n, k, header, config, signal_range, wrong_jackpot_hash);
+        return try_mine_one(
+            rng,
+            m,
+            n,
+            k,
+            header,
+            config,
+            signal_range,
+            wrong_jackpot_hash,
+            seed_derivation,
+        );
     }
 
     let moe_cfg = config.moe.unwrap();
@@ -182,8 +202,15 @@ pub fn try_mine_one_moe<R: Rng>(
         }
     }
 
-    let (b_noise_seed, a_noise_seed, routing_end_offsets) =
-        compute_commitment_hash_with_offsets(&job_key, &a_row_major, &b_col_major, Some(&routing[..]));
+    let (b_noise_seed, a_noise_seed, routing_end_offsets) = compute_commitment_hash_with_offsets(
+        &job_key,
+        &a_row_major,
+        &b_col_major,
+        Some(&routing[..]),
+        seed_derivation,
+        m as u32,
+        n as u32,
+    );
 
     // Compute noise using shared implementation from pearl_noise
     let a_all_rows: Vec<usize> = (0..m).collect();
@@ -298,17 +325,29 @@ pub fn mine(
     config: MiningConfiguration,
     signal_range: Option<(i8, i8)>,
     wrong_jackpot_hash: bool,
+    seed_derivation: SeedDerivation,
 ) -> Result<PlainProof> {
     let mut rng = rand::rng();
 
     loop {
-        let proof = try_mine_one(&mut rng, m, n, k, header, config, signal_range, wrong_jackpot_hash)?;
+        let proof = try_mine_one(
+            &mut rng,
+            m,
+            n,
+            k,
+            header,
+            config,
+            signal_range,
+            wrong_jackpot_hash,
+            seed_derivation,
+        )?;
         if let Some(proof) = proof {
             return Ok(proof);
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn mine_moe(
     m: usize,
     n: usize,
@@ -317,11 +356,22 @@ pub fn mine_moe(
     config: MiningConfiguration,
     signal_range: Option<(i8, i8)>,
     wrong_jackpot_hash: bool,
+    seed_derivation: SeedDerivation,
 ) -> Result<PlainProof> {
     let mut rng = rand::rng();
 
     loop {
-        let proof = try_mine_one_moe(&mut rng, m, n, k, header, config, signal_range, wrong_jackpot_hash)?;
+        let proof = try_mine_one_moe(
+            &mut rng,
+            m,
+            n,
+            k,
+            header,
+            config,
+            signal_range,
+            wrong_jackpot_hash,
+            seed_derivation,
+        )?;
         if let Some(proof) = proof {
             return Ok(proof);
         }
@@ -385,21 +435,22 @@ fn compute_job_key(header: &IncompleteBlockHeader, config: &MiningConfiguration)
     blake3_digest(&data, None)
 }
 
-fn compute_commitment_hash(job_key: &[u8; 32], a_row_major: &[u8], b_col_major: &[u8]) -> ([u8; 32], [u8; 32]) {
-    let (b_seed, a_seed, _) = compute_commitment_hash_with_offsets(job_key, a_row_major, b_col_major, None);
-
-    (b_seed, a_seed)
-}
-
 type MoECaseOutputs = ([u8; 32], [u8; 32], Vec<u32>);
+/// Miner-side noise-seed derivation; must match `PublicProofParams::commitment_hash`
+/// (MoE: A is salted before the routing fold, `n` is the per-expert dimension).
+#[allow(clippy::too_many_arguments)]
 fn compute_commitment_hash_with_offsets(
     job_key: &[u8; 32],
     a_row_major: &[u8],
     b_col_major: &[u8],
     opt_routing: Option<&[Vec<u32>]>,
+    seed_derivation: SeedDerivation,
+    m: u32,
+    n: u32,
 ) -> MoECaseOutputs {
-    let hash_a = blake3_digest(a_row_major, Some(*job_key));
-    let hash_b = blake3_digest(b_col_major, Some(*job_key));
+    let raw_hash_a = blake3_digest(a_row_major, Some(*job_key));
+    let raw_hash_b = blake3_digest(b_col_major, Some(*job_key));
+    let (hash_a, hash_b) = seed_derivation.bind_roots(&raw_hash_a, &raw_hash_b, m, n);
 
     let (hash_activations, routing_offsets) = match opt_routing {
         Some(r) => {
@@ -546,14 +597,22 @@ mod tests {
         let b_col_major = pearl_blake3::pad_to_chunk_boundary(&[2u8; 100]);
 
         // Miner side.
-        let (b_mine, a_mine, offsets) =
-            compute_commitment_hash_with_offsets(&job_key, &a_row_major, &b_col_major, Some(&routing));
+        let (b_mine, a_mine, offsets) = compute_commitment_hash_with_offsets(
+            &job_key,
+            &a_row_major,
+            &b_col_major,
+            Some(&routing),
+            SeedDerivation::Legacy,
+            0,
+            0,
+        );
 
         // Verifier side: take `hash_routing` from the actual routing Merkle proof root
         // (what the wire carries), then recompute the seeds via the canonical path.
         let hash_routing = build_routing_proof(&routing, &job_key, 1, &[0]).proof.root;
         let params = PublicProofParams {
             block_header: IncompleteBlockHeader::new_for_test(0x207FFFFF),
+            seed_derivation: SeedDerivation::Legacy,
             mining_config: MiningConfiguration {
                 common_dim: 1024,
                 rank: 32,
@@ -602,7 +661,7 @@ mod tests {
             cols_pattern: PeriodicPattern::from_list(&[0, 1, 8, 9, 32, 33, 40, 41, 64, 65, 72, 73, 96, 97, 104, 105]).unwrap(),
             moe: Some(MoEConfig { e: e as u16, top_k: 1 }),
         };
-        let proof = mine_moe(m, n, k as usize, header, config, None, false).unwrap();
-        verify_plain_proof(&header, &proof, None).unwrap();
+        let proof = mine_moe(m, n, k as usize, header, config, None, false, SeedDerivation::Legacy).unwrap();
+        verify_plain_proof(&header, &proof, None, SeedDerivation::Legacy).unwrap();
     }
 }

--- a/zk-pow/src/ffi/plain_proof.rs
+++ b/zk-pow/src/ffi/plain_proof.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::proof::{
     IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, MoEParams, PeriodicPattern, PrivateProofParams,
-    PublicProofParams,
+    PublicProofParams, SeedDerivation,
 };
 use crate::circuit::chip::blake3::program::{AuxiliaryCvLocation, AuxiliaryMsgLocation, ProofSource, routing_blake_hotspot_rows};
 use crate::circuit::utils::macros::ensure_eq;
@@ -162,6 +162,19 @@ pub enum CertificateVersion {
     ZkDense = 1,
     /// V2: MoE and dense proofs.
     ZkMoe = 2,
+    /// V3: same wire layout as V2, salted noise-seed derivation.
+    ZkV3 = 3,
+}
+
+impl CertificateVersion {
+    /// The noise-seed derivation this certificate version mandates. This is the
+    /// single version→derivation mapping; the `api` layer only sees [`SeedDerivation`].
+    pub fn seed_derivation(self) -> SeedDerivation {
+        match self {
+            Self::ZkDense | Self::ZkMoe => SeedDerivation::Legacy,
+            Self::ZkV3 => SeedDerivation::Salted,
+        }
+    }
 }
 
 impl TryFrom<u32> for CertificateVersion {
@@ -171,6 +184,7 @@ impl TryFrom<u32> for CertificateVersion {
         match version {
             v if v == Self::ZkDense as u32 => Ok(Self::ZkDense),
             v if v == Self::ZkMoe as u32 => Ok(Self::ZkMoe),
+            v if v == Self::ZkV3 as u32 => Ok(Self::ZkV3),
             v => bail!("unknown certificate version: {v}"),
         }
     }
@@ -453,7 +467,11 @@ impl PlainProof {
     }
 
     /// Converts plain proof to Rust proof types, checks a,bt merkle roots match provided hashes.
-    pub fn parse_proof(&self, header: IncompleteBlockHeader) -> Result<(PrivateProofParams, PublicProofParams)> {
+    pub fn parse_proof(
+        &self,
+        header: IncompleteBlockHeader,
+        seed_derivation: SeedDerivation,
+    ) -> Result<(PrivateProofParams, PublicProofParams)> {
         let (m, n, k) = (self.m, self.n, self.k);
 
         for &tok in &self.a.row_indices {
@@ -466,6 +484,7 @@ impl PlainProof {
 
         let public = PublicProofParams {
             block_header: header,
+            seed_derivation,
             mining_config: MiningConfiguration {
                 common_dim: k as u32,
                 rank: self.noise_rank as u16,
@@ -647,8 +666,25 @@ mod tests {
     }
 
     #[test]
+    fn both_proof_kinds_eligible_under_v3() {
+        for proof in [dense_proof(), moe_proof()] {
+            assert_eq!(
+                check_cert_version_eligible(CertificateVersion::ZkV3 as u32, &proof).unwrap(),
+                CertificateVersion::ZkV3
+            );
+        }
+    }
+
+    #[test]
+    fn seed_derivation_mapping() {
+        assert_eq!(CertificateVersion::ZkDense.seed_derivation(), SeedDerivation::Legacy);
+        assert_eq!(CertificateVersion::ZkMoe.seed_derivation(), SeedDerivation::Legacy);
+        assert_eq!(CertificateVersion::ZkV3.seed_derivation(), SeedDerivation::Salted);
+    }
+
+    #[test]
     fn unknown_cert_versions_rejected() {
-        for version in [0u32, 3, u32::MAX] {
+        for version in [0u32, 4, u32::MAX] {
             assert!(check_cert_version_eligible(version, &dense_proof()).is_err());
         }
     }

--- a/zk-pow/src/v1/compat_test.rs
+++ b/zk-pow/src/v1/compat_test.rs
@@ -145,12 +145,24 @@ mod test {
         };
         let main_header = crate::api::proof::IncompleteBlockHeader::new_for_test(0x1D2FFFFF);
         let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(0xdeadbeef);
-        let plain_proof = crate::ffi::mine::try_mine_one(&mut rng, m, n, k, main_header, main_config, None, false)
-            .unwrap()
-            .unwrap();
+        let plain_proof = crate::ffi::mine::try_mine_one(
+            &mut rng,
+            m,
+            n,
+            k,
+            main_header,
+            main_config,
+            None,
+            false,
+            crate::api::proof::SeedDerivation::Legacy,
+        )
+        .unwrap()
+        .unwrap();
 
         // Parse with main module to get public/private params for hashing
-        let (private_params, public_params) = plain_proof.parse_proof(main_header).unwrap();
+        let (private_params, public_params) = plain_proof
+            .parse_proof(main_header, crate::api::proof::SeedDerivation::Legacy)
+            .unwrap();
 
         let mut hasher = blake3::Hasher::new();
         hasher.update(&public_params.block_header.to_bytes());

--- a/zk-pow/tests/moe_test.rs
+++ b/zk-pow/tests/moe_test.rs
@@ -8,7 +8,9 @@
 
 use rand_chacha::rand_core::SeedableRng;
 
-use zk_pow::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern, ZKProof};
+use zk_pow::api::proof::{
+    IncompleteBlockHeader, MMAType, MiningConfiguration, MoEConfig, PeriodicPattern, SeedDerivation, ZKProof,
+};
 use zk_pow::api::{prove, verify};
 use zk_pow::circuit::chip::blake3::program::{BLOCK_LEN, routing_blake_hotspot_rows};
 use zk_pow::circuit::circuit_utils::CircuitCache;
@@ -53,7 +55,18 @@ fn moe_params() -> MoETestParams {
 fn mine_moe_proof(p: &MoETestParams, seed: u64) -> PlainProof {
     let mut rng = rand_chacha::ChaCha20Rng::seed_from_u64(seed);
     loop {
-        let proof = try_mine_one_moe(&mut rng, p.m, p.n, p.k, p.header, p.config, None, false).unwrap();
+        let proof = try_mine_one_moe(
+            &mut rng,
+            p.m,
+            p.n,
+            p.k,
+            p.header,
+            p.config,
+            None,
+            false,
+            SeedDerivation::Legacy,
+        )
+        .unwrap();
         if let Some(proof) = proof {
             return proof;
         }
@@ -63,7 +76,7 @@ fn mine_moe_proof(p: &MoETestParams, seed: u64) -> PlainProof {
 /// Prove an MoE proof end-to-end and return the serialized result.
 fn prove_moe(p: &MoETestParams, moe_proof: &PlainProof) -> prove::ProveResult {
     let mut cache = CircuitCache::default();
-    prove::zk_prove_plain_proof(p.header, moe_proof, &mut cache, true).expect("MoE proving failed")
+    prove::zk_prove_plain_proof(p.header, moe_proof, &mut cache, true, SeedDerivation::Legacy).expect("MoE proving failed")
 }
 
 // =============================================================================
@@ -76,7 +89,8 @@ fn test_moe_prove_verify() {
     let moe_proof = mine_moe_proof(&p, 0xdeadbeef);
     let result = prove_moe(&p, &moe_proof);
 
-    let (public_params, zk_proof) = ZKProof::deserialize(p.header, &result.public_data, &result.proof_data).unwrap();
+    let (public_params, zk_proof) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &result.public_data, &result.proof_data).unwrap();
 
     let mut cache = CircuitCache::default();
     verify::verify_block(&public_params, &zk_proof, &mut cache).expect("MoE proof must verify");
@@ -111,7 +125,7 @@ fn test_moe_routing_not_multiple_of_64_parse() {
     let p = moe_params_routing_not_multiple_of_64();
     let moe_proof = mine_moe_proof(&p, 0x51515151);
 
-    let (private, public) = moe_proof.parse_proof(p.header).unwrap();
+    let (private, public) = moe_proof.parse_proof(p.header, SeedDerivation::Legacy).unwrap();
     public.sanity_check().unwrap();
     public.sanity_check_private_params(&private).unwrap();
 }
@@ -124,7 +138,8 @@ fn test_moe_routing_not_multiple_of_64_prove_verify() {
     let moe_proof = mine_moe_proof(&p, 0x51515151);
     let result = prove_moe(&p, &moe_proof);
 
-    let (public_params, zk_proof) = ZKProof::deserialize(p.header, &result.public_data, &result.proof_data).unwrap();
+    let (public_params, zk_proof) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &result.public_data, &result.proof_data).unwrap();
     let mut cache = CircuitCache::default();
     verify::verify_block(&public_params, &zk_proof, &mut cache).expect("non-64-aligned routing must verify");
 }
@@ -141,7 +156,8 @@ fn test_moe_wrong_public_outer_indices_fails_verification() {
     let moe_proof = mine_moe_proof(&p, 0xcafebabe);
     let result = prove_moe(&p, &moe_proof);
 
-    let (mut public_params, _) = ZKProof::deserialize(p.header, &result.public_data, &result.proof_data).unwrap();
+    let (mut public_params, _) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &result.public_data, &result.proof_data).unwrap();
 
     let moe = public_params.moe.as_mut().unwrap();
     for idx in moe.outer_indices.iter_mut() {
@@ -149,7 +165,8 @@ fn test_moe_wrong_public_outer_indices_fails_verification() {
     }
 
     let tampered_public_data = public_params.to_wire_bytes().unwrap();
-    let (tampered_params, zk_proof) = ZKProof::deserialize(p.header, &tampered_public_data, &result.proof_data).unwrap();
+    let (tampered_params, zk_proof) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &tampered_public_data, &result.proof_data).unwrap();
 
     let mut cache = CircuitCache::default();
     let err = verify::verify_block(&tampered_params, &zk_proof, &mut cache).unwrap_err();
@@ -177,7 +194,7 @@ fn test_moe_corrupted_routing_root_fails_parse() {
 
     moe_proof.moe = Some(moe);
 
-    moe_proof.parse_proof(p.header).unwrap();
+    moe_proof.parse_proof(p.header, SeedDerivation::Legacy).unwrap();
 }
 
 // =============================================================================
@@ -196,7 +213,7 @@ fn test_moe_routing_outer_index_mismatch_fails_parse() {
     assert!(len >= 1, "Need at least 1 row index");
     moe_proof.a.row_indices[len - 1] += 1;
 
-    moe_proof.parse_proof(p.header).unwrap();
+    moe_proof.parse_proof(p.header, SeedDerivation::Legacy).unwrap();
 }
 
 // =============================================================================
@@ -208,7 +225,7 @@ fn test_moe_roundtrip_parse_only() {
     let p = moe_params();
     let moe_proof = mine_moe_proof(&p, 0xdeadbeef);
 
-    let (private, public) = moe_proof.parse_proof(p.header).unwrap();
+    let (private, public) = moe_proof.parse_proof(p.header, SeedDerivation::Legacy).unwrap();
 
     let moe = public.moe.as_ref().unwrap();
     assert_eq!(moe.outer_indices.len(), moe_proof.a.row_indices.len());
@@ -241,13 +258,15 @@ fn test_moe_tampered_hash_routing_fails() {
     let moe_proof = mine_moe_proof(&p, 0xabcdef01);
     let result = prove_moe(&p, &moe_proof);
 
-    let (mut public_params, _) = ZKProof::deserialize(p.header, &result.public_data, &result.proof_data).unwrap();
+    let (mut public_params, _) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &result.public_data, &result.proof_data).unwrap();
 
     let moe = public_params.moe.as_mut().unwrap();
     moe.hash_routing[0] ^= 0xFF;
 
     let tampered_data = public_params.to_wire_bytes().unwrap();
-    let (tampered_params, zk_proof) = ZKProof::deserialize(p.header, &tampered_data, &result.proof_data).unwrap();
+    let (tampered_params, zk_proof) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &tampered_data, &result.proof_data).unwrap();
 
     let mut cache = CircuitCache::default();
     let err = verify::verify_block(&tampered_params, &zk_proof, &mut cache).unwrap_err();
@@ -278,7 +297,7 @@ fn test_moe_wrong_routing_start_offset_fails_parse() {
     moe.routing_end_offsets[moe.expert_idx as usize - 1] += 1;
     moe_proof.moe = Some(moe);
 
-    moe_proof.parse_proof(p.header).unwrap();
+    moe_proof.parse_proof(p.header, SeedDerivation::Legacy).unwrap();
 }
 
 // =============================================================================
@@ -526,7 +545,8 @@ fn run_moe_prove_verify(p: &MoETestParams, seed: u64) {
         offset % 16
     );
 
-    let (public_params, zk_proof) = ZKProof::deserialize(p.header, &result.public_data, &result.proof_data).unwrap();
+    let (public_params, zk_proof) =
+        ZKProof::deserialize(p.header, SeedDerivation::Legacy, &result.public_data, &result.proof_data).unwrap();
     let mut cache = CircuitCache::default();
     verify::verify_block(&public_params, &zk_proof, &mut cache).expect("MoE proof must verify");
 }
@@ -611,7 +631,7 @@ fn test_moe_prove_verify_e5_top_k3() {
 fn test_moe_outer_index_exceeding_26_bits_fails() {
     let p = moe_params();
     let moe_proof = mine_moe_proof(&p, 0xdeadbeef);
-    let (private_params, mut public_params) = moe_proof.parse_proof(p.header).unwrap();
+    let (private_params, mut public_params) = moe_proof.parse_proof(p.header, SeedDerivation::Legacy).unwrap();
 
     // Set the last outer_index to 2^26, which exceeds the 26-bit range.
     // Each outer index is split into two 13-bit limbs that are range-checked


### PR DESCRIPTION
## Summary

- **Salted Noise-Seed Derivation**: Updates Blake3 commitment hash calculations to use domain-separated salted hashing for noise-seed derivation (`hash_a` and `hash_b`).
- **Certificate Version V3 & Protocol Version 2**: Introduces `wire.CertificateVersionV3`, bumps `wire.ProtocolVersion` to 2, and enforces strict version cutovers in block validation logic.
- **Cross-Component Alignment**: Updates CUDA GEMM kernels in `pearl-gemm`, `zk-pow` Rust library & FFI bindings, `py-pearl-mining`, and gateway/miner RPC schemas.
- **Activation Heights**: Configured activation heights across networks: MainNet (`98900`), TestNet (`38648`), TestNet2 (`83109`), and active from genesis on RegTest & SimNet (`1`).
- **Documentation & Tests**: Includes node and library unit tests, pinned vector assertions, and upgrade documentation in `docs/salted-seed-fork-upgrade-guide.md`.

## Test plan

- [x] Verified Go unit tests in `node/chaincfg`, `node/blockchain`, `node/peer`, `node/wire`, and `node/zkpow`
- [x] Verified Rust unit tests and pinned vector checks in `zk-pow`
- [x] Verified clean rebase and zero conflicts against `master`