### PR TITLE
refactor(peer): drop blockchain import from node/peer

### DIFF
--- a/node/netsync/manager.go
+++ b/node/netsync/manager.go
@@ -22,6 +22,10 @@ import (
 	"github.com/pearl-research-labs/pearl/node/wire"
 )
 
+func hashesOf(loc blockchain.BlockLocator) []*chainhash.Hash {
+	return []*chainhash.Hash(loc)
+}
+
 const (
 	// minInFlightBlocks is the minimum number of blocks that should be
 	// in the request queue for headers-first mode before requesting
@@ -402,13 +406,13 @@ func (sm *SyncManager) startSync() {
 		best.Height < sm.nextCheckpoint.Height &&
 		sm.chainParams != &chaincfg.RegressionNetParams {
 
-		bestPeer.PushGetHeadersMsg(locator, sm.nextCheckpoint.Hash, true)
+		bestPeer.PushGetHeadersMsg(hashesOf(locator), sm.nextCheckpoint.Hash, true)
 		sm.headersFirstMode = true
 		log.Infof("Downloading headers for blocks %d to "+
 			"%d from peer %s", best.Height+1,
 			sm.nextCheckpoint.Height, bestPeer.Addr())
 	} else {
-		bestPeer.PushGetBlocksMsg(locator, &zeroHash)
+		bestPeer.PushGetBlocksMsg(hashesOf(locator), &zeroHash)
 	}
 	sm.syncPeer = bestPeer
 
@@ -847,7 +851,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) error {
 
 		orphanRoot := sm.chain.GetOrphanRoot(blockHash)
 		locator, _ := sm.chain.LatestBlockLocator()
-		peer.PushGetBlocksMsg(locator, orphanRoot)
+		peer.PushGetBlocksMsg(hashesOf(locator), orphanRoot)
 	} else {
 		if peer == sm.syncPeer {
 			sm.lastProgressTime = time.Now()
@@ -909,7 +913,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) error {
 	sm.nextCheckpoint = sm.findNextHeaderCheckpoint(prevHeight)
 	if sm.nextCheckpoint != nil {
 		locator := blockchain.BlockLocator([]*chainhash.Hash{prevHash})
-		err := peer.PushGetHeadersMsg(locator, sm.nextCheckpoint.Hash, true)
+		err := peer.PushGetHeadersMsg(hashesOf(locator), sm.nextCheckpoint.Hash, true)
 		if err != nil {
 			log.Warnf("Failed to send getheaders message to "+
 				"peer %s: %v", peer.Addr(), err)
@@ -928,7 +932,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) error {
 	sm.headerList.Init()
 	log.Infof("Reached the final checkpoint -- switching to normal mode")
 	locator := blockchain.BlockLocator([]*chainhash.Hash{blockHash})
-	err = peer.PushGetBlocksMsg(locator, &zeroHash)
+	err = peer.PushGetBlocksMsg(hashesOf(locator), &zeroHash)
 	if err != nil {
 		log.Warnf("Failed to send getblocks message to peer %s: %v",
 			peer.Addr(), err)
@@ -1158,7 +1162,7 @@ func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 	// headers starting from the latest known header and ending with the
 	// next checkpoint.
 	locator := blockchain.BlockLocator([]*chainhash.Hash{finalHash})
-	err := peer.PushGetHeadersMsg(locator, sm.nextCheckpoint.Hash, true)
+	err := peer.PushGetHeadersMsg(hashesOf(locator), sm.nextCheckpoint.Hash, true)
 	if err != nil {
 		log.Warnf("Failed to send getheaders message to "+
 			"peer %s: %v", peer.Addr(), err)
@@ -1302,7 +1306,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		if have, _ := sm.haveInventory(invVects[lastBlock]); !have {
 			locator, _ := sm.chain.LatestBlockLocator()
 			_ = peer.PushGetHeadersMsg(
-				locator, &invVects[lastBlock].Hash, false)
+				hashesOf(locator), &invVects[lastBlock].Hash, false)
 		}
 	}
 
@@ -1378,7 +1382,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 				// in.
 				orphanRoot := sm.chain.GetOrphanRoot(&iv.Hash)
 				locator, _ := sm.chain.LatestBlockLocator()
-				peer.PushGetBlocksMsg(locator, orphanRoot)
+				peer.PushGetBlocksMsg(hashesOf(locator), orphanRoot)
 				continue
 			}
 
@@ -1401,7 +1405,7 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 					continue
 				}
 				locator := sm.chain.BlockLocatorFromHash(&iv.Hash)
-				peer.PushGetBlocksMsg(locator, &zeroHash)
+				peer.PushGetBlocksMsg(hashesOf(locator), &zeroHash)
 			}
 		}
 	}

--- a/node/peer/peer.go
+++ b/node/peer/peer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/btcsuite/go-socks/socks"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/decred/dcrd/lru"
-	"github.com/pearl-research-labs/pearl/node/blockchain"
 	"github.com/pearl-research-labs/pearl/node/chaincfg"
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/v2transport"
@@ -897,7 +896,7 @@ func (p *Peer) PushAddrV2Msg(addrs []*wire.NetAddressV2) (
 // and stop hash.  It will ignore back-to-back duplicate requests.
 //
 // This function is safe for concurrent access.
-func (p *Peer) PushGetBlocksMsg(locator blockchain.BlockLocator, stopHash *chainhash.Hash) error {
+func (p *Peer) PushGetBlocksMsg(locator []*chainhash.Hash, stopHash *chainhash.Hash) error {
 	// Extract the begin hash from the block locator, if one was specified,
 	// to use for filtering duplicate getblocks requests.
 	var beginHash *chainhash.Hash
@@ -943,7 +942,7 @@ func (p *Peer) PushGetBlocksMsg(locator blockchain.BlockLocator, stopHash *chain
 // the response; when false only bare headers are returned.
 //
 // This function is safe for concurrent access.
-func (p *Peer) PushGetHeadersMsg(locator blockchain.BlockLocator, stopHash *chainhash.Hash, includeCerts bool) error {
+func (p *Peer) PushGetHeadersMsg(locator []*chainhash.Hash, stopHash *chainhash.Hash, includeCerts bool) error {
 	// Extract the begin hash from the block locator, if one was specified,
 	// to use for filtering duplicate getheaders requests.
 	var beginHash *chainhash.Hash

--- a/spv/blockmanager.go
+++ b/spv/blockmanager.go
@@ -28,6 +28,10 @@ import (
 	"github.com/pearl-research-labs/pearl/spv/query"
 )
 
+func hashesOf(loc blockchain.BlockLocator) []*chainhash.Hash {
+	return []*chainhash.Hash(loc)
+}
+
 const (
 	// numMaxMemHeaders is the max number of headers to store in memory for
 	// a particular peer. By bounding this value, we're able to closely
@@ -387,7 +391,7 @@ func (b *blockManager) handleNewPeerMsg(peers *list.List, sp *ServerPeer) {
 			return
 		}
 		stopHash := &zeroHash
-		_ = sp.PushGetHeadersMsg(locator, stopHash, true)
+		_ = sp.PushGetHeadersMsg(hashesOf(locator), stopHash, true)
 	}
 
 	// Start syncing by choosing the best candidate if needed.
@@ -2154,7 +2158,7 @@ func (b *blockManager) startSync(peers *list.List) {
 
 		// With our stop hash selected, we'll kick off the sync from
 		// this peer with an initial GetHeaders message.
-		_ = b.SyncPeer().PushGetHeadersMsg(locator, stopHash, true)
+		_ = b.SyncPeer().PushGetHeadersMsg(hashesOf(locator), stopHash, true)
 	} else {
 		log.Warnf("No sync peer candidates available")
 	}
@@ -2321,7 +2325,7 @@ func (b *blockManager) handleInvMsg(imsg *invMsg) {
 			}
 
 			// Get headers based on locator.
-			err = imsg.peer.PushGetHeadersMsg(locator,
+			err = imsg.peer.PushGetHeadersMsg(hashesOf(locator),
 				&invVects[lastBlock].Hash, true)
 			if err != nil {
 				log.Warnf("Failed to send getheaders message "+
@@ -2407,7 +2411,7 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 			if b.nextCheckpoint != nil {
 				stopHash = *b.nextCheckpoint.Hash
 			}
-			err := hmsg.peer.PushGetHeadersMsg(locator, &stopHash, true)
+			err := hmsg.peer.PushGetHeadersMsg(hashesOf(locator), &stopHash, true)
 			if err != nil {
 				log.Warnf("Failed to send speculative "+
 					"getheaders to peer %s: %s",
@@ -2759,7 +2763,7 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 		if b.nextCheckpoint != nil {
 			nextHash = *b.nextCheckpoint.Hash
 		}
-		err := hmsg.peer.PushGetHeadersMsg(locator, &nextHash, true)
+		err := hmsg.peer.PushGetHeadersMsg(hashesOf(locator), &nextHash, true)
 		if err != nil {
 			log.Warnf("Failed to send getheaders message to "+
 				"peer %s: %s", hmsg.peer.Addr(), err)


### PR DESCRIPTION
## Why

`node/peer` imported `node/blockchain` only because `PushGetBlocksMsg` / `PushGetHeadersMsg` took `blockchain.BlockLocator`. That type is `[]*chainhash.Hash`. The import pulled database/zkpow into any binary that only needed handshake/version/verack.

coins-minimal/pearl-minimal needs pearld P2P (peer + addrmgr + connmgr) without linking consensus.

## What

- Signatures take `[]*chainhash.Hash`
- netsync and spv convert with `hashesOf`

## Tests

`go build ./node/peer ./node/netsync ./spv`