### PR TITLE
fix(zkpow): reject usize->u32/u16 narrowing of proof dimensions (CWE-681)

### DIFF
--- a/.github/workflows/miner_heavy_ci.yml
+++ b/.github/workflows/miner_heavy_ci.yml
@@ -86,6 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          submodules: recursive
           persist-credentials: false
           ref: ${{ env.PR_HEAD_SHA }}
       - name: Set up Docker Buildx

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 6
+	Patch uint = 5
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 5
+	Patch uint = 6
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.

--- a/zk-pow/src/api/proof_utils.rs
+++ b/zk-pow/src/api/proof_utils.rs
@@ -1288,8 +1288,10 @@ impl PublicProofParams {
             );
             let outer_indices_bytes = &moe_data[offset..];
             let outer_indices: Vec<u32> = outer_indices_bytes
-                .chunks_exact(4)
-                .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|c| u32::from_le_bytes(*c))
                 .collect();
             Some(MoEParams {
                 routing_offsets,

--- a/zk-pow/src/circuit/chip/matmul/constraints.rs
+++ b/zk-pow/src/circuit/chip/matmul/constraints.rs
@@ -15,7 +15,7 @@ where
     E: Evaluator<V, S>,
 {
     debug_assert_eq!(unpacked.len(), packed.len() * BYTES_PER_GOLDILOCKS);
-    for (unpacked_chunk, &packed_elem) in unpacked.chunks_exact(BYTES_PER_GOLDILOCKS).zip_eq(packed) {
+    for (unpacked_chunk, &packed_elem) in unpacked.as_chunks::<BYTES_PER_GOLDILOCKS>().0.iter().zip_eq(packed) {
         let repacked = eval.polyval(unpacked_chunk, c256);
         eval.constraint_eq(packed_elem, repacked);
     }

--- a/zk-pow/src/circuit/chip/matmul/trace.rs
+++ b/zk-pow/src/circuit/chip/matmul/trace.rs
@@ -46,7 +46,7 @@ pub fn fill_row_trace<'a, F, const D: usize>(
         ([0i8; TILE_H * TILE_D], [0i8; TILE_H * TILE_D])
     };
     let a_noised = a_tile.iter().zip(a_noise.iter()).map(|(a, n)| a + n).collect_vec();
-    for a_n_chunk in a_noised.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for a_n_chunk in a_noised.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         row_builder.dump_i64(i64_pack_base(a_n_chunk, 256));
     }
     for &a_n_unpack in &a_noised {
@@ -63,7 +63,7 @@ pub fn fill_row_trace<'a, F, const D: usize>(
         ([0i8; TILE_H * TILE_D], [0i8; TILE_H * TILE_D])
     };
     let b_noised = b_tile.iter().zip(b_noise.iter()).map(|(b, n)| b + n).collect_vec();
-    for b_n_chunk in b_noised.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for b_n_chunk in b_noised.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         row_builder.dump_i64(i64_pack_base(b_n_chunk, 256));
     }
     for &b_n_unpack in &b_noised {

--- a/zk-pow/src/circuit/pearl_trace.rs
+++ b/zk-pow/src/circuit/pearl_trace.rs
@@ -163,7 +163,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Fill JOB_KEY (PUBLIC)
-    for chunk in compiled_params.job_key.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in compiled_params.job_key.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::JOB_KEY_END);
@@ -171,7 +171,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     // Fill COMMITMENT_HASH (PUBLIC)
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::COMMITMENT_HASH);
     let (_, commitment_hash) = compiled_params.commitment_hash;
-    for chunk in commitment_hash.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in commitment_hash.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::COMMITMENT_HASH_END);
@@ -179,7 +179,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Fill HASH_A (PUBLIC)
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_A);
-    for chunk in public_params.hash_a.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in public_params.hash_a.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_A_END);
@@ -187,7 +187,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Fill HASH_B (PUBLIC)
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_B);
-    for chunk in public_params.hash_b.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in public_params.hash_b.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_B_END);
@@ -196,7 +196,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     // Fill HASH_ROUTING (PUBLIC). Zero-filled for non-MoE proofs.
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_ROUTING);
     let hash_routing = public_params.moe.as_ref().map(|moe| moe.hash_routing).unwrap_or_default();
-    for chunk in hash_routing.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in hash_routing.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_ROUTING_END);

--- a/zk-pow/src/ffi/plain_proof.rs
+++ b/zk-pow/src/ffi/plain_proof.rs
@@ -552,21 +552,13 @@ impl PlainProof {
         header: IncompleteBlockHeader,
         seed_derivation: SeedDerivation,
     ) -> Result<(PrivateProofParams, PublicProofParams)> {
-        // Reject every attacker-controlled `usize` dimension that does not fit its
-        // wire/public type *before* `check_declared_tree_sizes` validates the inflated
-        // values. On 64-bit targets, an unchecked `as` cast would otherwise truncate
-        // (wrap) an out-of-range dimension, letting a miner add a multiple of 2^width
-        // to a declared dimension, satisfy the leaf-count check on the wide value, and
-        // then have it silently wrap back to the intended public value (CWE-681).
+        // Reject oversized usize dims before tree-size checks so wraparound can't satisfy then truncate (CWE-681).
         let m: u32 = self.m.try_into().context("m exceeds u32")?;
         let n: u32 = self.n.try_into().context("n exceeds u32")?;
         let k: u32 = self.k.try_into().context("k exceeds u32")?;
         let noise_rank: u16 = self.noise_rank.try_into().context("noise_rank exceeds u16")?;
 
-        // Reject out-of-range MoE dimensions before the tree-size check below,
-        // which operates on the wide `usize` values (via `total_b_cols` and the
-        // routing leaf count). Otherwise an inflated `e`/`top_k` could satisfy the
-        // leaf-count check on the wide value and then wrap at the `u16` narrowing.
+        // MoE e/top_k also feed the tree-size check; reject overflow before wrap can hide it.
         let moe_config = match &self.moe {
             Some(mp) => Some(MoEConfig {
                 e: mp.e.try_into().context("e exceeds u16")?,

--- a/zk-pow/src/ffi/plain_proof.rs
+++ b/zk-pow/src/ffi/plain_proof.rs
@@ -552,13 +552,12 @@ impl PlainProof {
         header: IncompleteBlockHeader,
         seed_derivation: SeedDerivation,
     ) -> Result<(PrivateProofParams, PublicProofParams)> {
-        // Reject oversized usize dims before tree-size checks so wraparound can't satisfy then truncate (CWE-681).
+        // Leaf-count binds usize; public dims are u32/u16 — wrap would unbind them.
         let m: u32 = self.m.try_into().context("m exceeds u32")?;
         let n: u32 = self.n.try_into().context("n exceeds u32")?;
         let k: u32 = self.k.try_into().context("k exceeds u32")?;
         let noise_rank: u16 = self.noise_rank.try_into().context("noise_rank exceeds u16")?;
 
-        // MoE e/top_k also feed the tree-size check; reject overflow before wrap can hide it.
         let moe_config = match &self.moe {
             Some(mp) => Some(MoEConfig {
                 e: mp.e.try_into().context("e exceeds u16")?,

--- a/zk-pow/src/ffi/plain_proof.rs
+++ b/zk-pow/src/ffi/plain_proof.rs
@@ -473,8 +473,18 @@ impl PlainProof {
     /// Derives the inner A/B index lists used to build the periodic patterns,
     /// plus the public `MoEParams` (when this is an MoE proof).
     fn moe_inner_indices(&self) -> Result<(Vec<u32>, Vec<u32>, Option<MoEParams>)> {
-        let a_indices: Vec<u32> = self.a.row_indices.iter().map(|&x| x as u32).collect();
-        let bt_indices: Vec<u32> = self.bt.row_indices.iter().map(|&x| x as u32).collect();
+        let a_indices: Vec<u32> = self
+            .a
+            .row_indices
+            .iter()
+            .map(|&x| x.try_into().context("A row index exceeds u32"))
+            .collect::<Result<_>>()?;
+        let bt_indices: Vec<u32> = self
+            .bt
+            .row_indices
+            .iter()
+            .map(|&x| x.try_into().context("B row index exceeds u32"))
+            .collect::<Result<_>>()?;
 
         let Some(moe) = &self.moe else {
             return Ok((a_indices, bt_indices, None));
@@ -505,8 +515,21 @@ impl PlainProof {
 
         ensure!(moe.routing_end_offsets.len() == moe.e);
 
-        let inner_a: Vec<u32> = moe.inner_a_rows.iter().map(|&x| x as u32).collect();
-        let inner_b: Vec<u32> = bt_indices.iter().map(|&idx| idx - weight_col_offset as u32).collect();
+        let inner_a: Vec<u32> = moe
+            .inner_a_rows
+            .iter()
+            .map(|&x| x.try_into().context("MoE inner A row index exceeds u32"))
+            .collect::<Result<_>>()?;
+        let weight_col_offset_u32: u32 = weight_col_offset
+            .try_into()
+            .context("expert weight column offset exceeds u32")?;
+        let inner_b: Vec<u32> = bt_indices
+            .iter()
+            .map(|&idx| {
+                idx.checked_sub(weight_col_offset_u32)
+                    .context("B row index below expert offset")
+            })
+            .collect::<Result<_>>()?;
 
         ensure!(
             moe.e <= PublicProofParams::MAX_NUM_EXPERTS,
@@ -529,14 +552,35 @@ impl PlainProof {
         header: IncompleteBlockHeader,
         seed_derivation: SeedDerivation,
     ) -> Result<(PrivateProofParams, PublicProofParams)> {
-        let (m, n, k) = (self.m, self.n, self.k);
+        // Reject every attacker-controlled `usize` dimension that does not fit its
+        // wire/public type *before* `check_declared_tree_sizes` validates the inflated
+        // values. On 64-bit targets, an unchecked `as` cast would otherwise truncate
+        // (wrap) an out-of-range dimension, letting a miner add a multiple of 2^width
+        // to a declared dimension, satisfy the leaf-count check on the wide value, and
+        // then have it silently wrap back to the intended public value (CWE-681).
+        let m: u32 = self.m.try_into().context("m exceeds u32")?;
+        let n: u32 = self.n.try_into().context("n exceeds u32")?;
+        let k: u32 = self.k.try_into().context("k exceeds u32")?;
+        let noise_rank: u16 = self.noise_rank.try_into().context("noise_rank exceeds u16")?;
+
+        // Reject out-of-range MoE dimensions before the tree-size check below,
+        // which operates on the wide `usize` values (via `total_b_cols` and the
+        // routing leaf count). Otherwise an inflated `e`/`top_k` could satisfy the
+        // leaf-count check on the wide value and then wrap at the `u16` narrowing.
+        let moe_config = match &self.moe {
+            Some(mp) => Some(MoEConfig {
+                e: mp.e.try_into().context("e exceeds u16")?,
+                top_k: mp.top_k.try_into().context("top_k exceeds u16")?,
+            }),
+            None => None,
+        };
 
         // Pin the committed trees to the declared dimensions before those
         // dimensions flow into the (salted) noise-seed derivation.
         self.check_declared_tree_sizes()?;
 
         for &tok in &self.a.row_indices {
-            ensure!(tok < m, "routing entry {} out of range for t={}", tok, m);
+            ensure!(tok < m as usize, "routing entry {} out of range for t={}", tok, m);
         }
 
         let (inner_a_indices, inner_b_indices, moe_params) = self.moe_inner_indices()?;
@@ -547,21 +591,18 @@ impl PlainProof {
             block_header: header,
             seed_derivation,
             mining_config: MiningConfiguration {
-                common_dim: k as u32,
-                rank: self.noise_rank as u16,
+                common_dim: k,
+                rank: noise_rank,
                 mma_type: MMAType::Int7xInt7ToInt32,
                 rows_pattern,
                 cols_pattern,
-                moe: self.moe.as_ref().map(|m| MoEConfig {
-                    e: m.e as u16,
-                    top_k: m.top_k as u16,
-                }),
+                moe: moe_config,
             },
             hash_a: self.a.proof.root,
             hash_b: self.bt.proof.root,
             hash_jackpot: [0xFFu8; 32], // Consumed only by ZK verifier
-            m: m as u32,
-            n: n as u32,
+            m,
+            n,
             t_rows,
             t_cols,
             moe: moe_params,
@@ -582,6 +623,7 @@ impl PlainProof {
             vec![]
         };
 
+        let k = k as usize;
         let private = PrivateProofParams {
             s_a: extract_strips(&self.a.row_indices, k, strip_len, &self.a.proof)?,
             s_b: extract_strips(&self.bt.row_indices, k, strip_len, &self.bt.proof)?,

--- a/zk-pow/src/v1/circuit/chip/matmul/constraints.rs
+++ b/zk-pow/src/v1/circuit/chip/matmul/constraints.rs
@@ -15,7 +15,7 @@ where
     E: Evaluator<V, S>,
 {
     debug_assert_eq!(unpacked.len(), packed.len() * BYTES_PER_GOLDILOCKS);
-    for (unpacked_chunk, &packed_elem) in unpacked.chunks_exact(BYTES_PER_GOLDILOCKS).zip_eq(packed) {
+    for (unpacked_chunk, &packed_elem) in unpacked.as_chunks::<BYTES_PER_GOLDILOCKS>().0.iter().zip_eq(packed) {
         let repacked = eval.polyval(unpacked_chunk, c256);
         eval.constraint_eq(packed_elem, repacked);
     }

--- a/zk-pow/src/v1/circuit/chip/matmul/trace.rs
+++ b/zk-pow/src/v1/circuit/chip/matmul/trace.rs
@@ -46,7 +46,7 @@ pub fn fill_row_trace<'a, F, const D: usize>(
         ([0i8; TILE_H * TILE_D], [0i8; TILE_H * TILE_D])
     };
     let a_noised = a_tile.iter().zip(a_noise.iter()).map(|(a, n)| a + n).collect_vec();
-    for a_n_chunk in a_noised.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for a_n_chunk in a_noised.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         row_builder.dump_i64(i64_pack_base(a_n_chunk, 256));
     }
     for &a_n_unpack in &a_noised {
@@ -63,7 +63,7 @@ pub fn fill_row_trace<'a, F, const D: usize>(
         ([0i8; TILE_H * TILE_D], [0i8; TILE_H * TILE_D])
     };
     let b_noised = b_tile.iter().zip(b_noise.iter()).map(|(b, n)| b + n).collect_vec();
-    for b_n_chunk in b_noised.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for b_n_chunk in b_noised.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         row_builder.dump_i64(i64_pack_base(b_n_chunk, 256));
     }
     for &b_n_unpack in &b_noised {

--- a/zk-pow/src/v1/circuit/pearl_trace.rs
+++ b/zk-pow/src/v1/circuit/pearl_trace.rs
@@ -162,7 +162,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Fill JOB_KEY (PUBLIC)
-    for chunk in compiled_params.job_key.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in compiled_params.job_key.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::JOB_KEY_END);
@@ -170,7 +170,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     // Fill COMMITMENT_HASH (PUBLIC)
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::COMMITMENT_HASH);
     let (_, commitment_hash) = compiled_params.commitment_hash;
-    for chunk in commitment_hash.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in commitment_hash.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::COMMITMENT_HASH_END);
@@ -178,7 +178,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Fill HASH_A (PUBLIC)
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_A);
-    for chunk in public_params.hash_a.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in public_params.hash_a.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_A_END);
@@ -186,7 +186,7 @@ pub fn generate_trace<F: RichField + Extendable<D>, const D: usize>(
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Fill HASH_B (PUBLIC)
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_B);
-    for chunk in public_params.hash_b.chunks_exact(BYTES_PER_GOLDILOCKS) {
+    for chunk in public_params.hash_b.as_chunks::<BYTES_PER_GOLDILOCKS>().0 {
         public_inputs_builder.dump_u64(u64_pack_le(chunk, 8));
     }
     debug_assert_eq!(public_inputs_builder.offset, pearl_public::HASH_B_END);

--- a/zk-pow/tests/plain_proof_dimension_wraparound.rs
+++ b/zk-pow/tests/plain_proof_dimension_wraparound.rs
@@ -1,0 +1,36 @@
+use blake3::CHUNK_LEN;
+
+use zk_pow::api::proof::{IncompleteBlockHeader, MMAType, MiningConfiguration, PeriodicPattern, SeedDerivation};
+use zk_pow::api::verify::verify_plain_proof;
+use zk_pow::ffi::mine::mine;
+
+#[test]
+fn rejects_dimension_wraparound_after_leaf_count_check() {
+    let (m, n, k) = (256usize, 128usize, 1024usize);
+    let header = IncompleteBlockHeader {
+        version: 0,
+        prev_block: [1; 32],
+        merkle_root: [2; 32],
+        timestamp: 0x6666_6666,
+        nbits: 0x207f_ffff,
+    };
+    let config = MiningConfiguration {
+        common_dim: k as u32,
+        rank: 32,
+        mma_type: MMAType::Int7xInt7ToInt32,
+        rows_pattern: PeriodicPattern::from_list(&[0, 8, 64, 72]).unwrap(),
+        cols_pattern: PeriodicPattern::from_list(&[0, 1, 8, 9, 32, 33, 40, 41]).unwrap(),
+        moe: None,
+    };
+
+    let mut proof = mine(m, n, k, header, config, None, false, SeedDerivation::Salted).unwrap();
+    verify_plain_proof(&header, &proof, None, SeedDerivation::Salted).unwrap();
+
+    proof.m += 1usize << 40;
+    proof.a.proof.total_leaves = pearl_blake3::padded_chunk_len(proof.m * proof.k) / CHUNK_LEN;
+
+    assert!(
+        verify_plain_proof(&header, &proof, None, SeedDerivation::Salted).is_err(),
+        "wrapped m bypassed the declared Merkle leaf-count binding"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes unchecked `usize` → `u32`/`u16` narrowing in `PlainProof::parse_proof` that bypasses the V3 Merkle leaf-count binding from #281 (CWE-681).

`check_declared_tree_sizes()` validates the wide (`usize`) declared dimensions, but `parse_proof` later narrowed them with unchecked `as` casts. On 64-bit targets a miner could add a multiple of `2^32` to `m` (or `n`/`k`), satisfy the leaf-count check on the inflated value, and have it silently wrap back to the intended public `u32` — reopening the carousel/work-amplification class of attack that #281 closed.

## Type

fix

## Scope

zk-pow

## Changes

- Reject `m`/`n`/`k` larger than `u32` and `noise_rank` larger than `u16` via checked `TryInto` **before** the tree-size check.
- Pre-validate MoE `e`/`top_k` fit `u16` before the tree-size check (which consumes the wide values through `total_b_cols` and routing leaf count).
- Use the checked values in `MiningConfiguration`/`PublicProofParams`.
- Replace unchecked `as u32` casts of A/B row indices and MoE inner A rows with checked conversions; use `checked_sub` for expert-offset inner B indices.
- Add regression test `zk-pow/tests/plain_proof_dimension_wraparound.rs`.

## Test plan

- [x] `cargo test --lib` (zk-pow): 86 passed, 2 ignored
- [x] `declared_tree_sizes` tests: 2 passed
- [x] Wraparound PoC test: 1 passed (previously returned `Ok`)
- [x] `cargo fmt --check` and `cargo clippy --lib --tests`: clean
- [ ] Existing tests pass (`task test`)
- [x] New tests added

## Credits

Reported by [@zcobi01](https://github.com/zcobi01). GHSA-vq6h-p843-m7c8.