### PR TITLE
docs: require identity verification in bug bounty terms

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -95,6 +95,9 @@ Indicative rewards by severity (as determined by us):
 - **No entitlement.** Submission of a report does not create any right,
   claim, or expectation to a reward. Duplicate, out-of-scope, low-quality,
   or previously known issues may receive no award.
+- **Identity verification.** To comply with applicable U.S. sanctions laws
+  and regulations, Contributors may be required to disclose and verify their
+  identity.
 
 Submit reports through the process described in
 [Reporting a Vulnerability](#reporting-a-vulnerability).


### PR DESCRIPTION
## Summary

Add U.S. sanctions compliance language to the bug bounty program terms, requiring contributors to disclose and verify their identity when applicable.

## Type

docs

## Scope

SECURITY.md

## Changes

- Add identity verification bullet to the Terms section of the bug bounty policy

## Test plan

- [x] Existing tests pass (`task test`)
- [ ] New tests added (if applicable) — N/A, documentation-only change