### PR TITLE
feat(chaincfg): migrate DNS seeds to pearlnetwork.net hosts

### DIFF
--- a/node/chaincfg/params.go
+++ b/node/chaincfg/params.go
@@ -342,7 +342,14 @@ var MainNetParams = Params{
 	Name:        "mainnet",
 	Net:         wire.MainNet,
 	DefaultPort: "44108",
+	// Both seed families are listed while the seeders migrate. The
+	// pearlresearch.ai names must stay until the nodes already deployed
+	// against them are retired, or those nodes lose their only way to
+	// bootstrap.
 	DNSSeeds: []DNSSeed{
+		{"reef.seeder.pearlnetwork.net", false},
+		{"tide.seeder.pearlnetwork.net", false},
+		{"stream.seeder.pearlnetwork.net", false},
 		{"seeder1.pearlresearch.ai", false},
 		{"seeder2.pearlresearch.ai", false},
 		{"seeder3.pearlresearch.ai", false},
@@ -549,6 +556,9 @@ var TestNetParams = Params{
 	Net:         wire.TestNet,
 	DefaultPort: "44110",
 	DNSSeeds: []DNSSeed{
+		{"reef.seeder.testnet.pearlnetwork.net", false},
+		{"tide.seeder.testnet.pearlnetwork.net", false},
+		{"stream.seeder.testnet.pearlnetwork.net", false},
 		{"seeder1.internal.pearlresearch.ai", false},
 		{"seeder2.internal.pearlresearch.ai", false},
 		{"seeder3.internal.pearlresearch.ai", false},
@@ -645,6 +655,9 @@ var TestNet2Params = Params{
 	Net:         wire.TestNet2,
 	DefaultPort: "44112",
 	DNSSeeds: []DNSSeed{
+		{"reef.seeder.testnet2.pearlnetwork.net", false},
+		{"tide.seeder.testnet2.pearlnetwork.net", false},
+		{"stream.seeder.testnet2.pearlnetwork.net", false},
 		{"seeder1.testnet.pearlresearch.ai", false},
 		{"seeder2.testnet.pearlresearch.ai", false},
 		{"seeder3.testnet.pearlresearch.ai", false},

--- a/version/version.go
+++ b/version/version.go
@@ -20,7 +20,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	Major uint = 1
 	Minor uint = 4
-	Patch uint = 6
+	Patch uint = 7
 
 	// PreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
## Summary

Add the `reef`/`tide`/`stream` `*.seeder.pearlnetwork.net` DNS seeders for mainnet, testnet, and testnet2, alongside the existing `pearlresearch.ai` names.

Both seed families are listed during the seeder migration. The `pearlresearch.ai` names stay until nodes already deployed against them are retired, so those nodes keep a bootstrap path.

Also bumps the patch version to `1.4.7`.

## Test plan

- [x] `go build ./node/chaincfg/ ./version/`
- [x] Verified all new seed hosts resolve (`dig A` on mainnet, testnet, and testnet2 hosts)