### PR TITLE
feat(pearld): add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ wallet and generate a Taproot mining address:
 ```
 
 Key flags: `--testnet` / `--simnet` for non-mainnet, `--notls` to disable TLS,
-`--debuglevel=debug` for verbose logs. See `node/sample-pearld.conf` for all
-options.
+`--debuglevel=debug` for verbose logs, `--metricslisten=127.0.0.1:9105` to
+serve [Prometheus metrics](node/metrics/). See `node/sample-pearld.conf` for
+all options.
 
 | Network  | RPC   | P2P   | Wallet Server |
 |----------|-------|-------|---------------|

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -57,6 +57,7 @@ VOLUME ["/root/.pearld"]
 
 # 44108  Mainnet Pearl peer-to-peer port
 # 44107  Mainnet RPC port
-EXPOSE 44108 44107
+# 9105   Prometheus metrics (only served with --metricslisten)
+EXPOSE 44108 44107 9105
 
 ENTRYPOINT ["pearld"]

--- a/node/btcd.go
+++ b/node/btcd.go
@@ -19,7 +19,9 @@ import (
 	"github.com/pearl-research-labs/pearl/node/blockchain/indexers"
 	"github.com/pearl-research-labs/pearl/node/database"
 	"github.com/pearl-research-labs/pearl/node/limits"
+	"github.com/pearl-research-labs/pearl/node/metrics"
 	"github.com/pearl-research-labs/pearl/node/ossec"
+	"github.com/pearl-research-labs/pearl/node/peer"
 )
 
 const (
@@ -74,6 +76,30 @@ func pearldMain(serverChan chan<- *server) error {
 				http.StatusSeeOther)
 			http.Handle("/", profileRedirect)
 			prldLog.Errorf("%v", http.ListenAndServe(listenAddr, nil))
+		}()
+	}
+
+	// Enable Prometheus metrics server if requested.
+	var metricsServer *metrics.Server
+	if len(cfg.MetricsListeners) > 0 {
+		var err error
+		metricsServer, err = metrics.NewServer(cfg.MetricsListeners)
+		if err != nil {
+			prldLog.Errorf("Unable to start metrics server on %v: %v",
+				cfg.MetricsListeners, err)
+			return err
+		}
+		metrics.SetInfo(version(), activeNetParams.Name, fmt.Sprintf("%d", peer.MaxProtocolVersion))
+		metricsServer.Start()
+		prldLog.Infof("Metrics server listening on %v", metricsServer.ListenAddrs())
+		go func() {
+			for err := range metricsServer.Errors() {
+				prldLog.Errorf("Metrics server error: %v", err)
+			}
+		}()
+		defer func() {
+			prldLog.Infof("Gracefully shutting down the metrics server...")
+			metricsServer.Stop()
 		}()
 	}
 
@@ -272,6 +298,9 @@ func pearldMain(serverChan chan<- *server) error {
 		srvrLog.Infof("Server shutdown complete")
 	}()
 	server.Start()
+	if metricsServer != nil {
+		metricsServer.SetSource(server.MetricsSource())
+	}
 	if serverChan != nil {
 		serverChan <- server
 	}

--- a/node/config.go
+++ b/node/config.go
@@ -50,6 +50,7 @@ const (
 	defaultMaxRPCClients            = 10
 	defaultMaxRPCWebsockets         = 25
 	defaultMaxRPCConcurrentReqs     = 20
+	defaultMetricsPort              = "9105"
 	defaultDbType                   = "ffldb"
 	defaultFreeTxRelayLimit         = 15.0
 	defaultTrickleInterval          = peer.DefaultTrickleInterval
@@ -126,6 +127,7 @@ type config struct {
 	MaxMempool               uint64        `long:"maxmempool" description:"Maximum mempool size in MB (default: 300)"`
 	MaxOrphanTxs             int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
 	MaxPeers                 int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	MetricsListeners         []string      `long:"metricslisten" description:"Add an interface/port to listen for Prometheus metrics (default port: 9105)"`
 	MiningAddrs              []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
 	MinRelayTxFee            float64       `long:"minrelaytxfee" description:"The minimum transaction fee in PRL/kB to be considered a non-zero fee."`
 	DisableBanning           bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
@@ -319,6 +321,18 @@ func normalizeAddress(addr, defaultPort string) string {
 		return net.JoinHostPort(addr, defaultPort)
 	}
 	return addr
+}
+
+// isLoopbackHost reports whether host refers to the local machine only.  An
+// empty host means the wildcard address, which is not loopback.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // normalizeAddresses returns a new slice with all the passed peer addresses
@@ -700,6 +714,14 @@ func loadConfig() (*config, []string, error) {
 			fmt.Fprintln(os.Stderr, usageMessage)
 			return nil, nil, err
 		}
+
+		// The profile server takes a port rather than an address, so it always
+		// binds every interface.  net/http/pprof also serves
+		// /debug/pprof/cmdline, which discloses the process arguments, and
+		// those commonly include --rpcpass.
+		prldLog.Warnf("Profile server on port %s binds all interfaces and is "+
+			"unauthenticated -- it exposes heap dumps and the process command "+
+			"line, so restrict access with a firewall", cfg.Profile)
 	}
 
 	// Don't allow ban durations that are too short.
@@ -957,13 +979,31 @@ func loadConfig() (*config, []string, error) {
 	cfg.RPCListeners = normalizeAddresses(cfg.RPCListeners,
 		activeNetParams.rpcPort)
 
+	// Add default port to all metrics listener addresses if needed and remove
+	// duplicate addresses.
+	cfg.MetricsListeners = normalizeAddresses(cfg.MetricsListeners,
+		defaultMetricsPort)
+
+	// Remote scrapers (a central Prometheus, or a PodMonitor hitting the pod
+	// IP) require a routable bind address, so this is expected in most
+	// deployments rather than a misconfiguration. The endpoint is
+	// unauthenticated either way, hence the reminder.
+	for _, addr := range cfg.MetricsListeners {
+		host, _, err := net.SplitHostPort(addr)
+		if err == nil && !isLoopbackHost(host) {
+			prldLog.Warnf("Metrics endpoint %s is reachable beyond localhost "+
+				"and is unauthenticated -- restrict access with a firewall or "+
+				"network policy", addr)
+		}
+	}
+
 	if !cfg.DisableRPC && cfg.DisableTLS {
 		if activeNetParams.Params.Net == wire.MainNet {
 			rpcsLog.Warnf("Running on mainnet with --notls is not recommended")
 		}
 
 		for _, addr := range cfg.RPCListeners {
-			_, _, err := net.SplitHostPort(addr)
+			host, _, err := net.SplitHostPort(addr)
 			if err != nil {
 				str := "%s: RPC listen interface '%s' is " +
 					"invalid: %v"
@@ -971,6 +1011,13 @@ func loadConfig() (*config, []string, error) {
 				fmt.Fprintln(os.Stderr, err)
 				fmt.Fprintln(os.Stderr, usageMessage)
 				return nil, nil, err
+			}
+
+			// Basic-auth credentials cross the network in the clear here
+			// regardless of which chain the node follows.
+			if !isLoopbackHost(host) {
+				rpcsLog.Warnf("RPC listener %s has TLS disabled -- "+
+					"credentials will be sent in cleartext", addr)
 			}
 		}
 	}

--- a/node/metrics/README.md
+++ b/node/metrics/README.md
@@ -1,0 +1,205 @@
+# metrics
+
+Opt-in Prometheus metrics for `pearld`, covering chain state, P2P traffic,
+JSON-RPC performance, and the mempool.
+
+No HTTP endpoint is served unless `--metricslisten` is given. Collection itself
+is always on, because incrementing a counter costs about as much as checking a
+flag; the exception is the per-frame P2P wire hooks, which are only installed
+when the endpoint is configured.
+
+## Enabling
+
+Pass `--metricslisten` on the command line or set `metricslisten` in
+`pearld.conf`:
+
+```bash
+pearld --metricslisten=127.0.0.1:9105
+```
+
+Repeat the flag to bind more than one interface:
+
+```bash
+pearld --metricslisten=127.0.0.1:9105 --metricslisten=[::1]:9105
+```
+
+Metrics are served at `/metrics`, with a health check at `/healthz`.
+
+### Choosing a bind address
+
+The address has to be reachable by whatever scrapes it, so loopback only works
+when Prometheus runs on the same host:
+
+| Scrape setup | Bind address |
+|--------------|--------------|
+| Prometheus or an agent on the same host | `127.0.0.1:9105` |
+| Central Prometheus over the network | the host's private/VPC address, or `0.0.0.0:9105` |
+| Kubernetes `PodMonitor` / `ServiceMonitor` | `0.0.0.0:9105`, so the pod IP is reachable |
+
+`/metrics` is unauthenticated, so any address beyond loopback is reachable by
+anything that can route to the node. Restrict it with a firewall, security
+group, or Kubernetes `NetworkPolicy`. pearld logs a warning at startup when the
+endpoint is bound beyond loopback.
+
+## Metrics
+
+Everything uses the `pearld_` namespace. The standard Go runtime (`go_*`) and
+process (`process_*`) collectors are exported on the same endpoint.
+
+Identity labels such as `node` and `region` are attached by Prometheus at
+scrape time rather than by pearld, so every node in a fleet produces identical
+metric names.
+
+### Node
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pearld_info` | Gauge | `version`, `network`, `protocol_version` | Always 1; carries build and network identity as labels |
+
+### Chain
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pearld_chain_tip_height` | Gauge | | Current chain tip height |
+| `pearld_chain_tip_timestamp_seconds` | Gauge | | Unix timestamp of the tip block |
+| `pearld_chain_total_transactions` | Gauge | | Total transactions in the main chain |
+| `pearld_chain_is_current` | Gauge | | 1 when synced, 0 while syncing |
+| `pearld_chain_blocks_connected_total` | Counter | | Blocks connected to the main chain |
+| `pearld_chain_blocks_disconnected_total` | Counter | | Blocks disconnected from the main chain |
+| `pearld_chain_blocks_accepted_total` | Counter | | Blocks accepted into the blockchain |
+
+Tip freshness is derived from the timestamp rather than exported as an age, so
+`time() - pearld_chain_tip_timestamp_seconds` stays correct even if the node
+stalls between scrapes.
+
+### P2P
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pearld_p2p_peers` | Gauge | `direction` | Connected peers |
+| `pearld_p2p_peer_connects_total` | Counter | `direction` | Peer connections established |
+| `pearld_p2p_peer_disconnects_total` | Counter | `direction` | Peer disconnections |
+| `pearld_p2p_peers_banned_total` | Counter | | Peers banned for misbehavior |
+| `pearld_p2p_peers_rejected_total` | Counter | `reason` | Rejected connection attempts |
+| `pearld_p2p_wire_bytes_total` | Counter | `direction`, `command` | Bytes per wire message type |
+| `pearld_p2p_wire_messages_total` | Counter | `direction`, `command` | Wire messages by type |
+| `pearld_net_totalbytes_recv_total` | Counter | | Cumulative bytes received |
+| `pearld_net_totalbytes_sent_total` | Counter | | Cumulative bytes sent |
+
+`direction` is `inbound` or `outbound`. `reason` is one of `max_peers`,
+`banned`, `undesired_agent`, `shutdown`, or `other`.
+
+### JSON-RPC
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pearld_rpc_requests_total` | Counter | `method`, `result` | Requests processed |
+| `pearld_rpc_request_duration_seconds` | Histogram | `method` | Handler execution latency |
+| `pearld_rpc_auth_failures_total` | Counter | | Failed authentication attempts |
+| `pearld_rpc_websocket_clients` | Gauge | | Connected WebSocket clients |
+
+`result` is `success` or `error`. `method` is restricted to registered RPC
+methods; anything else collapses to `unknown` so an unauthenticated caller
+cannot inflate series count with arbitrary method names.
+
+### Mempool
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `pearld_mempool_transactions` | Gauge | | Transactions in the mempool |
+| `pearld_mempool_bytes` | Gauge | | Mempool size in bytes |
+| `pearld_mempool_max_bytes` | Gauge | | Configured mempool size limit |
+| `pearld_mempool_last_updated_timestamp_seconds` | Gauge | | When the mempool last changed |
+
+## Scraping
+
+### Standalone hosts
+
+Bind an address the Prometheus server can reach, then point a job at it:
+
+```yaml
+scrape_configs:
+  - job_name: 'pearld'
+    static_configs:
+      - targets: ['10.0.1.20:9105']
+        labels:
+          node: 'validator-1'
+          region: 'us-east'
+```
+
+For a larger fleet prefer `file_sd_configs`, so targets can be added without
+editing and reloading the Prometheus configuration by hand.
+
+### Kubernetes
+
+Bind the wildcard address so the pod IP is reachable, and name the container
+port so a monitor can reference it:
+
+```yaml
+spec:
+  containers:
+    - name: pearld
+      image: ghcr.io/pearl-research-labs/pearl/pearld:latest
+      args:
+        - --metricslisten=0.0.0.0:9105
+      ports:
+        - name: metrics
+          containerPort: 9105
+```
+
+With the Prometheus Operator installed, a `PodMonitor` completes the wiring:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: pearld
+spec:
+  selector:
+    matchLabels:
+      app: pearld
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+```
+
+A `ServiceMonitor` referencing the same named port works if the pods sit behind
+a `Service`. Pair either with a `NetworkPolicy` admitting only the Prometheus
+namespace.
+
+## Design
+
+Metrics live in a private `prometheus.Registry` rather than the default one, so
+tests stay isolated and nothing is registered implicitly by importing a
+package.
+
+The HTTP server builds its own `http.ServeMux`. It must not reuse
+`http.DefaultServeMux`, because `node/btcd.go` imports `net/http/pprof`, which
+registers profiling handlers there — serving the default mux would expose
+`/debug/pprof` on the metrics port. `server_test.go` guards this by asserting
+`/debug/pprof/` returns 404.
+
+Values that can be read cheaply from live state — chain tip, peer counts,
+mempool size — are collected at scrape time through `Source`, a struct of
+accessor functions supplied by `package main`. There is no background polling
+goroutine. Event counts that cannot be sampled, such as block connections and
+RPC latency, are pushed from their call sites.
+
+The package does no logging. `Server` reports bound addresses through
+`ListenAddrs` and unexpected serve failures through the `Errors` channel, both
+consumed by `pearldMain`, so there is no subsystem logger to wire up.
+
+The record helpers deliberately carry no enabled/disabled flag. All metrics are
+registered in `init()` regardless, so a flag would save no memory and no
+registration work — only an atomic increment, which costs about the same as the
+atomic load needed to check it. The one place the distinction pays for itself is
+`newPeerConfig` in `node/server.go`, which skips installing the `OnRead`/
+`OnWrite` closures entirely when no metrics endpoint is configured, keeping the
+per-frame path identical to an uninstrumented build.
+
+Instrumentation lives entirely in `package main` and hooks that already exist
+(`peer.Config.Listeners.OnRead`/`OnWrite`, `blockchain.Subscribe`), so shared
+packages like `node/blockchain` and `node/peer` gain no Prometheus dependency.
+That matters because they are imported by `spv/`, `wallet/`, `dnsseeder/`, and
+`coredns-dnsseed/`.

--- a/node/metrics/bench_test.go
+++ b/node/metrics/bench_test.go
@@ -1,0 +1,35 @@
+package metrics
+
+import "testing"
+
+// RecordWireMessage runs on every P2P frame in both directions, so it is the
+// only recording helper whose cost is worth tracking.  newPeerConfig in
+// node/server.go skips installing the hooks entirely when no metrics endpoint is
+// configured, so these numbers only apply when metrics are in use.
+func BenchmarkRecordWireMessage(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		RecordWireMessage(true, "inv", 128)
+	}
+}
+
+// Every peer's read and write handler shares one CounterVec, so measure the
+// contention a full peer set would produce.
+func BenchmarkRecordWireMessageParallel(b *testing.B) {
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			RecordWireMessage(true, "inv", 128)
+		}
+	})
+}
+
+// Spread across commands so the label lookup misses the same map slot every
+// time, approximating real mixed traffic.
+func BenchmarkRecordWireMessageMixedCommands(b *testing.B) {
+	commands := []string{"inv", "tx", "block", "ping", "pong", "getdata", "headers", "addr"}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		RecordWireMessage(i%2 == 0, commands[i%len(commands)], 128)
+	}
+}

--- a/node/metrics/collector.go
+++ b/node/metrics/collector.go
@@ -1,0 +1,162 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Source provides accessor functions for scrape-time metrics collection.
+type Source struct {
+	ChainTipHeight     func() int32
+	ChainTipTimestamp  func() time.Time
+	ChainTotalTxs      func() int64
+	ChainIsCurrent     func() bool
+	PeerCount          func() (inbound, outbound int64)
+	NetTotals          func() (totalRecv, totalSent uint64)
+	MempoolTxCount     func() int
+	MempoolBytes       func() uint64
+	MempoolMaxBytes    func() uint64
+	MempoolLastUpdated func() time.Time
+}
+
+// ScrapeCollector implements prometheus.Collector to collect live state at scrape time.
+type ScrapeCollector struct {
+	source Source
+
+	chainTipHeightDesc              *prometheus.Desc
+	chainTipTimestampDesc           *prometheus.Desc
+	chainTotalTxsDesc               *prometheus.Desc
+	chainIsCurrentDesc              *prometheus.Desc
+	p2pPeersDesc                    *prometheus.Desc
+	p2pNetBytesRecvDesc             *prometheus.Desc
+	p2pNetBytesSentDesc             *prometheus.Desc
+	mempoolTransactionsDesc         *prometheus.Desc
+	mempoolBytesDesc                *prometheus.Desc
+	mempoolMaxBytesDesc             *prometheus.Desc
+	mempoolLastUpdatedTimestampDesc *prometheus.Desc
+}
+
+func NewScrapeCollector(src Source) *ScrapeCollector {
+	return &ScrapeCollector{
+		source: src,
+		chainTipHeightDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "chain_tip_height"),
+			"Current chain tip height",
+			nil, nil,
+		),
+		chainTipTimestampDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "chain_tip_timestamp_seconds"),
+			"Unix timestamp of current chain tip block",
+			nil, nil,
+		),
+		chainTotalTxsDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "chain_total_transactions"),
+			"Total transactions in the main chain",
+			nil, nil,
+		),
+		chainIsCurrentDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "chain_is_current"),
+			"Whether the chain is synced / current (1 = true, 0 = false)",
+			nil, nil,
+		),
+		p2pPeersDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "p2p_peers"),
+			"Current number of connected peers",
+			[]string{"direction"}, nil,
+		),
+		p2pNetBytesRecvDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "net_totalbytes_recv_total"),
+			"Total bytes received across network interfaces",
+			nil, nil,
+		),
+		p2pNetBytesSentDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "net_totalbytes_sent_total"),
+			"Total bytes sent across network interfaces",
+			nil, nil,
+		),
+		mempoolTransactionsDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "mempool_transactions"),
+			"Current number of transactions in the mempool",
+			nil, nil,
+		),
+		mempoolBytesDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "mempool_bytes"),
+			"Current size of the mempool in bytes",
+			nil, nil,
+		),
+		mempoolMaxBytesDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "mempool_max_bytes"),
+			"Configured maximum size of the mempool in bytes",
+			nil, nil,
+		),
+		mempoolLastUpdatedTimestampDesc: prometheus.NewDesc(
+			prometheus.BuildFQName(Namespace, "", "mempool_last_updated_timestamp_seconds"),
+			"Unix timestamp when mempool was last updated",
+			nil, nil,
+		),
+	}
+}
+
+func (c *ScrapeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.chainTipHeightDesc
+	ch <- c.chainTipTimestampDesc
+	ch <- c.chainTotalTxsDesc
+	ch <- c.chainIsCurrentDesc
+	ch <- c.p2pPeersDesc
+	ch <- c.p2pNetBytesRecvDesc
+	ch <- c.p2pNetBytesSentDesc
+	ch <- c.mempoolTransactionsDesc
+	ch <- c.mempoolBytesDesc
+	ch <- c.mempoolMaxBytesDesc
+	ch <- c.mempoolLastUpdatedTimestampDesc
+}
+
+func (c *ScrapeCollector) Collect(ch chan<- prometheus.Metric) {
+	s := c.source
+
+	if s.ChainTipHeight != nil {
+		ch <- prometheus.MustNewConstMetric(c.chainTipHeightDesc, prometheus.GaugeValue, float64(s.ChainTipHeight()))
+	}
+	if s.ChainTipTimestamp != nil {
+		ts := s.ChainTipTimestamp()
+		if !ts.IsZero() {
+			ch <- prometheus.MustNewConstMetric(c.chainTipTimestampDesc, prometheus.GaugeValue, float64(ts.Unix()))
+		}
+	}
+	if s.ChainTotalTxs != nil {
+		ch <- prometheus.MustNewConstMetric(c.chainTotalTxsDesc, prometheus.GaugeValue, float64(s.ChainTotalTxs()))
+	}
+	if s.ChainIsCurrent != nil {
+		v := 0.0
+		if s.ChainIsCurrent() {
+			v = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(c.chainIsCurrentDesc, prometheus.GaugeValue, v)
+	}
+	if s.PeerCount != nil {
+		inbound, outbound := s.PeerCount()
+		ch <- prometheus.MustNewConstMetric(c.p2pPeersDesc, prometheus.GaugeValue, float64(inbound), "inbound")
+		ch <- prometheus.MustNewConstMetric(c.p2pPeersDesc, prometheus.GaugeValue, float64(outbound), "outbound")
+	}
+	if s.NetTotals != nil {
+		recv, sent := s.NetTotals()
+		ch <- prometheus.MustNewConstMetric(c.p2pNetBytesRecvDesc, prometheus.CounterValue, float64(recv))
+		ch <- prometheus.MustNewConstMetric(c.p2pNetBytesSentDesc, prometheus.CounterValue, float64(sent))
+	}
+	if s.MempoolTxCount != nil {
+		ch <- prometheus.MustNewConstMetric(c.mempoolTransactionsDesc, prometheus.GaugeValue, float64(s.MempoolTxCount()))
+	}
+	if s.MempoolBytes != nil {
+		ch <- prometheus.MustNewConstMetric(c.mempoolBytesDesc, prometheus.GaugeValue, float64(s.MempoolBytes()))
+	}
+	if s.MempoolMaxBytes != nil {
+		ch <- prometheus.MustNewConstMetric(c.mempoolMaxBytesDesc, prometheus.GaugeValue, float64(s.MempoolMaxBytes()))
+	}
+	if s.MempoolLastUpdated != nil {
+		lu := s.MempoolLastUpdated()
+		if !lu.IsZero() {
+			ch <- prometheus.MustNewConstMetric(c.mempoolLastUpdatedTimestampDesc, prometheus.GaugeValue, float64(lu.Unix()))
+		}
+	}
+}

--- a/node/metrics/metrics.go
+++ b/node/metrics/metrics.go
@@ -1,0 +1,263 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+)
+
+const Namespace = "pearld"
+
+var (
+	// registry is the private Prometheus registry for pearld.
+	registry *prometheus.Registry
+
+	// Chain counters
+	chainBlocksConnectedTotal    prometheus.Counter
+	chainBlocksDisconnectedTotal prometheus.Counter
+	chainBlocksAcceptedTotal     prometheus.Counter
+
+	// P2P counters
+	p2pPeerConnectsTotal    *prometheus.CounterVec
+	p2pPeerDisconnectsTotal *prometheus.CounterVec
+	p2pPeersBannedTotal     prometheus.Counter
+	p2pPeersRejectedTotal   *prometheus.CounterVec
+	p2pWireBytesTotal       *prometheus.CounterVec
+	p2pWireMessagesTotal    *prometheus.CounterVec
+
+	// RPC metrics
+	rpcRequestsTotal       *prometheus.CounterVec
+	rpcRequestDurationSecs *prometheus.HistogramVec
+	rpcAuthFailuresTotal   prometheus.Counter
+	rpcWebsocketClients    prometheus.Gauge
+
+	// Info metric
+	pearldInfo *prometheus.GaugeVec
+
+	// Known RPC methods set for sanitization
+	knownRPCMethodsMu sync.RWMutex
+	knownRPCMethods   map[string]struct{}
+)
+
+func init() {
+	registry = prometheus.NewRegistry()
+
+	// Register Go and Process collectors
+	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+
+	// Chain events
+	chainBlocksConnectedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "chain_blocks_connected_total",
+		Help:      "Total number of blocks connected to the main chain",
+	})
+	chainBlocksDisconnectedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "chain_blocks_disconnected_total",
+		Help:      "Total number of blocks disconnected from the main chain",
+	})
+	chainBlocksAcceptedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "chain_blocks_accepted_total",
+		Help:      "Total number of blocks accepted into the blockchain",
+	})
+
+	// P2P metrics
+	p2pPeerConnectsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "p2p_peer_connects_total",
+		Help:      "Total number of peer connections established",
+	}, []string{"direction"})
+
+	p2pPeerDisconnectsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "p2p_peer_disconnects_total",
+		Help:      "Total number of peer disconnections",
+	}, []string{"direction"})
+
+	p2pPeersBannedTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "p2p_peers_banned_total",
+		Help:      "Total number of peers banned due to misbehavior",
+	})
+
+	p2pPeersRejectedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "p2p_peers_rejected_total",
+		Help:      "Total number of peer connection attempts rejected",
+	}, []string{"reason"})
+
+	p2pWireBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "p2p_wire_bytes_total",
+		Help:      "Total bytes transferred over the P2P wire",
+	}, []string{"direction", "command"})
+
+	p2pWireMessagesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "p2p_wire_messages_total",
+		Help:      "Total P2P wire messages sent or received",
+	}, []string{"direction", "command"})
+
+	// RPC metrics
+	rpcRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "rpc_requests_total",
+		Help:      "Total JSON-RPC requests processed",
+	}, []string{"method", "result"})
+
+	rpcRequestDurationSecs = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: Namespace,
+		Name:      "rpc_request_duration_seconds",
+		Help:      "JSON-RPC request execution duration in seconds",
+		Buckets:   []float64{0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10},
+	}, []string{"method"})
+
+	rpcAuthFailuresTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: Namespace,
+		Name:      "rpc_auth_failures_total",
+		Help:      "Total RPC authentication failures",
+	})
+
+	rpcWebsocketClients = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "rpc_websocket_clients",
+		Help:      "Current number of connected WebSocket clients",
+	})
+
+	// Info metric
+	pearldInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: Namespace,
+		Name:      "info",
+		Help:      "Pearld node version and network information",
+	}, []string{"version", "network", "protocol_version"})
+
+	// Register metrics with private registry
+	registry.MustRegister(
+		chainBlocksConnectedTotal,
+		chainBlocksDisconnectedTotal,
+		chainBlocksAcceptedTotal,
+		p2pPeerConnectsTotal,
+		p2pPeerDisconnectsTotal,
+		p2pPeersBannedTotal,
+		p2pPeersRejectedTotal,
+		p2pWireBytesTotal,
+		p2pWireMessagesTotal,
+		rpcRequestsTotal,
+		rpcRequestDurationSecs,
+		rpcAuthFailuresTotal,
+		rpcWebsocketClients,
+		pearldInfo,
+	)
+}
+
+// InitKnownRPCMethods initializes the set of valid RPC methods for label sanitization.
+func InitKnownRPCMethods(methods []string) {
+	knownRPCMethodsMu.Lock()
+	defer knownRPCMethodsMu.Unlock()
+
+	knownRPCMethods = make(map[string]struct{}, len(methods))
+	for _, m := range methods {
+		knownRPCMethods[m] = struct{}{}
+	}
+}
+
+// SanitizeRPCMethod returns method if it is in the known set, or "unknown" otherwise.
+func SanitizeRPCMethod(method string) string {
+	knownRPCMethodsMu.RLock()
+	defer knownRPCMethodsMu.RUnlock()
+
+	if knownRPCMethods == nil {
+		return method
+	}
+	if _, ok := knownRPCMethods[method]; ok {
+		return method
+	}
+	return "unknown"
+}
+
+// SetInfo sets the pearld_info metric labels.
+func SetInfo(version, network, protocolVersion string) {
+	pearldInfo.WithLabelValues(version, network, protocolVersion).Set(1)
+}
+
+// Chain event recording helpers
+func RecordBlockConnected() {
+	chainBlocksConnectedTotal.Inc()
+}
+
+func RecordBlockDisconnected() {
+	chainBlocksDisconnectedTotal.Inc()
+}
+
+func RecordBlockAccepted() {
+	chainBlocksAcceptedTotal.Inc()
+}
+
+// P2P recording helpers
+func RecordPeerConnect(inbound bool) {
+	p2pPeerConnectsTotal.WithLabelValues(directionLabel(inbound)).Inc()
+}
+
+func RecordPeerDisconnect(inbound bool) {
+	p2pPeerDisconnectsTotal.WithLabelValues(directionLabel(inbound)).Inc()
+}
+
+func RecordPeerBanned() {
+	p2pPeersBannedTotal.Inc()
+}
+
+func RecordPeerRejected(reason string) {
+	p2pPeersRejectedTotal.WithLabelValues(reason).Inc()
+}
+
+// RecordWireMessage records a single P2P message.  Callers should only install
+// the wire hooks when the metrics server is configured, since this runs on every
+// frame.
+func RecordWireMessage(inbound bool, command string, bytes int) {
+	if command == "" {
+		command = "unknown"
+	}
+	dir := directionLabel(inbound)
+	p2pWireMessagesTotal.WithLabelValues(dir, command).Inc()
+	p2pWireBytesTotal.WithLabelValues(dir, command).Add(float64(bytes))
+}
+
+func directionLabel(inbound bool) string {
+	if inbound {
+		return "inbound"
+	}
+	return "outbound"
+}
+
+// RPC recording helpers
+func RecordRPCRequest(method string, duration time.Duration, err error) {
+	method = SanitizeRPCMethod(method)
+	result := "success"
+	if err != nil {
+		result = "error"
+	}
+	rpcRequestsTotal.WithLabelValues(method, result).Inc()
+	rpcRequestDurationSecs.WithLabelValues(method).Observe(duration.Seconds())
+}
+
+// RecordRPCMethodNotFound counts a request rejected before dispatch.  No
+// latency is observed because no handler ran.
+func RecordRPCMethodNotFound(method string) {
+	rpcRequestsTotal.WithLabelValues(SanitizeRPCMethod(method), "error").Inc()
+}
+
+func RecordRPCAuthFailure() {
+	rpcAuthFailuresTotal.Inc()
+}
+
+func AddWSClient() {
+	rpcWebsocketClients.Inc()
+}
+
+func RemoveWSClient() {
+	rpcWebsocketClients.Dec()
+}

--- a/node/metrics/metrics_test.go
+++ b/node/metrics/metrics_test.go
@@ -1,0 +1,126 @@
+package metrics
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMethodSanitization(t *testing.T) {
+	InitKnownRPCMethods([]string{"getblock", "getpeerinfo", "getmempoolinfo"})
+
+	assert.Equal(t, "getblock", SanitizeRPCMethod("getblock"))
+	assert.Equal(t, "getpeerinfo", SanitizeRPCMethod("getpeerinfo"))
+	assert.Equal(t, "getmempoolinfo", SanitizeRPCMethod("getmempoolinfo"))
+	assert.Equal(t, "unknown", SanitizeRPCMethod("malicious_unregistered_method"))
+	assert.Equal(t, "unknown", SanitizeRPCMethod("dropdatabase"))
+}
+
+func TestRecordingHelpers(t *testing.T) {
+	InitKnownRPCMethods([]string{"getblock", "getpeerinfo"})
+
+	SetInfo("v0.1.0", "simnet", "70016")
+	RecordBlockConnected()
+	RecordBlockDisconnected()
+	RecordBlockAccepted()
+	RecordPeerConnect(true)
+	RecordPeerDisconnect(false)
+	RecordPeerBanned()
+	RecordPeerRejected("max_peers")
+	RecordWireMessage(true, "inv", 128)
+	RecordWireMessage(false, "block", 1024)
+	RecordWireMessage(true, "", 64)
+	RecordRPCRequest("getblock", 5*time.Millisecond, nil)
+	RecordRPCRequest("unknownMethod", 10*time.Millisecond, errors.New("not found"))
+	RecordRPCAuthFailure()
+	AddWSClient()
+
+	assert.Greater(t, testutil.ToFloat64(chainBlocksConnectedTotal), float64(0))
+	assert.Greater(t, testutil.ToFloat64(chainBlocksDisconnectedTotal), float64(0))
+	assert.Greater(t, testutil.ToFloat64(chainBlocksAcceptedTotal), float64(0))
+	assert.Greater(t, testutil.ToFloat64(p2pPeersBannedTotal), float64(0))
+	assert.Greater(t, testutil.ToFloat64(rpcAuthFailuresTotal), float64(0))
+	assert.Equal(t, float64(1), testutil.ToFloat64(rpcWebsocketClients))
+
+	assert.Equal(t, float64(128),
+		testutil.ToFloat64(p2pWireBytesTotal.WithLabelValues("inbound", "inv")))
+	assert.Equal(t, float64(64),
+		testutil.ToFloat64(p2pWireBytesTotal.WithLabelValues("inbound", "unknown")),
+		"a message with no command must fall back to the unknown label")
+
+	RemoveWSClient()
+	assert.Equal(t, float64(0), testutil.ToFloat64(rpcWebsocketClients))
+}
+
+// A rejected method never reaches a handler, so it must count as a request
+// without contributing a zero-second sample to the latency histogram.
+func TestMethodNotFoundRecordsNoLatency(t *testing.T) {
+	InitKnownRPCMethods([]string{"getblock"})
+
+	before := testutil.CollectAndCount(rpcRequestDurationSecs)
+	countBefore := testutil.ToFloat64(rpcRequestsTotal.WithLabelValues("unknown", "error"))
+
+	RecordRPCMethodNotFound("nosuchmethod")
+
+	assert.Equal(t, countBefore+1,
+		testutil.ToFloat64(rpcRequestsTotal.WithLabelValues("unknown", "error")))
+	assert.Equal(t, before, testutil.CollectAndCount(rpcRequestDurationSecs),
+		"rejected methods must not add a latency series")
+}
+
+func TestScrapeCollector(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
+	src := Source{
+		ChainTipHeight:     func() int32 { return 100 },
+		ChainTipTimestamp:  func() time.Time { return now },
+		ChainTotalTxs:      func() int64 { return 500 },
+		ChainIsCurrent:     func() bool { return true },
+		PeerCount:          func() (int64, int64) { return 8, 4 },
+		NetTotals:          func() (uint64, uint64) { return 1000, 2000 },
+		MempoolTxCount:     func() int { return 25 },
+		MempoolBytes:       func() uint64 { return 50000 },
+		MempoolMaxBytes:    func() uint64 { return 300000000 },
+		MempoolLastUpdated: func() time.Time { return now },
+	}
+
+	collector := NewScrapeCollector(src)
+	assert.Equal(t, 12, testutil.CollectAndCount(collector))
+}
+
+func TestServerAndPprofIsolation(t *testing.T) {
+	server, err := NewServer([]string{"127.0.0.1:0"})
+	require.NoError(t, err)
+	defer server.Stop()
+
+	server.Start()
+
+	addrs := server.ListenAddrs()
+	require.Len(t, addrs, 1)
+
+	metricsURL := "http://" + addrs[0] + "/metrics"
+	resp, err := http.Get(metricsURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "pearld_info")
+
+	// Pprof isolation regression test: ensure /debug/pprof/ returns 404
+	// on the metrics server HTTP listener.
+	pprofURL := "http://" + addrs[0] + "/debug/pprof/"
+	pprofResp, err := http.Get(pprofURL)
+	require.NoError(t, err)
+	defer pprofResp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, pprofResp.StatusCode,
+		"Metrics endpoint MUST NOT expose DefaultServeMux or /debug/pprof/")
+}

--- a/node/metrics/server.go
+++ b/node/metrics/server.go
@@ -1,0 +1,140 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Server manages the standalone HTTP metrics server.  It does no logging of its
+// own; callers report bound addresses via ListenAddrs and serve failures via
+// Errors.
+type Server struct {
+	listeners    []net.Listener
+	httpServers  []*http.Server
+	errs         chan error
+	collector    *ScrapeCollector
+	collectorReg prometheus.Collector
+	mu           sync.Mutex
+	started      bool
+}
+
+// NewServer binds TCP listeners for the provided addresses and prepares the metrics HTTP server.
+func NewServer(listenAddrs []string) (*Server, error) {
+	if len(listenAddrs) == 0 {
+		return nil, fmt.Errorf("no metrics listen addresses specified")
+	}
+
+	var listeners []net.Listener
+	for _, addr := range listenAddrs {
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			// Close any already bound listeners on failure
+			for _, bound := range listeners {
+				bound.Close()
+			}
+			return nil, fmt.Errorf("failed to bind metrics listener on %s: %w", addr, err)
+		}
+		listeners = append(listeners, l)
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(registry, promhttp.HandlerOpts{}))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	var httpServers []*http.Server
+	for range listeners {
+		httpServers = append(httpServers, &http.Server{
+			Handler:           mux,
+			ReadHeaderTimeout: 5 * time.Second,
+		})
+	}
+
+	return &Server{
+		listeners:   listeners,
+		httpServers: httpServers,
+		errs:        make(chan error, len(listeners)),
+	}, nil
+}
+
+// Errors receives an error for each listener that stops unexpectedly.  The
+// channel is closed once every listener has stopped, so a caller can simply
+// range over it.  It is buffered to one slot per listener and each listener
+// sends at most once, so sends never block.
+func (s *Server) Errors() <-chan error {
+	return s.errs
+}
+
+// SetSource attaches or replaces the scrape-time metric source.
+func (s *Server) SetSource(src Source) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.collectorReg != nil {
+		registry.Unregister(s.collectorReg)
+	}
+
+	s.collector = NewScrapeCollector(src)
+	s.collectorReg = s.collector
+	registry.MustRegister(s.collectorReg)
+}
+
+// ListenAddrs returns the actual bound addresses for the server listeners.
+func (s *Server) ListenAddrs() []string {
+	var addrs []string
+	for _, l := range s.listeners {
+		addrs = append(addrs, l.Addr().String())
+	}
+	return addrs
+}
+
+// Start launches background HTTP serving for all bound listeners.
+func (s *Server) Start() {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for i, l := range s.listeners {
+		srv := s.httpServers[i]
+		wg.Add(1)
+		go func(listener net.Listener, server *http.Server) {
+			defer wg.Done()
+			if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				s.errs <- fmt.Errorf("metrics listener %s: %w", listener.Addr(), err)
+			}
+		}(l, srv)
+	}
+
+	go func() {
+		wg.Wait()
+		close(s.errs)
+	}()
+}
+
+// Stop gracefully shuts down the metrics HTTP servers.
+func (s *Server) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	for _, srv := range s.httpServers {
+		_ = srv.Shutdown(ctx)
+	}
+}

--- a/node/rpcserver.go
+++ b/node/rpcserver.go
@@ -4381,6 +4381,11 @@ func (s *rpcServer) processRequest(request *btcjson.Request, isAdmin bool, close
 		parsedCmd := parseCmd(request)
 		if parsedCmd.err != nil {
 			jsonErr = parsedCmd.err
+			// Record metric for method not found errors that happen
+			// during parsing (e.g., unregistered methods).
+			if jsonErr == btcjson.ErrRPCMethodNotFound {
+				metrics.RecordRPCMethodNotFound(request.Method)
+			}
 		} else {
 			result, err = s.standardCmdResult(parsedCmd,
 				closeChan)
@@ -4917,7 +4922,6 @@ func newRPCServer(config *rpcserverConfig) (*rpcServer, error) {
 func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notification) {
 	switch notification.Type {
 	case blockchain.NTBlockAccepted:
-		metrics.RecordBlockAccepted()
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			rpcsLog.Warnf("Chain accepted notification is not a block.")
@@ -4930,7 +4934,6 @@ func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notifi
 		s.gbtWorkState.NotifyBlockConnected(block.Hash())
 
 	case blockchain.NTBlockConnected:
-		metrics.RecordBlockConnected()
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			rpcsLog.Warnf("Chain connected notification is not a block.")
@@ -4941,7 +4944,6 @@ func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notifi
 		s.ntfnMgr.NotifyBlockConnected(block)
 
 	case blockchain.NTBlockDisconnected:
-		metrics.RecordBlockDisconnected()
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			rpcsLog.Warnf("Chain disconnected notification is not a block.")

--- a/node/rpcserver.go
+++ b/node/rpcserver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/database"
 	"github.com/pearl-research-labs/pearl/node/mempool"
+	"github.com/pearl-research-labs/pearl/node/metrics"
 	"github.com/pearl-research-labs/pearl/node/mining"
 	"github.com/pearl-research-labs/pearl/node/mining/cpuminer"
 	"github.com/pearl-research-labs/pearl/node/peer"
@@ -4216,6 +4217,7 @@ func (s *rpcServer) checkAuth(r *http.Request, require bool) (bool, bool, error)
 		if require {
 			rpcsLog.Warnf("RPC authentication failure from %s",
 				r.RemoteAddr)
+			metrics.RecordRPCAuthFailure()
 			return false, false, errors.New("auth failure")
 		}
 
@@ -4225,6 +4227,7 @@ func (s *rpcServer) checkAuth(r *http.Request, require bool) (bool, bool, error)
 	authenticated, isAdmin := s.checkCredentials(user, pass)
 	if !authenticated {
 		rpcsLog.Warnf("RPC authentication failure from %s", r.RemoteAddr)
+		metrics.RecordRPCAuthFailure()
 		return false, false, errors.New("auth failure")
 	}
 
@@ -4258,29 +4261,36 @@ type parsedRPCCmd struct {
 	err     *btcjson.RPCError
 }
 
+// rpcHandlerForMethod returns the handler for the given JSON-RPC method, or nil
+// if the method is not registered.
+func rpcHandlerForMethod(method string) commandHandler {
+	if handler, ok := rpcHandlers[method]; ok {
+		return handler
+	}
+	if _, ok := rpcAskWallet[method]; ok {
+		return handleAskWallet
+	}
+	if _, ok := rpcUnimplemented[method]; ok {
+		return handleUnimplemented
+	}
+	return nil
+}
+
 // standardCmdResult checks that a parsed command is a standard JSON-RPC
 // command and runs the appropriate handler to reply to the command.  Any
 // commands which are not recognized or not implemented will return an error
 // suitable for use in replies.
 func (s *rpcServer) standardCmdResult(cmd *parsedRPCCmd, closeChan <-chan struct{}) (interface{}, error) {
-	handler, ok := rpcHandlers[cmd.method]
-	if ok {
-		goto handled
+	handler := rpcHandlerForMethod(cmd.method)
+	if handler == nil {
+		metrics.RecordRPCMethodNotFound(cmd.method)
+		return nil, btcjson.ErrRPCMethodNotFound
 	}
-	_, ok = rpcAskWallet[cmd.method]
-	if ok {
-		handler = handleAskWallet
-		goto handled
-	}
-	_, ok = rpcUnimplemented[cmd.method]
-	if ok {
-		handler = handleUnimplemented
-		goto handled
-	}
-	return nil, btcjson.ErrRPCMethodNotFound
-handled:
 
-	return handler(s, cmd.cmd, closeChan)
+	start := time.Now()
+	res, err := handler(s, cmd.cmd, closeChan)
+	metrics.RecordRPCRequest(cmd.method, time.Since(start), err)
+	return res, err
 }
 
 // parseCmd parses a JSON-RPC request object into known concrete command.  The
@@ -4907,6 +4917,7 @@ func newRPCServer(config *rpcserverConfig) (*rpcServer, error) {
 func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notification) {
 	switch notification.Type {
 	case blockchain.NTBlockAccepted:
+		metrics.RecordBlockAccepted()
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			rpcsLog.Warnf("Chain accepted notification is not a block.")
@@ -4919,6 +4930,7 @@ func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notifi
 		s.gbtWorkState.NotifyBlockConnected(block.Hash())
 
 	case blockchain.NTBlockConnected:
+		metrics.RecordBlockConnected()
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			rpcsLog.Warnf("Chain connected notification is not a block.")
@@ -4929,6 +4941,7 @@ func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notifi
 		s.ntfnMgr.NotifyBlockConnected(block)
 
 	case blockchain.NTBlockDisconnected:
+		metrics.RecordBlockDisconnected()
 		block, ok := notification.Data.(*btcutil.Block)
 		if !ok {
 			rpcsLog.Warnf("Chain disconnected notification is not a block.")
@@ -4943,4 +4956,16 @@ func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notifi
 func init() {
 	rpcHandlers = rpcHandlersBeforeInit
 	rand.Seed(time.Now().UnixNano())
+
+	knownMethods := make([]string, 0, len(rpcHandlers)+len(rpcAskWallet)+len(rpcUnimplemented))
+	for m := range rpcHandlers {
+		knownMethods = append(knownMethods, m)
+	}
+	for m := range rpcAskWallet {
+		knownMethods = append(knownMethods, m)
+	}
+	for m := range rpcUnimplemented {
+		knownMethods = append(knownMethods, m)
+	}
+	metrics.InitKnownRPCMethods(knownMethods)
 }

--- a/node/rpcwebsocket.go
+++ b/node/rpcwebsocket.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pearl-research-labs/pearl/node/chaincfg"
 	"github.com/pearl-research-labs/pearl/node/chaincfg/chainhash"
 	"github.com/pearl-research-labs/pearl/node/database"
+	"github.com/pearl-research-labs/pearl/node/metrics"
 	"github.com/pearl-research-labs/pearl/node/txscript"
 	"github.com/pearl-research-labs/pearl/node/wire"
 	"golang.org/x/crypto/ripemd160"
@@ -1100,12 +1101,14 @@ func (*wsNotificationManager) removeAddrRequest(addrs map[string]map[chan struct
 
 // AddClient adds the passed websocket client to the notification manager.
 func (m *wsNotificationManager) AddClient(wsc *wsClient) {
+	metrics.AddWSClient()
 	m.queueNotification <- (*notificationRegisterClient)(wsc)
 }
 
 // RemoveClient removes the passed websocket client and all notifications
 // registered for it.
 func (m *wsNotificationManager) RemoveClient(wsc *wsClient) {
+	metrics.RemoveWSClient()
 	select {
 	case m.queueNotification <- (*notificationUnregisterClient)(wsc):
 	case <-m.quit:

--- a/node/rpcwebsocket.go
+++ b/node/rpcwebsocket.go
@@ -1269,6 +1269,11 @@ func (c *wsClient) authorizeRequest(req *btcjson.Request) requestOutcome {
 		if !c.authenticated {
 			return requestOutcome{disconnect: true}
 		}
+		// Record metric for method not found errors that happen
+		// during parsing (e.g., unregistered methods).
+		if cmd.err == btcjson.ErrRPCMethodNotFound {
+			metrics.RecordRPCMethodNotFound(req.Method)
+		}
 		return requestOutcome{reply: marshalReply(cmd.jsonrpc, cmd.id, cmd.err)}
 	}
 

--- a/node/sample-pearld.conf
+++ b/node/sample-pearld.conf
@@ -348,3 +348,8 @@
 ; be disabled if this option is not specified.  The profile information can be
 ; accessed at http://localhost:<profileport>/debug/pprof once running.
 ; profile=6061
+
+; Add an interface/port to listen for Prometheus metrics requests.
+; The metrics server will be disabled if this option is not specified.
+; The metrics can be accessed at http://localhost:<metricsport>/metrics once running.
+; metricslisten=127.0.0.1:9105

--- a/node/server.go
+++ b/node/server.go
@@ -3004,6 +3004,20 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		return nil, err
 	}
 
+	// Subscribe to blockchain notifications for metrics recording.
+	// This is done here (independent of RPC) so that metrics are
+	// recorded even when RPC is disabled.
+	s.chain.Subscribe(func(notification *blockchain.Notification) {
+		switch notification.Type {
+		case blockchain.NTBlockAccepted:
+			metrics.RecordBlockAccepted()
+		case blockchain.NTBlockConnected:
+			metrics.RecordBlockConnected()
+		case blockchain.NTBlockDisconnected:
+			metrics.RecordBlockDisconnected()
+		}
+	})
+
 	// Search for a FeeEstimator state in the database. If none can be found
 	// or if it cannot be loaded, create a new one.
 	db.Update(func(tx database.Tx) error {
@@ -3571,17 +3585,25 @@ func (s *server) MetricsSource() metrics.Source {
 		},
 		PeerCount: func() (int64, int64) {
 			replyChan := make(chan []*serverPeer, 1)
-			s.query <- getPeersMsg{reply: replyChan}
-			peers := <-replyChan
-			var inbound, outbound int64
-			for _, p := range peers {
-				if p.Inbound() {
-					inbound++
-				} else {
-					outbound++
-				}
+			select {
+			case s.query <- getPeersMsg{reply: replyChan}:
+			case <-s.quit:
+				return 0, 0
 			}
-			return inbound, outbound
+			select {
+			case peers := <-replyChan:
+				var inbound, outbound int64
+				for _, p := range peers {
+					if p.Inbound() {
+						inbound++
+					} else {
+						outbound++
+					}
+				}
+				return inbound, outbound
+			case <-s.quit:
+				return 0, 0
+			}
 		},
 		NetTotals: func() (uint64, uint64) {
 			return atomic.LoadUint64(&s.bytesReceived), atomic.LoadUint64(&s.bytesSent)

--- a/node/server.go
+++ b/node/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pearl-research-labs/pearl/node/connmgr"
 	"github.com/pearl-research-labs/pearl/node/database"
 	"github.com/pearl-research-labs/pearl/node/mempool"
+	"github.com/pearl-research-labs/pearl/node/metrics"
 	"github.com/pearl-research-labs/pearl/node/mining"
 	"github.com/pearl-research-labs/pearl/node/mining/cpuminer"
 	"github.com/pearl-research-labs/pearl/node/netsync"
@@ -1812,12 +1813,14 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 
 	// Disconnect peers with unwanted user agents.
 	if sp.HasUndesiredUserAgent(s.agentBlacklist, s.agentWhitelist) {
+		metrics.RecordPeerRejected("undesired_agent")
 		sp.Disconnect()
 		return false
 	}
 
 	// Ignore new peers if we're shutting down.
 	if atomic.LoadInt32(&s.shutdown) != 0 {
+		metrics.RecordPeerRejected("shutdown")
 		srvrLog.Infof("New peer %s ignored - server is shutting down", sp)
 		sp.Disconnect()
 		return false
@@ -1826,12 +1829,14 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 	// Disconnect banned peers.
 	host, _, err := net.SplitHostPort(sp.Addr())
 	if err != nil {
+		metrics.RecordPeerRejected("other")
 		srvrLog.Debugf("can't split hostport %v", err)
 		sp.Disconnect()
 		return false
 	}
 	if banEnd, ok := state.banned[host]; ok {
 		if time.Now().Before(banEnd) {
+			metrics.RecordPeerRejected("banned")
 			srvrLog.Debugf("Peer %s is banned for another %v - disconnecting",
 				host, time.Until(banEnd))
 			sp.Disconnect()
@@ -1846,6 +1851,7 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 
 	// Limit max number of total peers.
 	if state.Count() >= cfg.MaxPeers {
+		metrics.RecordPeerRejected("max_peers")
 		srvrLog.Infof("Max peers reached [%d] - disconnecting peer %s",
 			cfg.MaxPeers, sp)
 		sp.Disconnect()
@@ -1856,6 +1862,7 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 
 	// Add the new peer and start it.
 	srvrLog.Debugf("New peer %s", sp)
+	metrics.RecordPeerConnect(sp.Inbound())
 	if sp.Inbound() {
 		state.inboundPeers[sp.ID()] = sp
 	} else {
@@ -1938,6 +1945,7 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
 		}
 		delete(list, sp.ID())
+		metrics.RecordPeerDisconnect(sp.Inbound())
 		srvrLog.Debugf("Removed peer %s", sp)
 	}
 
@@ -1971,6 +1979,7 @@ func (s *server) handleBanPeerMsg(state *peerState, sp *serverPeer) {
 	srvrLog.Infof("Banned peer %s (%s) for %v", host, direction,
 		cfg.BanDuration)
 	state.banned[host] = time.Now().Add(cfg.BanDuration)
+	metrics.RecordPeerBanned()
 }
 
 // handleRelayInvMsg deals with relaying inventory to peers that are not already
@@ -2227,32 +2236,58 @@ func disconnectPeer(peerList map[int32]*serverPeer, compareFunc func(*serverPeer
 
 // newPeerConfig returns the configuration for the given serverPeer.
 func newPeerConfig(sp *serverPeer) *peer.Config {
+	listeners := peer.MessageListeners{
+		OnVersion:      sp.OnVersion,
+		OnVerAck:       sp.OnVerAck,
+		OnMemPool:      sp.OnMemPool,
+		OnTx:           sp.OnTx,
+		OnBlock:        sp.OnBlock,
+		OnInv:          sp.OnInv,
+		OnHeaders:      sp.OnHeaders,
+		OnGetData:      sp.OnGetData,
+		OnGetBlocks:    sp.OnGetBlocks,
+		OnGetHeaders:   sp.OnGetHeaders,
+		OnGetCFilters:  sp.OnGetCFilters,
+		OnGetCFHeaders: sp.OnGetCFHeaders,
+		OnGetCFCheckpt: sp.OnGetCFCheckpt,
+		OnFeeFilter:    sp.OnFeeFilter,
+		OnFilterAdd:    sp.OnFilterAdd,
+		OnFilterClear:  sp.OnFilterClear,
+		OnFilterLoad:   sp.OnFilterLoad,
+		OnGetAddr:      sp.OnGetAddr,
+		OnAddr:         sp.OnAddr,
+		OnAddrV2:       sp.OnAddrV2,
+		OnRead:         sp.OnRead,
+		OnWrite:        sp.OnWrite,
+		OnNotFound:     sp.OnNotFound,
+	}
+
+	// These hooks run on every P2P frame, so only pay for them when the metrics
+	// endpoint is actually configured.
+	if len(cfg.MetricsListeners) > 0 {
+		origOnRead := listeners.OnRead
+		listeners.OnRead = func(p *peer.Peer, bytesRead int, msg wire.Message, err error) {
+			if origOnRead != nil {
+				origOnRead(p, bytesRead, msg, err)
+			}
+			if err == nil && msg != nil {
+				metrics.RecordWireMessage(true, msg.Command(), bytesRead)
+			}
+		}
+
+		origOnWrite := listeners.OnWrite
+		listeners.OnWrite = func(p *peer.Peer, bytesWritten int, msg wire.Message, err error) {
+			if origOnWrite != nil {
+				origOnWrite(p, bytesWritten, msg, err)
+			}
+			if err == nil && msg != nil {
+				metrics.RecordWireMessage(false, msg.Command(), bytesWritten)
+			}
+		}
+	}
+
 	return &peer.Config{
-		Listeners: peer.MessageListeners{
-			OnVersion:      sp.OnVersion,
-			OnVerAck:       sp.OnVerAck,
-			OnMemPool:      sp.OnMemPool,
-			OnTx:           sp.OnTx,
-			OnBlock:        sp.OnBlock,
-			OnInv:          sp.OnInv,
-			OnHeaders:      sp.OnHeaders,
-			OnGetData:      sp.OnGetData,
-			OnGetBlocks:    sp.OnGetBlocks,
-			OnGetHeaders:   sp.OnGetHeaders,
-			OnGetCFilters:  sp.OnGetCFilters,
-			OnGetCFHeaders: sp.OnGetCFHeaders,
-			OnGetCFCheckpt: sp.OnGetCFCheckpt,
-			OnFeeFilter:    sp.OnFeeFilter,
-			OnFilterAdd:    sp.OnFilterAdd,
-			OnFilterClear:  sp.OnFilterClear,
-			OnFilterLoad:   sp.OnFilterLoad,
-			OnGetAddr:      sp.OnGetAddr,
-			OnAddr:         sp.OnAddr,
-			OnAddrV2:       sp.OnAddrV2,
-			OnRead:         sp.OnRead,
-			OnWrite:        sp.OnWrite,
-			OnNotFound:     sp.OnNotFound,
-		},
+		Listeners:           listeners,
 		NewestBlock:         sp.newestBlock,
 		HostToNetAddress:    sp.server.addrManager.HostToNetAddress,
 		Proxy:               cfg.Proxy,
@@ -3504,4 +3539,76 @@ func (sp *serverPeer) HasUndesiredUserAgent(blacklistedAgents,
 		"whitelist", sp, agent)
 
 	return true
+}
+
+// MetricsSource returns a metrics.Source populated with accessor closures for
+// pearld subsystem metrics.
+func (s *server) MetricsSource() metrics.Source {
+	return metrics.Source{
+		ChainTipHeight: func() int32 {
+			if s.chain != nil {
+				return s.chain.BestSnapshot().Height
+			}
+			return 0
+		},
+		ChainTipTimestamp: func() time.Time {
+			if s.chain != nil {
+				return s.chain.BestSnapshot().BlockTime
+			}
+			return time.Time{}
+		},
+		ChainTotalTxs: func() int64 {
+			if s.chain != nil {
+				return int64(s.chain.BestSnapshot().TotalTxns)
+			}
+			return 0
+		},
+		ChainIsCurrent: func() bool {
+			if s.chain != nil {
+				return s.chain.IsCurrent()
+			}
+			return false
+		},
+		PeerCount: func() (int64, int64) {
+			replyChan := make(chan []*serverPeer, 1)
+			s.query <- getPeersMsg{reply: replyChan}
+			peers := <-replyChan
+			var inbound, outbound int64
+			for _, p := range peers {
+				if p.Inbound() {
+					inbound++
+				} else {
+					outbound++
+				}
+			}
+			return inbound, outbound
+		},
+		NetTotals: func() (uint64, uint64) {
+			return atomic.LoadUint64(&s.bytesReceived), atomic.LoadUint64(&s.bytesSent)
+		},
+		MempoolTxCount: func() int {
+			if s.txMemPool != nil {
+				return s.txMemPool.Count()
+			}
+			return 0
+		},
+		MempoolBytes: func() uint64 {
+			if s.txMemPool != nil {
+				return s.txMemPool.PoolBytes()
+			}
+			return 0
+		},
+		MempoolMaxBytes: func() uint64 {
+			if s.txMemPool != nil {
+				return s.txMemPool.MaxMempoolSize()
+			}
+			return 0
+		},
+		MempoolLastUpdated: func() time.Time {
+			if s.txMemPool != nil {
+				return s.txMemPool.LastUpdated()
+			}
+			return time.Time{}
+		},
+	}
 }


### PR DESCRIPTION
## Summary

Add an opt-in Prometheus metrics endpoint to `pearld` (`--metricslisten`), exposing chain, P2P, JSON-RPC, and mempool metrics. No endpoint is served unless the flag is given.

## Type

feat

## Scope

node (`pearld`)

## Changes

- New `node/metrics` package with a private Prometheus registry and a standalone HTTP server, isolated behind its own `ServeMux` so `net/http/pprof`'s `DefaultServeMux` handlers are never exposed on the metrics port (guarded by a regression test).
- Scrape-time collector (`Source` accessor closures) for chain tip, peer counts, net totals, and mempool state — no background polling goroutine.
- Event-count instrumentation at existing call sites: peer connect/reject/disconnect/ban, wire message/byte counters (only when metrics are configured, so the per-frame path stays unchanged otherwise), RPC request counts/latency/auth failures, websocket client gauge, and block connect/disconnect/accept.
- RPC method-name sanitization so unauthenticated callers cannot inflate series cardinality with arbitrary method names.
- `--metricslisten` config option (repeatable, default port 9105), sample config entry, Dockerfile `EXPOSE 9105`, and startup warnings when the metrics/profile/RPC endpoints are bound beyond loopback.
- Unit tests for the collector, recording helpers, method sanitization, and pprof isolation, plus benchmarks for the per-frame wire hook.

## Test plan

- [x] Existing tests pass (`go test ./node/ ./node/metrics/`)
- [x] New tests added (`node/metrics/metrics_test.go`, `bench_test.go`)
- [x] `go vet` and `gofmt -l` clean on touched packages; `go test -race` clean on `node/metrics`
- [x] `go build ./node/...` succeeds
