### PR TITLE
fix(chaincfg): delay mainnet salted seed fork height by 100 blocks & bump 1.4.1

### DIFF
--- a/docs/salted-seed-fork-upgrade-guide.md
+++ b/docs/salted-seed-fork-upgrade-guide.md
@@ -23,7 +23,7 @@ from the V2 (MoE) ZK certificate to the new V3 (salted noise-seed) certificate.
 
 ---
 
-## Step 1: Upgrade your node to v1.4.0
+## Step 1: Upgrade your node to v1.4.1
 
 Safe to do at any time before the fork. The node stays fully compatible with V2 blocks
 and shares until the fork height.

--- a/docs/salted-seed-fork-upgrade-guide.md
+++ b/docs/salted-seed-fork-upgrade-guide.md
@@ -5,7 +5,7 @@ from the V2 (MoE) ZK certificate to the new V3 (salted noise-seed) certificate.
 
 | Network  | Fork height (`SaltedSeedForkHeight`) |
 | -------- | ------------------------------------ |
-| Mainnet  | `98900`                              |
+| Mainnet  | `99000`                              |
 | Testnet  | `38648`                              |
 | Testnet2 | `83109`                              |
 

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -368,7 +368,7 @@ var MainNetParams = Params{
 
 	RankPenaltyForkHeight: 96251,
 
-	SaltedSeedForkHeight: 98900,
+	SaltedSeedForkHeight: 99000,
 
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 0
+	Patch uint = 1
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

- **Mainnet Activation Delay**: Updates `SaltedSeedForkHeight` for Mainnet from `98900` to `99000` (delaying activation by 100 blocks).
- **Version Bump**: Bumps version from `1.4.0` to `1.4.1` in `version/version.go`.
- **Documentation**: Updates `docs/salted-seed-fork-upgrade-guide.md` to reflect the new Mainnet height (`99000`) and node version (`v1.4.1`).

## Test plan

- [x] Verified `node/chaincfg` unit tests pass
- [x] Verified `node/blockchain` salted seed fork tests pass
- [x] Verified `version` package compiles and reports `1.4.1`