### PR TITLE
chore: bump pearl-desktop-wallet to 2.0.5 and ignore .omo dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,9 @@ simnet_data
 .cursor
 .aider*
 
+# OpenCode (OhMyOpenCode) work plans/state
+.omo/
+
 # Library .lock file
 miner/blake3-utils/*.lock
 

--- a/apps/apps/pearl-desktop-wallet/package.json
+++ b/apps/apps/pearl-desktop-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pearl/pearl-desktop-wallet",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Pearl Desktop Wallet - A modern cryptocurrency wallet application",
   "author": {
     "name": "Pearl Research Labs",


### PR DESCRIPTION
## Summary

Bumps the Pearl desktop wallet package version from 2.0.4 to 2.0.5 and adds the `.omo/` directory (OpenCode work state) to the root `.gitignore`.

## Type

chore

## Scope

wallet, repo

## Changes

- Add `.omo/` to the root `.gitignore` so OpenCode (OhMyOpenCode) work plans/state are not tracked.
- Bump `apps/apps/pearl-desktop-wallet/package.json` version from `2.0.4` to `2.0.5`.

## Test plan

- [ ] Existing tests pass (`task test`)
- [x] No behavioral code changes; version string and gitignore only.