### PR TITLE
fix(zkpow): pin Merkle tree leaf counts to declared dimensions

### DIFF
--- a/.github/workflows/miner_heavy_ci.yml
+++ b/.github/workflows/miner_heavy_ci.yml
@@ -93,9 +93,6 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          # Build the approved checkout above. Without this the action uses the
-          # Git context, which on pull_request_target is the base branch, so the
-          # job never tested PR code.
           context: .
           file: ./miner/vllm-miner/Dockerfile
           push: false

--- a/.github/workflows/miner_heavy_ci.yml
+++ b/.github/workflows/miner_heavy_ci.yml
@@ -93,6 +93,10 @@ jobs:
       - name: Build Docker image
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
+          # Build the approved checkout above. Without this the action uses the
+          # Git context, which on pull_request_target is the base branch, so the
+          # job never tested PR code.
+          context: .
           file: ./miner/vllm-miner/Dockerfile
           push: false
 

--- a/docs/salted-seed-fork-upgrade-guide.md
+++ b/docs/salted-seed-fork-upgrade-guide.md
@@ -23,7 +23,7 @@ from the V2 (MoE) ZK certificate to the new V3 (salted noise-seed) certificate.
 
 ---
 
-## Step 1: Upgrade your node to v1.4.1
+## Step 1: Upgrade your node to v1.4.0
 
 Safe to do at any time before the fork. The node stays fully compatible with V2 blocks
 and shares until the fork height.

--- a/docs/salted-seed-fork-upgrade-guide.md
+++ b/docs/salted-seed-fork-upgrade-guide.md
@@ -23,7 +23,7 @@ from the V2 (MoE) ZK certificate to the new V3 (salted noise-seed) certificate.
 
 ---
 
-## Step 1: Upgrade your node to v1.4.0
+## Step 1: Upgrade your node to v1.4.1
 
 Safe to do at any time before the fork. The node stays fully compatible with V2 blocks
 and shares until the fork height.
@@ -37,7 +37,7 @@ hardcode the fork height.
 Deploy before the fork height, or every block you build after the fork is rejected.
 
 If you followed the MoE fork guide and use the certificate-version dispatchers, you
-only need the new `pearl-mining` package (v0.3.0) — the dispatchers accept version 3:
+only need the new `pearl-mining` package (v0.3.1) — the dispatchers accept version 3:
 
 - `check_cert_version_eligible`, `generate_proof_for_cert_version`,
   `verify_proof_for_cert_version`, and `verify_plain_proof_for_cert_version` handle

--- a/miner/miner-base/src/miner_base/commitment_hash.py
+++ b/miner/miner-base/src/miner_base/commitment_hash.py
@@ -43,6 +43,8 @@ class CommitmentHasher:
         B: torch.Tensor,
         incomplete_header_bytes: bytes,
         mining_config: MiningConfiguration,
+        *,
+        salted_dims: tuple[int, int] | None,
     ) -> CommitmentHash:
         key = cls.get_key(incomplete_header_bytes, mining_config)
         merkle_tree_A = MatrixMerkleTree(A, key)
@@ -50,7 +52,9 @@ class CommitmentHasher:
         # We hash B.T because we would like to expose a column strip of B
         merkle_tree_B = MatrixMerkleTree(B.T, key)
 
-        return cls.commitment_hash_from_merkle_roots(merkle_tree_A.root, merkle_tree_B.root, key)
+        return cls.commitment_hash_from_merkle_roots(
+            merkle_tree_A.root, merkle_tree_B.root, key, salted_dims=salted_dims
+        )
 
     @staticmethod
     def get_commitment_B_key(key: bytes, B_merkle_root: bytes) -> bytes:
@@ -81,8 +85,10 @@ class CommitmentHasher:
         *,
         routing_root: bytes | None = None,
         offsets_root: bytes | None = None,
-        salted_dims: tuple[int, int] | None = None,
+        salted_dims: tuple[int, int] | None,
     ) -> CommitmentHash:
+        # salted_dims has no default so callers must choose a derivation explicitly:
+        # (m, n) for V3 salted seeds, None for the legacy (V1/V2) chain.
         # V3 (salted) derivation: salt each root before the MoE routing fold.
         if salted_dims is not None:
             m, n = salted_dims

--- a/miner/miner-base/tests/test_commitment_hash.py
+++ b/miner/miner-base/tests/test_commitment_hash.py
@@ -28,7 +28,9 @@ class TestCommitmentHasher:
         A = torch.randint(-128, 127, (8, 8), dtype=torch.int8)
         B = torch.randint(-128, 127, (8, 8), dtype=torch.int8)
 
-        result = CommitmentHasher.commitment_hash(A, B, incomplete_header_bytes, mining_config)
+        result = CommitmentHasher.commitment_hash(
+            A, B, incomplete_header_bytes, mining_config, salted_dims=None
+        )
 
         assert isinstance(result, CommitmentHash)
         assert len(result.noise_seed_A) == 32
@@ -39,8 +41,12 @@ class TestCommitmentHasher:
         A = torch.randint(-128, 127, (8, 8), dtype=torch.int8)
         B = torch.randint(-128, 127, (8, 8), dtype=torch.int8)
 
-        result1 = CommitmentHasher.commitment_hash(A, B, incomplete_header_bytes, mining_config)
-        result2 = CommitmentHasher.commitment_hash(A, B, incomplete_header_bytes, mining_config)
+        result1 = CommitmentHasher.commitment_hash(
+            A, B, incomplete_header_bytes, mining_config, salted_dims=None
+        )
+        result2 = CommitmentHasher.commitment_hash(
+            A, B, incomplete_header_bytes, mining_config, salted_dims=None
+        )
 
         assert result1 == result2
 
@@ -50,8 +56,12 @@ class TestCommitmentHasher:
         A = torch.zeros((8, 8), dtype=torch.int8)
         B = torch.ones((8, 8), dtype=torch.int8)
 
-        result1 = CommitmentHasher.commitment_hash(A, B, incomplete_header_bytes, mining_config)
-        result2 = CommitmentHasher.commitment_hash(B, A, incomplete_header_bytes, mining_config)
+        result1 = CommitmentHasher.commitment_hash(
+            A, B, incomplete_header_bytes, mining_config, salted_dims=None
+        )
+        result2 = CommitmentHasher.commitment_hash(
+            B, A, incomplete_header_bytes, mining_config, salted_dims=None
+        )
 
         assert result1 != result2
 
@@ -62,14 +72,14 @@ class TestCommitmentHasher:
         tensor_1d = torch.randint(-128, 127, (8,), dtype=torch.int8)
         with pytest.raises(ValueError, match="Expected 2D tensor"):
             CommitmentHasher.commitment_hash(
-                tensor_1d, tensor_1d, incomplete_header_bytes, mining_config
+                tensor_1d, tensor_1d, incomplete_header_bytes, mining_config, salted_dims=None
             )
 
         # 3D tensor
         tensor_3d = torch.randint(-128, 127, (8, 8, 3), dtype=torch.int8)
         with pytest.raises(ValueError, match="Expected 2D tensor"):
             CommitmentHasher.commitment_hash(
-                tensor_3d, tensor_3d, incomplete_header_bytes, mining_config
+                tensor_3d, tensor_3d, incomplete_header_bytes, mining_config, salted_dims=None
             )
 
 
@@ -115,6 +125,7 @@ class TestSaltedSeedDerivation:
             root_a,
             root_b,
             job_key,
+            salted_dims=None,
         )
         assert (
             result.noise_seed_B.hex()
@@ -175,6 +186,7 @@ class TestSaltedSeedDerivation:
             bind_root_a(root_a, matrix_rows),
             bind_root_b(root_b, matrix_columns),
             job_key,
+            salted_dims=None,
             **moe_roots,
         )
         salted = CommitmentHasher.commitment_hash_from_merkle_roots(

--- a/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
@@ -177,7 +177,10 @@ class CommitmentHashFromMerkleRootsKernel {
       rBlock(i) = root[i];
       out(i) = salt[i];
     }
-    rBlock(blake3::CHAINING_VALUE_SIZE_U32) = dim;
+    // Local copy: passing the host constexpr straight into the tensor's
+    // const-ref operator() ODR-uses it, which nvcc rejects in device code.
+    constexpr int kDimWordIdx = blake3::CHAINING_VALUE_SIZE_U32;
+    rBlock(kDimWordIdx) = dim;
     blake3::compress_msg_block_u32(rBlock, out,
                                    blake3::COMPRESS_PARAMS_SINGLE_BLOCK_KEYED);
   }

--- a/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
@@ -177,8 +177,8 @@ class CommitmentHashFromMerkleRootsKernel {
       rBlock(i) = root[i];
       out(i) = salt[i];
     }
-    constexpr int kDimWordIdx = blake3::CHAINING_VALUE_SIZE_U32;
-    rBlock(kDimWordIdx) = dim;
+    // Int<> index: any odr-use of the host constexpr trips nvcc in device code.
+    rBlock(Int<blake3::CHAINING_VALUE_SIZE_U32>{}) = dim;
     blake3::compress_msg_block_u32(rBlock, out,
                                    blake3::COMPRESS_PARAMS_SINGLE_BLOCK_KEYED);
   }

--- a/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
@@ -177,8 +177,6 @@ class CommitmentHashFromMerkleRootsKernel {
       rBlock(i) = root[i];
       out(i) = salt[i];
     }
-    // Local copy: passing the host constexpr straight into the tensor's
-    // const-ref operator() ODR-uses it, which nvcc rejects in device code.
     constexpr int kDimWordIdx = blake3::CHAINING_VALUE_SIZE_U32;
     rBlock(kDimWordIdx) = dim;
     blake3::compress_msg_block_u32(rBlock, out,

--- a/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
+++ b/miner/pearl-gemm/csrc/tensor_hash/commitment_hash_from_merkle_roots_kernel.hpp
@@ -177,7 +177,6 @@ class CommitmentHashFromMerkleRootsKernel {
       rBlock(i) = root[i];
       out(i) = salt[i];
     }
-    // Int<> index: any odr-use of the host constexpr trips nvcc in device code.
     rBlock(Int<blake3::CHAINING_VALUE_SIZE_U32>{}) = dim;
     blake3::compress_msg_block_u32(rBlock, out,
                                    blake3::COMPRESS_PARAMS_SINGLE_BLOCK_KEYED);

--- a/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
+++ b/miner/pearl-gemm/src/pearl_gemm/pearl_gemm_interface.py
@@ -586,9 +586,14 @@ def commitment_hash_from_merkle_roots(
     B_commitment_hash,
     routing_root=None,
     offsets_hash=None,
-    salted_dims: tuple[int, int] | None = None,
+    *,
+    salted_dims: tuple[int, int] | None,
 ):
-    """Compute commitment hashes from 2D-tensor Merkle roots."""
+    """Compute commitment hashes from 2D-tensor Merkle roots.
+
+    salted_dims has no default so callers must choose a derivation explicitly:
+    (m, n) for V3 salted seeds, None for the legacy (V1/V2) chain.
+    """
     salted_dim_a, salted_dim_b = salted_dims if salted_dims is not None else (None, None)
     return pearl_gemm_cuda.commitment_hash_from_merkle_roots(
         A_merkle_root,

--- a/miner/pearl-gemm/src/pearl_gemm/test_components.py
+++ b/miner/pearl-gemm/src/pearl_gemm/test_components.py
@@ -56,13 +56,15 @@ def commitment_hash_from_merkle_roots(
     commitment_hash_B: torch.Tensor,
     routing_root: torch.Tensor | None = None,
     offsets_hash: torch.Tensor | None = None,
-    salted_dims: tuple[int, int] | None = None,
+    *,
+    salted_dims: tuple[int, int] | None,
 ):
     """
     Compute the commitment hash from merkle roots of a 2D tensor.
 
     routing_root and offsets_hash are optional paired MoE inputs; omitting both
-    selects the dense path.
+    selects the dense path. salted_dims has no default so callers must choose a
+    derivation explicitly: (m, n) for V3 salted seeds, None for legacy (V1/V2).
     """
     salted_dim_a, salted_dim_b = salted_dims if salted_dims is not None else (None, None)
     return torch.ops.pearl_gemm.commitment_hash_from_merkle_roots(

--- a/miner/pearl-gemm/tests/test_tensor_hash.py
+++ b/miner/pearl-gemm/tests/test_tensor_hash.py
@@ -99,7 +99,7 @@ class TestTensorHash:
         cuda_result_A = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
         cuda_result_B = torch.empty(blake3.digest_size, dtype=torch.uint8, device="cuda")
         commitment_hash_from_merkle_roots(
-            A_merkle_root, B_merkle_root, key, cuda_result_A, cuda_result_B
+            A_merkle_root, B_merkle_root, key, cuda_result_A, cuda_result_B, salted_dims=None
         )
         torch.cuda.synchronize()
 
@@ -142,6 +142,7 @@ class TestTensorHash:
             cuda_result_B,
             routing_root=routing_root,
             offsets_hash=offsets_hash,
+            salted_dims=None,
         )
         torch.cuda.synchronize()
 
@@ -151,6 +152,7 @@ class TestTensorHash:
             key.cpu().numpy().tobytes(),
             routing_root=routing_root.cpu().numpy().tobytes(),
             offsets_root=offsets_root,
+            salted_dims=None,
         )
 
         assert cuda_result_A.cpu().numpy().tobytes() == reference.noise_seed_A, (

--- a/py-pearl-mining/Cargo.lock
+++ b/py-pearl-mining/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "py-pearl-mining"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "blake3",
  "env_logger 0.10.2",

--- a/py-pearl-mining/Cargo.toml
+++ b/py-pearl-mining/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-pearl-mining"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Unified Python bindings for Pearl mining (blake3 merkle trees + ZK proof)"
 

--- a/py-pearl-mining/pyproject.toml
+++ b/py-pearl-mining/pyproject.toml
@@ -11,7 +11,7 @@ dev = [
 
 [project]
 name = "py-pearl-mining"
-version = "0.3.0"
+version = "0.3.1"
 requires-python = ">=3.12"
 description = "Unified Python bindings for Pearl mining"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2579,7 +2579,7 @@ wheels = [
 
 [[package]]
 name = "py-pearl-mining"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "py-pearl-mining" }
 
 [package.dev-dependencies]

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 1
+	Patch uint = 0
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 0
+	Patch uint = 1
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/zk-pow/src/ffi/plain_proof.rs
+++ b/zk-pow/src/ffi/plain_proof.rs
@@ -413,6 +413,63 @@ impl PlainProof {
         if let Some(moe) = &self.moe { self.n * moe.e } else { self.n }
     }
 
+    /// Leaf count the Merkle tree of a row-major byte buffer whose length is the
+    /// product of `dims` must declare. Errors if the product overflows `usize`.
+    fn expected_merkle_leaves(dims: &[usize]) -> Result<usize> {
+        let bytes = dims
+            .iter()
+            .try_fold(1usize, |acc, &d| acc.checked_mul(d))
+            .ok_or_else(|| anyhow::anyhow!("declared dimensions {dims:?} overflow usize"))?;
+        Ok(pearl_blake3::padded_chunk_len(bytes) / BLAKE3_CHUNK_LEN)
+    }
+
+    /// Rejects a proof whose committed Merkle trees don't have the leaf count
+    /// implied by the declared dimensions.
+    ///
+    /// The V3 noise seed is salted with the declared `m`/`n`, making them
+    /// consensus-critical: without pinning each tree's `total_leaves` to those
+    /// dimensions a miner could open one committed tree under several dimension
+    /// interpretations. The A/B trees are row-major `m*k` / `total_b_cols*k`
+    /// int8 bytes; the MoE routing tree is `m*top_k` little-endian `u32`s.
+    fn check_declared_tree_sizes(&self) -> Result<()> {
+        let a_expected = Self::expected_merkle_leaves(&[self.m, self.k])?;
+        ensure_eq!(
+            self.a.proof.total_leaves,
+            a_expected,
+            "A Merkle tree declares {} leaves but m={} k={} imply {}",
+            self.a.proof.total_leaves,
+            self.m,
+            self.k,
+            a_expected
+        );
+
+        let b_expected = Self::expected_merkle_leaves(&[self.total_b_cols(), self.k])?;
+        ensure_eq!(
+            self.bt.proof.total_leaves,
+            b_expected,
+            "B^T Merkle tree declares {} leaves but n={} k={} (total columns {}) imply {}",
+            self.bt.proof.total_leaves,
+            self.n,
+            self.k,
+            self.total_b_cols(),
+            b_expected
+        );
+
+        if let Some(moe) = &self.moe {
+            let routing_expected = Self::expected_merkle_leaves(&[self.m, moe.top_k, std::mem::size_of::<u32>()])?;
+            ensure_eq!(
+                moe.routing_proof.total_leaves,
+                routing_expected,
+                "routing Merkle tree declares {} leaves but m={} top_k={} imply {}",
+                moe.routing_proof.total_leaves,
+                self.m,
+                moe.top_k,
+                routing_expected
+            );
+        }
+        Ok(())
+    }
+
     /// Derives the inner A/B index lists used to build the periodic patterns,
     /// plus the public `MoEParams` (when this is an MoE proof).
     fn moe_inner_indices(&self) -> Result<(Vec<u32>, Vec<u32>, Option<MoEParams>)> {
@@ -473,6 +530,10 @@ impl PlainProof {
         seed_derivation: SeedDerivation,
     ) -> Result<(PrivateProofParams, PublicProofParams)> {
         let (m, n, k) = (self.m, self.n, self.k);
+
+        // Pin the committed trees to the declared dimensions before those
+        // dimensions flow into the (salted) noise-seed derivation.
+        self.check_declared_tree_sizes()?;
 
         for &tok in &self.a.row_indices {
             ensure!(tok < m, "routing entry {} out of range for t={}", tok, m);
@@ -719,5 +780,36 @@ mod tests {
         let mut bytes = bincode::serialize(&dense_proof()).unwrap();
         bytes.extend_from_slice(&[0x01, 0x02]);
         assert!(PlainProof::deserialize_compat(&bytes).is_err());
+    }
+
+    #[test]
+    fn declared_tree_sizes_must_match_padded_leaf_counts() {
+        // m*k = 200*16 = 3200 bytes -> ceil(3200/1024) = 4 leaves for A;
+        // n*k = 4*16 = 64 bytes -> 1 leaf for B^T.
+        let mut proof = PlainProof { m: 200, ..dense_proof() };
+        proof.a.proof.total_leaves = 4;
+        proof.bt.proof.total_leaves = 1;
+        proof.check_declared_tree_sizes().unwrap();
+
+        // Off-by-one in either tree is rejected.
+        proof.a.proof.total_leaves = 3;
+        assert!(proof.check_declared_tree_sizes().is_err());
+        proof.a.proof.total_leaves = 4;
+        proof.bt.proof.total_leaves = 2;
+        assert!(proof.check_declared_tree_sizes().is_err());
+    }
+
+    #[test]
+    fn declared_tree_sizes_check_routing_tree_for_moe() {
+        // m*k = 8*16 = 128 -> 1 leaf; total_b_cols*k = (4*4)*16 = 256 -> 1 leaf;
+        // routing m*top_k*4 = 8*2*4 = 64 -> 1 leaf.
+        let mut proof = moe_proof();
+        proof.a.proof.total_leaves = 1;
+        proof.bt.proof.total_leaves = 1;
+        proof.moe.as_mut().unwrap().routing_proof.total_leaves = 1;
+        proof.check_declared_tree_sizes().unwrap();
+
+        proof.moe.as_mut().unwrap().routing_proof.total_leaves = 3;
+        assert!(proof.check_declared_tree_sizes().is_err());
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to the salted noise-seed hardfork (#280). That PR made the declared `m`/`n` consensus-critical by salting the V3 noise seed with them (`bind_root_a`/`bind_root_b`), but `PlainProof::parse_proof` never validated that a proof's committed Merkle trees actually have the leaf count those dimensions imply. `MerkleProof::total_leaves` was carried in the proof and, for the A/B trees, never checked against `m`/`n`/`k` at all.

This adds `check_declared_tree_sizes`, called at the top of `parse_proof`, which rejects any plain proof whose:
- **A** tree doesn't declare `padded_chunk_len(m*k)/CHUNK_LEN` leaves,
- **B^T** tree doesn't declare `padded_chunk_len(total_b_cols*k)/CHUNK_LEN` leaves (`total_b_cols = n` dense, `n*e` MoE), or
- **MoE routing** tree doesn't declare `padded_chunk_len(m*top_k*4)/CHUNK_LEN` leaves.

This keeps a miner from opening one committed "carousel" tree under several dimension interpretations. The salted seed already gives each interpretation a distinct seed; this makes the dimension↔tree binding explicit and local rather than emergent. Dimension products use checked arithmetic so adversarial inputs error instead of overflowing.

Honest proofs are unaffected: their trees are built over exactly `padded_chunk_len(bytes)` leaves, which is the same size `compute_external_cvs` already uses to reconstruct the roots.

## Test plan

- [x] `cargo test --lib ffi::plain_proof` — 11 passed, including two new tests covering dense off-by-one rejection and the MoE routing-tree leaf count.
- [x] `rustfmt --check` clean.
- [ ] CI: full `zk-pow` suite (incl. `moe_test` end-to-end mine/parse/verify) to confirm honest proofs still verify.

Made with [Cursor](https://cursor.com)