### PR TITLE
docs(security): limit bounty eligibility to master/production code

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,15 @@ wallet components:
 - **Oyster** - wallet daemon (`wallet/`)
 - **SPV** - light client (`spv/`)
 
+Those rewards apply only to production code on the default branch (`master`)
+or the latest supported release. Reports against feature branches,
+work-in-progress, experimental PRs, or other unmerged code are **not
+bounty-eligible**, even if the component would otherwise be in bounty scope.
+Such findings may still be reported privately via
+[Reporting a Vulnerability](#reporting-a-vulnerability), or as regular
+[GitHub issues](https://github.com/pearl-research-labs/pearl/issues) for
+non-security bugs, but no bounty is implied.
+
 Reports against other components in the repo (`miner/`, `py-pearl-mining/`,
 `dnsseeder/`, `apps/`) are **not bounty-eligible** and should be filed as
 regular [GitHub issues](https://github.com/pearl-research-labs/pearl/issues).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,14 +63,14 @@ wallet components:
 - **Oyster** - wallet daemon (`wallet/`)
 - **SPV** - light client (`spv/`)
 
-Those rewards apply only to production code on the default branch (`master`)
-or the latest supported release. Reports against feature branches,
-work-in-progress, experimental PRs, or other unmerged code are **not
-bounty-eligible**, even if the component would otherwise be in bounty scope.
-Such findings may still be reported privately via
+The rewards mentioned above apply only to production code on the default
+branch (`master`) or the latest supported release. Reports against feature
+branches, work-in-progress, experimental PRs, or other unmerged code are
+**not bounty-eligible**, even if the component would otherwise be in bounty
+scope. Nevertheless, such findings may still be reported privately via
 [Reporting a Vulnerability](#reporting-a-vulnerability), or as regular
 [GitHub issues](https://github.com/pearl-research-labs/pearl/issues) for
-non-security bugs, but no bounty is implied.
+non-security bugs.
 
 Reports against other components in the repo (`miner/`, `py-pearl-mining/`,
 `dnsseeder/`, `apps/`) are **not bounty-eligible** and should be filed as


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarify that bug-bounty rewards apply only to vulnerabilities in production code on the default branch (`master`) or the latest supported release. Reports against feature branches, work-in-progress, experimental PRs, or other unmerged code are not bounty-eligible, even when the component is otherwise in bounty scope.

This keeps community review of unmerged work (for example the FP8 feature-branch PR) from implying bounty coverage.

## Type

docs

## Scope

SECURITY.md

## Changes

- Under **Bounty scope**, state that rewards apply only to production code on `master` or the latest supported release
- Explicitly exclude feature branches, WIP, experimental PRs, and other unmerged code from bounty eligibility
- Point those findings to the existing private vulnerability process (or regular issues for non-security bugs), with no bounty implied
- Leave the existing component allowlist and denylist unchanged (`miner/`, `apps/`, `dnsseeder/` remain out of bounty)

## Test plan

- [x] Docs-only change; verified wording against existing bounty-scope and Supported Versions language
- [ ] Existing tests pass (`task test`) — N/A, documentation-only
- [ ] New tests added (if applicable) — N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d64f217b-1d0e-48bb-8891-d9e05d492869?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d64f217b-1d0e-48bb-8891-d9e05d492869&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

