### PR TITLE
feat: raise minimum peer protocol version and add checkpoints

### DIFF
--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -370,10 +370,20 @@ var MainNetParams = Params{
 
 	SaltedSeedForkHeight: 99000,
 
-	// Checkpoints ordered from oldest to newest.
+	// Checkpoints ordered from oldest to newest, one per 10000 blocks.
+	// Add the next multiple once it is at least CheckpointConfirmations
+	// deep; denser checkpoints cap how much headers-first sync progress a
+	// peer disconnect can throw away.
 	Checkpoints: []Checkpoint{
+		{10000, newHashFromStr("a3c196fb1c3f7837bbebd69b98fc451d88d48083af98c318c78486d7f1888490")},
+		{20000, newHashFromStr("513270b25c6d538f38b26ecdc014f2a809639ec7ebd3c09e4685675311420273")},
+		{30000, newHashFromStr("fd61132c2ad6c22fa48a8df483bc6b885c12ceeb3fe0a9fa55eb5beb849fac7b")},
+		{40000, newHashFromStr("35aac0e2a1e7f2d54924d584cf423b56f0d72d6770ee8365dc1667dbb5b5b320")},
 		{50000, newHashFromStr("608f32e5390b2ae964c986a53e1be10ba4a640f3ccecf96d6b7838e06cb517ff")},
-		{75000, newHashFromStr("7e415e95db27950a220eae7affb8c3ddf3ddc7b06eb50ef7e5c606bb4be88cf6")},
+		{60000, newHashFromStr("5a7f0590c3a89099b2d0f1509d2186c73bc3d8e2e4a60e7ce4ec236856900dad")},
+		{70000, newHashFromStr("281a3469d55226bb9e1b3ccee06eeb923177817b4cdead75131074b171b215c1")},
+		{80000, newHashFromStr("69d40caca39b3c04ee55589d13cd1c5c546a3eb8712a3367840c5f67ab707cfc")},
+		{90000, newHashFromStr("0738b30bb353820a4f97331d805d134de4321a5fc5c8b2955988e7291a0c8562")},
 	},
 
 	// Consensus rule change deployments.

--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -373,6 +373,7 @@ var MainNetParams = Params{
 	// Checkpoints ordered from oldest to newest.
 	Checkpoints: []Checkpoint{
 		{50000, newHashFromStr("608f32e5390b2ae964c986a53e1be10ba4a640f3ccecf96d6b7838e06cb517ff")},
+		{75000, newHashFromStr("7e415e95db27950a220eae7affb8c3ddf3ddc7b06eb50ef7e5c606bb4be88cf6")},
 	},
 
 	// Consensus rule change deployments.

--- a/node/peer/peer.go
+++ b/node/peer/peer.go
@@ -37,8 +37,10 @@ const (
 	DefaultTrickleInterval = 10 * time.Second
 
 	// MinAcceptableProtocolVersion is the lowest protocol version that a
-	// connected peer may support.
-	MinAcceptableProtocolVersion = 1
+	// connected peer may support. Raise it only after a protocol upgrade
+	// activates; raising it together with wire.ProtocolVersion would
+	// disconnect not-yet-upgraded peers that still share our chain.
+	MinAcceptableProtocolVersion = 2
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 50

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 1
+	Patch uint = 2
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

Post-activation follow-up to the salted noise-seed hardfork (#280, #282): now that the fork is active, peers still speaking protocol version 1 cannot follow the chain, so this ships as the 1.4.2 patch release.

- `feat(chaincfg): add mainnet checkpoint at height 75000` — anchors the post-MoE chain and gives DNS seed height gates a recent floor.
- `feat(peer): raise the minimum peer protocol version to 2` — `peer.MinAcceptableProtocolVersion` is the handshake floor for every component that peers (node, SPV client, both seeders); dead-chain protocol-1 peers are refused at the version handshake and shed from the network.
- `chore: bump version to 1.4.2` — patch release on top of 1.4.1.
- `feat(chaincfg): checkpoint mainnet every 10000 blocks` — replaces the 75000 entry with a uniform 10000–90000 grid (hashes verified against the public [Blockbook index](https://blockbook.pearlresearch.ai/)). Headers on this chain carry ZK certificates and headers-first progress is not persisted across sync-peer disconnects, so denser checkpoints cap how much certified-header download and verification a flaky peer can throw away, and let block download begin sooner during IBD.

### Design notes

- The floor is deliberately decoupled from `wire.ProtocolVersion` (the invariant comment in `peer.go` records the procedure): it is raised only after an upgrade activates, never together with a wire-version bump, so future upgrade windows keep not-yet-upgraded peers connected until their chain actually diverges.
- The node's server-side version check (`node/server.go`) and the standalone dnsseeder both compare against this constant, so they inherit the raise with no further changes.
- Checkpoint cadence going forward: add the next 10000-multiple each release once it is at least `CheckpointConfirmations` (2016) blocks deep (the comment in `params.go` records the policy).

### Testing

`go test -race` on `node/chaincfg`, `node/blockchain`, and `node/peer` (the peer suite exercises the handshake floor), plus a full node build. All nine checkpoint hashes verified byte-for-byte against the Blockbook API; the 50000 entry was cross-checked against the value already shipped, confirming the hash convention. (`TestCheckBlockSanity` fails without the `zkpow` build tag on this machine — pre-existing, unrelated.) The CoreDNS seeder PR stacked on this branch (#278) adds an end-to-end check that a mock peer advertising protocol 1 is refused during the handshake.

### Stacking

#278 (CoreDNS seeder) is rebased onto this branch and consumes both changes: its height gate reads the latest checkpoint and its serving floor is inherited from the peer library. Merge this first.